### PR TITLE
Fix: convert execute-ability error payloads to isError format

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -166,6 +166,29 @@ class McpRouter {
       return;
     }
 
+    // Detect execute-ability error responses and convert to isError format
+    if (parsedMsg.result && parsedMsg.result.content) {
+      const content = parsedMsg.result.content;
+      if (Array.isArray(content) && content.length === 1 && content[0].type === 'text') {
+        try {
+          const payload = JSON.parse(content[0].text);
+          if (payload.success === false && payload.error) {
+            const errorParts = [];
+            if (payload.error_code) errorParts.push(`[${payload.error_code}]`);
+            errorParts.push(payload.error);
+            if (payload.error_data) errorParts.push(`Details: ${JSON.stringify(payload.error_data)}`);
+
+            parsedMsg.result.content[0].text = errorParts.join(' ');
+            parsedMsg.result.isError = true;
+
+            this.log(`Converted execute-ability error: ${errorParts.join(' ')}`);
+            this.sendToClient(JSON.stringify(parsedMsg));
+            return;
+          }
+        } catch { /* not JSON — pass through */ }
+      }
+    }
+
     // Normal response — forward
     this.sendToClient(rawLine || JSON.stringify(parsedMsg));
   }

--- a/lib/transports/http-transport.js
+++ b/lib/transports/http-transport.js
@@ -351,6 +351,21 @@ class HttpTransport {
 
         // Protocol version negotiation is handled server-side (InitializeHandler v1.0.7+).
 
+        // Fold _metadata.input_schema into error text content for client visibility
+        if (parsed.result && parsed.result.isError && parsed.result._metadata && parsed.result._metadata.input_schema) {
+          const content = parsed.result.content;
+          if (Array.isArray(content) && content.length > 0 && content[0].type === 'text') {
+            const schema = parsed.result._metadata.input_schema;
+            const required = schema.required || [];
+            const props = schema.properties || {};
+            const paramList = Object.entries(props).map(([k, v]) => {
+              const req = required.includes(k) ? ' (required)' : '';
+              return `  ${k}: ${v.type || 'any'}${req} — ${v.description || ''}`;
+            }).join('\n');
+            content[0].text += `\n\nExpected parameters:\n${paramList}`;
+          }
+        }
+
         // Sanitization is handled by the router (McpRouter.handleTransportMessage)
         // to avoid double-sanitization. Transport just forwards the parsed message.
 

--- a/lib/transports/ssh-transport.js
+++ b/lib/transports/ssh-transport.js
@@ -539,6 +539,21 @@ class SshTransport {
 
       // Protocol version negotiation is handled server-side (InitializeHandler v1.0.7+).
 
+      // Fold _metadata.input_schema into error text content for client visibility
+      if (msg.result && msg.result.isError && msg.result._metadata && msg.result._metadata.input_schema) {
+        const content = msg.result.content;
+        if (Array.isArray(content) && content.length > 0 && content[0].type === 'text') {
+          const schema = msg.result._metadata.input_schema;
+          const required = schema.required || [];
+          const props = schema.properties || {};
+          const paramList = Object.entries(props).map(([k, v]) => {
+            const req = required.includes(k) ? ' (required)' : '';
+            return `  ${k}: ${v.type || 'any'}${req} — ${v.description || ''}`;
+          }).join('\n');
+          content[0].text += `\n\nExpected parameters:\n${paramList}`;
+        }
+      }
+
       // Forward to callback
       if (this.onMessage) {
         this.onMessage(msg, JSON.stringify(msg));

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@wicked-evolutions/abilities-mcp",
-  "version": "1.0.0",
-  "description": "One MCP to Rule Your WordPress World — unified multi-site bridge for WordPress abilities",
+  "version": "1.3.0",
+  "description": "Open-source MCP bridge connecting AI clients to WordPress through the Abilities API — multi-site routing, zero dependencies",
   "main": "abilities-mcp.js",
   "bin": {
     "abilities-mcp": "./abilities-mcp.js"
   },
   "files": ["abilities-mcp.js", "lib/", "wp-sites.example.json", "LICENSE", "README.md", "CHANGELOG.md"],
-  "keywords": ["mcp", "wordpress", "ssh", "bridge", "claude", "abilities", "multi-site"],
+  "keywords": ["mcp", "wordpress", "bridge", "abilities", "ai", "open-source", "multi-site", "model-context-protocol"],
   "license": "GPL-2.0-or-later",
   "author": "Wicked Evolutions",
   "repository": {


### PR DESCRIPTION
## Summary
- **Fix 1:** Bridge now inspects `tools/call` result payloads for `{success: false, error: "..."}` pattern (from `execute-ability` and `batch-execute`) and converts to `isError: true` with `[code] message` format
- **Fix 2:** Transport layer folds `_metadata.input_schema` into error text content so MCP clients can see expected parameters on failures

## Tested on WE
| Test | Result |
|------|--------|
| Nonexistent ability via execute-ability | **FIXED** — `[-32008] Permission denied: Ability 'foo/bar' not found` |
| Successful call via execute-ability | Working — no regression |
| JSON-RPC level errors (validate_input) | Not covered — separate issue needed |

## Files changed
- `lib/router.js` — error detection in `handleTransportMessage()`
- `lib/transports/http-transport.js` — schema folding in `_processMessage()`
- `lib/transports/ssh-transport.js` — schema folding in `_handleChildStdout()`
- `package.json` — version bump to 1.3.0

Fixes #2