### PR TITLE
DB-6: .mcpb bundle + env-var config fallback (#8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ wp-sites*.json
 !wp-sites.example.json
 *.log
 .DS_Store
+*.mcpb

--- a/.mcpbignore
+++ b/.mcpbignore
@@ -1,0 +1,35 @@
+# Files excluded from the .mcpb bundle.
+# Bundle ships only the runtime: abilities-mcp.js, lib/, manifest.json, LICENSE, README.
+
+# Version control
+.git/
+.github/
+.gitignore
+
+# Tests + dev tooling
+test/
+.npmignore
+.nvmrc
+
+# Operator-specific configs (the bundle uses env vars from manifest user_config)
+wp-sites.json
+wp-sites-*.json
+!wp-sites.example.json
+
+# Docs that don't need to ship inside the bundle
+docs/
+CHANGELOG.md
+CONTRIBUTING.md
+SECURITY.md
+
+# Build artifacts
+*.mcpb
+node_modules/
+
+# OS / editor noise
+.DS_Store
+*.log
+*.swp
+*.swo
+.vscode/
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Abilities MCP are documented here.
 
+## [1.4.0] - 2026-04-26
+
+### Added
+- `.mcpb` distribution bundle for one-click install in Claude Desktop (#8). `manifest.json` against MCPB spec v0.3, `.mcpbignore`, and `npm run pack:mcpb` script. Application Password is stored encrypted in the OS keychain via `sensitive: true`. Published as a GitHub Release asset.
+- `ABILITIES_MCP_URL` / `ABILITIES_MCP_USERNAME` / `ABILITIES_MCP_PASSWORD` environment-variable config fallback in `lib/config.js`. When no `wp-sites.json` exists, the bridge builds a single-site config from the env vars and auto-derives the MCP adapter endpoint as `<URL>/wp-json/mcp/mcp-adapter-default-server`. Covers the `.mcpb` install path and any env-var-based MCP client (`claude mcp add`, Docker, etc.).
+- `npm run validate:mcpb` — validates `manifest.json` against the MCPB schema.
+
+### Changed
+- README restructured around three install paths: `.mcpb` bundle (recommended for Claude Desktop), env-vars + npm install (Claude Code / Cursor / Docker), and `wp-sites.json` (multi-site / power users). Existing `wp-sites.json` users are unaffected.
+
 ## [1.3.1] - 2026-03-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ Every ability enforces `current_user_can()` at execution time — your WordPress
 
 > **Sign up for the Abilities for AI alpha release:** https://community.wickedevolutions.com/item/abilities-for-ai/
 
-## Quick Start
+## Install
 
-### 1. Set up WordPress
+There are three install paths. Pick the one that matches how you use AI clients.
+
+### Set up WordPress (required for all paths)
 
 Create a dedicated WordPress user for AI access and generate an Application Password.
 
@@ -64,21 +66,72 @@ Install both on your WordPress site:
 
 Both are available as free downloads from our store, or install from GitHub: [abilities-for-ai](https://github.com/Wicked-Evolutions/abilities-for-ai) and [abilities-mcp-adapter](https://github.com/Wicked-Evolutions/abilities-mcp-adapter).
 
-### 2. Configure your sites
+---
 
-Copy the example config and edit:
+### Path 1 — `.mcpb` bundle for Claude Desktop (recommended)
+
+Single-click install for Claude Desktop on macOS and Windows. The Application Password is stored encrypted in your OS keychain (macOS Keychain / Windows Credential Manager).
+
+1. Download `abilities-mcp.mcpb` from the [latest GitHub Release](https://github.com/Wicked-Evolutions/abilities-mcp/releases/latest).
+2. Double-click the file. Claude Desktop opens an "Install Extension" dialog.
+3. Type three things:
+   - **WordPress Site URL** — `https://example.com`
+   - **WordPress Username** — `mcp-agent`
+   - **Application Password** — paste the password from the previous step
+4. Click **Install**. The connection is live.
+
+The bundle covers the single-site case. For multi-site (one bridge connected to several WordPress sites at once), use Path 3.
+
+---
+
+### Path 2 — Env vars (Claude Code, Cursor, Docker, any MCP client)
+
+Install the bridge from npm, then point your client at it with three environment variables:
+
+```bash
+npm install -g @wickedevolutions/abilities-mcp
+```
+
+In your client's MCP config:
+
+```json
+{
+  "mcpServers": {
+    "wordpress": {
+      "command": "abilities-mcp",
+      "env": {
+        "ABILITIES_MCP_URL": "https://example.com",
+        "ABILITIES_MCP_USERNAME": "mcp-agent",
+        "ABILITIES_MCP_PASSWORD": "xxxx xxxx xxxx xxxx xxxx xxxx"
+      }
+    }
+  }
+}
+```
+
+The endpoint is auto-derived as `<URL>/wp-json/mcp/mcp-adapter-default-server`. Single-site only — for multi-site, use Path 3.
+
+For `claude mcp add` users:
+
+```bash
+claude mcp add wordpress \
+  --env ABILITIES_MCP_URL=https://example.com \
+  --env ABILITIES_MCP_USERNAME=mcp-agent \
+  --env ABILITIES_MCP_PASSWORD='xxxx xxxx xxxx xxxx xxxx xxxx' \
+  -- abilities-mcp
+```
+
+---
+
+### Path 3 — `wp-sites.json` (multi-site, power users)
+
+Use this when you connect one bridge to multiple WordPress sites, when you want passwords sourced from a keychain or shell command, or when you're targeting WordPress multisite networks via dot-notation routing.
 
 ```bash
 cp wp-sites.example.json wp-sites.json
 ```
 
-Edit `wp-sites.json` with your site details.
-
-### 3. Add to your MCP client
-
-Works with any MCP-compatible client — Claude Code, Claude Desktop, Gemini CLI, Cursor, Windsurf, VS Code, and any other IDE or AI tool that supports the Model Context Protocol.
-
-Add the server to your client's MCP config (usually `.mcp.json`, `settings.json`, or equivalent):
+Edit `wp-sites.json` with your sites, then add the server to your client's MCP config:
 
 ```json
 {
@@ -128,11 +181,15 @@ node abilities-mcp.js --register
 }
 ```
 
-### Config file search order
+### Config search order
 
 1. `--config=/path/to/wp-sites.json` (explicit)
-2. Same directory as `abilities-mcp.js`
+2. `wp-sites.json` in the same directory as `abilities-mcp.js`
 3. `~/.abilities-mcp/wp-sites.json`
+4. `ABILITIES_MCP_URL` / `ABILITIES_MCP_USERNAME` / `ABILITIES_MCP_PASSWORD` env vars (single-site, used by the `.mcpb` bundle)
+5. `--host=<ssh-host> --path=<wp-path>` (legacy SSH single-site)
+
+The first one found wins. If a `wp-sites.json` exists, env vars are ignored.
 
 ### WordPress Multisite
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -6,14 +6,14 @@ const path = require('path');
 const os = require('os');
 
 /**
- * Load configuration from wp-sites.json or build from CLI args.
+ * Load configuration from wp-sites.json, environment variables, or CLI args.
  *
- * Search order for wp-sites.json:
+ * Search order:
  *   1. --config=<path> explicit path
  *   2. Same directory as abilities-mcp.js
  *   3. ~/.abilities-mcp/wp-sites.json
- *
- * If no config file and --host/--path provided, builds a single-site legacy config.
+ *   4. ABILITIES_MCP_URL/USERNAME/PASSWORD env vars (single-site, .mcpb path)
+ *   5. --host/--path CLI args (legacy SSH single-site)
  *
  * Copyright (C) 2026 Influencentricity | Wicked Evolutions
  * @license GPL-2.0-or-later
@@ -37,15 +37,93 @@ function loadConfig(args) {
     return loadConfigFile(homeConfig);
   }
 
+  // Env-var single-site config — covers the .mcpb install path and any
+  // env-var-based MCP client configuration (claude mcp add, Docker, etc.)
+  if (process.env.ABILITIES_MCP_URL) {
+    return buildEnvConfig(process.env);
+  }
+
   // Legacy CLI mode — single site from --host/--path
   if (args.host && args.path) {
     return buildLegacyConfig(args);
   }
 
   throw new Error(
-    'No wp-sites.json found and no --host/--path provided.\n' +
-    'Create wp-sites.json or use: --host=<ssh-host> --path=<wp-path>'
+    'No configuration found.\n' +
+    'Provide one of: wp-sites.json, ABILITIES_MCP_URL+USERNAME+PASSWORD env vars, or --host/--path.'
   );
+}
+
+/**
+ * Build single-site config from env vars (ABILITIES_MCP_URL/USERNAME/PASSWORD).
+ *
+ * Auto-derives the MCP adapter endpoint from the site URL:
+ *   https://example.com  →  https://example.com/wp-json/mcp/mcp-adapter-default-server
+ *
+ * This is the path used by .mcpb bundles installed in Claude Desktop and any
+ * other env-var-based MCP client configuration.
+ */
+function buildEnvConfig(env) {
+  const rawUrl = env.ABILITIES_MCP_URL;
+  const username = env.ABILITIES_MCP_USERNAME;
+  const password = env.ABILITIES_MCP_PASSWORD;
+
+  if (!username) {
+    throw new Error('ABILITIES_MCP_URL is set but ABILITIES_MCP_USERNAME is missing');
+  }
+  if (!password) {
+    throw new Error('ABILITIES_MCP_URL is set but ABILITIES_MCP_PASSWORD is missing');
+  }
+
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(rawUrl);
+  } catch (e) {
+    throw new Error(`ABILITIES_MCP_URL is not a valid URL: ${rawUrl}`);
+  }
+
+  const isHttps = parsedUrl.protocol === 'https:';
+  const isHttp = parsedUrl.protocol === 'http:';
+  if (!isHttps && !isHttp) {
+    throw new Error(`ABILITIES_MCP_URL must be http or https: ${rawUrl}`);
+  }
+
+  // Strip trailing slash from origin+path, then append the adapter route.
+  const base = (parsedUrl.origin + parsedUrl.pathname).replace(/\/+$/, '');
+  const endpoint = `${base}/wp-json/mcp/mcp-adapter-default-server`;
+
+  const siteConfig = {
+    label: parsedUrl.hostname,
+    url: parsedUrl.origin,
+    transport: 'http',
+    http: {
+      endpoint,
+      username,
+      password,
+    },
+  };
+
+  // Allow plain HTTP only when the operator explicitly opts in. The .mcpb path
+  // expects HTTPS by default; localhost dev gets a narrow exception.
+  if (isHttp) {
+    const isLocal = parsedUrl.hostname === 'localhost' || parsedUrl.hostname === '127.0.0.1';
+    if (!isLocal && env.ABILITIES_MCP_ALLOW_INSECURE !== 'true') {
+      throw new Error(
+        `ABILITIES_MCP_URL is HTTP (not HTTPS): ${rawUrl}\n` +
+        `Set ABILITIES_MCP_ALLOW_INSECURE=true to allow plain HTTP.`
+      );
+    }
+    siteConfig.allowInsecure = true;
+  }
+
+  return {
+    defaultSite: 'default',
+    _isMultiSite: false,
+    _configSource: 'env',
+    sites: {
+      default: siteConfig,
+    },
+  };
 }
 
 function loadConfigFile(filePath) {
@@ -207,4 +285,4 @@ function resolvePassword(httpConfig) {
   throw new Error('No password, passwordEnv, or passwordCommand configured');
 }
 
-module.exports = { loadConfig, resolvePassword, resolveSiteKey, buildSiteKeyEnum };
+module.exports = { loadConfig, resolvePassword, resolveSiteKey, buildSiteKeyEnum, buildEnvConfig };

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://raw.githubusercontent.com/anthropics/mcpb/main/schemas/mcpb-manifest-v0.3.schema.json",
+  "manifest_version": "0.3",
+  "name": "abilities-mcp",
+  "display_name": "WordPress (Abilities MCP)",
+  "version": "1.4.0",
+  "description": "Connect AI clients to WordPress through the Abilities API. One-click bridge to your site's content, users, plugins, and Fluent ecosystem.",
+  "long_description": "Abilities MCP is the open-source bridge that turns any WordPress site into a first-class MCP server. Install this bundle, type your site URL + WordPress username + application password, and your AI client gets typed access to content, users, media, plugins, themes, settings, FluentCRM/Forms/Community, and any other ability registered through the WordPress Abilities API.\n\nRequires the `abilities-mcp-adapter` and `abilities-for-ai` plugins on the WordPress site. The adapter exposes the MCP endpoint; this bundle is the client-side bridge running on your machine.",
+  "author": {
+    "name": "Wicked Evolutions",
+    "url": "https://wickedevolutions.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Wicked-Evolutions/abilities-mcp"
+  },
+  "homepage": "https://github.com/Wicked-Evolutions/abilities-mcp",
+  "documentation": "https://github.com/Wicked-Evolutions/abilities-mcp#readme",
+  "support": "https://github.com/Wicked-Evolutions/abilities-mcp/issues",
+  "license": "GPL-2.0-or-later",
+  "keywords": ["wordpress", "mcp", "abilities", "fluent", "bridge"],
+  "server": {
+    "type": "node",
+    "entry_point": "abilities-mcp.js",
+    "mcp_config": {
+      "command": "node",
+      "args": ["${__dirname}/abilities-mcp.js"],
+      "env": {
+        "ABILITIES_MCP_URL": "${user_config.site_url}",
+        "ABILITIES_MCP_USERNAME": "${user_config.username}",
+        "ABILITIES_MCP_PASSWORD": "${user_config.app_password}"
+      }
+    }
+  },
+  "user_config": {
+    "site_url": {
+      "type": "string",
+      "title": "WordPress Site URL",
+      "description": "Your WordPress site URL, e.g. https://example.com",
+      "required": true
+    },
+    "username": {
+      "type": "string",
+      "title": "WordPress Username",
+      "description": "The WordPress username the AI will act as. Capabilities of this user determine what abilities are available.",
+      "required": true
+    },
+    "app_password": {
+      "type": "string",
+      "title": "Application Password",
+      "description": "WordPress Application Password (Users → Profile → Application Passwords). Stored encrypted in your OS keychain.",
+      "sensitive": true,
+      "required": true
+    }
+  },
+  "compatibility": {
+    "platforms": ["darwin", "win32", "linux"],
+    "runtimes": {
+      "node": ">=18.0.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wickedevolutions/abilities-mcp",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Open-source MCP bridge connecting AI clients to WordPress through the Abilities API — multi-site routing, zero dependencies",
   "main": "abilities-mcp.js",
   "bin": {
@@ -15,7 +15,9 @@
     "url": "https://github.com/Wicked-Evolutions/abilities-mcp.git"
   },
   "scripts": {
-    "test": "node --test test/*.test.js"
+    "test": "node --test test/*.test.js",
+    "validate:mcpb": "npx --yes @anthropic-ai/mcpb validate manifest.json",
+    "pack:mcpb": "npx --yes @anthropic-ai/mcpb pack . abilities-mcp.mcpb"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/test/config-env.test.js
+++ b/test/config-env.test.js
@@ -1,0 +1,136 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { buildEnvConfig } = require('../lib/config');
+
+describe('buildEnvConfig', () => {
+  it('builds a single-site http config from URL/USERNAME/PASSWORD', () => {
+    const config = buildEnvConfig({
+      ABILITIES_MCP_URL: 'https://example.com',
+      ABILITIES_MCP_USERNAME: 'mcp-agent',
+      ABILITIES_MCP_PASSWORD: 'xxxx xxxx xxxx xxxx',
+    });
+
+    assert.equal(config.defaultSite, 'default');
+    assert.equal(config._isMultiSite, false);
+    assert.equal(config._configSource, 'env');
+
+    const site = config.sites.default;
+    assert.equal(site.transport, 'http');
+    assert.equal(site.http.username, 'mcp-agent');
+    assert.equal(site.http.password, 'xxxx xxxx xxxx xxxx');
+  });
+
+  it('auto-derives endpoint from site URL', () => {
+    const config = buildEnvConfig({
+      ABILITIES_MCP_URL: 'https://example.com',
+      ABILITIES_MCP_USERNAME: 'u',
+      ABILITIES_MCP_PASSWORD: 'p',
+    });
+    assert.equal(
+      config.sites.default.http.endpoint,
+      'https://example.com/wp-json/mcp/mcp-adapter-default-server'
+    );
+  });
+
+  it('strips trailing slash from URL when deriving endpoint', () => {
+    const config = buildEnvConfig({
+      ABILITIES_MCP_URL: 'https://example.com/',
+      ABILITIES_MCP_USERNAME: 'u',
+      ABILITIES_MCP_PASSWORD: 'p',
+    });
+    assert.equal(
+      config.sites.default.http.endpoint,
+      'https://example.com/wp-json/mcp/mcp-adapter-default-server'
+    );
+  });
+
+  it('preserves a subdirectory path in the URL when deriving endpoint', () => {
+    const config = buildEnvConfig({
+      ABILITIES_MCP_URL: 'https://example.com/wp',
+      ABILITIES_MCP_USERNAME: 'u',
+      ABILITIES_MCP_PASSWORD: 'p',
+    });
+    assert.equal(
+      config.sites.default.http.endpoint,
+      'https://example.com/wp/wp-json/mcp/mcp-adapter-default-server'
+    );
+  });
+
+  it('throws when USERNAME is missing', () => {
+    assert.throws(
+      () => buildEnvConfig({
+        ABILITIES_MCP_URL: 'https://example.com',
+        ABILITIES_MCP_PASSWORD: 'p',
+      }),
+      /ABILITIES_MCP_USERNAME is missing/
+    );
+  });
+
+  it('throws when PASSWORD is missing', () => {
+    assert.throws(
+      () => buildEnvConfig({
+        ABILITIES_MCP_URL: 'https://example.com',
+        ABILITIES_MCP_USERNAME: 'u',
+      }),
+      /ABILITIES_MCP_PASSWORD is missing/
+    );
+  });
+
+  it('throws when URL is not a valid URL', () => {
+    assert.throws(
+      () => buildEnvConfig({
+        ABILITIES_MCP_URL: 'not-a-url',
+        ABILITIES_MCP_USERNAME: 'u',
+        ABILITIES_MCP_PASSWORD: 'p',
+      }),
+      /not a valid URL/
+    );
+  });
+
+  it('throws when URL uses an unsupported scheme', () => {
+    assert.throws(
+      () => buildEnvConfig({
+        ABILITIES_MCP_URL: 'ftp://example.com',
+        ABILITIES_MCP_USERNAME: 'u',
+        ABILITIES_MCP_PASSWORD: 'p',
+      }),
+      /must be http or https/
+    );
+  });
+
+  it('rejects plain HTTP for non-local hosts by default', () => {
+    assert.throws(
+      () => buildEnvConfig({
+        ABILITIES_MCP_URL: 'http://example.com',
+        ABILITIES_MCP_USERNAME: 'u',
+        ABILITIES_MCP_PASSWORD: 'p',
+      }),
+      /HTTP \(not HTTPS\)/
+    );
+  });
+
+  it('allows plain HTTP for localhost without opt-in', () => {
+    const config = buildEnvConfig({
+      ABILITIES_MCP_URL: 'http://localhost:8080',
+      ABILITIES_MCP_USERNAME: 'u',
+      ABILITIES_MCP_PASSWORD: 'p',
+    });
+    assert.equal(config.sites.default.allowInsecure, true);
+    assert.equal(
+      config.sites.default.http.endpoint,
+      'http://localhost:8080/wp-json/mcp/mcp-adapter-default-server'
+    );
+  });
+
+  it('allows plain HTTP for non-local when ABILITIES_MCP_ALLOW_INSECURE=true', () => {
+    const config = buildEnvConfig({
+      ABILITIES_MCP_URL: 'http://example.com',
+      ABILITIES_MCP_USERNAME: 'u',
+      ABILITIES_MCP_PASSWORD: 'p',
+      ABILITIES_MCP_ALLOW_INSECURE: 'true',
+    });
+    assert.equal(config.sites.default.allowInsecure, true);
+  });
+});


### PR DESCRIPTION
**Held for public-alpha hardening sprint Launch Gate. See SYNTHESIS — Alpha Hardening Workstream 2026-04-26 v1.3.0.**

Closes #8 on merge. Do not merge until Launch Gate clears and J authorises the public alpha launch event.

## Summary

- `manifest.json` against MCPB spec v0.3 — validates clean via `npm run validate:mcpb`
- `.mcpbignore` + `npm run pack:mcpb` / `validate:mcpb` scripts
- Env-var config fallback in `lib/config.js`: `ABILITIES_MCP_URL` / `ABILITIES_MCP_USERNAME` / `ABILITIES_MCP_PASSWORD` build a single-site http config in memory; endpoint auto-derives as `<URL>/wp-json/mcp/mcp-adapter-default-server`
- README restructured around three install paths: `.mcpb` (Claude Desktop), env-vars + npm (Claude Code / Cursor / Docker), `wp-sites.json` (multi-site / power users)
- 11 new unit tests in `test/config-env.test.js`. Full suite: **55 tests pass**
- Version bump 1.3.1 → 1.4.0 (additive minor). Existing `wp-sites.json` users unaffected
- Bundle: **37.3 kB packed**, 17 files, no `node_modules`

## Acceptance criteria

Original issue body criteria:
- [x] Bridge starts with env vars when no `wp-sites.json` exists
- [x] Auto-derives MCP adapter endpoint from site URL
- [x] `manifest.json` validates against mcpb spec v0.3
- [x] `npm run pack:mcpb` produces working `.mcpb` bundle
- [ ] `.mcpb` installs correctly in Claude Desktop (macOS) — verified by reviewer at Launch Gate
- [x] Existing `wp-sites.json` users unaffected (search order preserved; smoke-tested with live `wp-sites.json`)

Public-alpha additions (DB-6 dev-brief comment):
- [x] README updated with `.mcpb` install path as the primary documented method
- [ ] GitHub Release publishes `.mcpb` as a downloadable asset on tagged releases — **held until Launch Gate clears**
- [x] App password stored encrypted in OS keychain via `sensitive: true` in `user_config` (manifest field present; keychain behaviour verified by reviewer at Launch Gate on macOS)
- [ ] Connection succeeds end-to-end: install bundle → type 3 fields → call `mcp-adapter/discover-abilities` → see ability list — **verified by reviewer at Launch Gate**

## Safety / behaviour notes

- **Plain HTTP rejected** unless host is `localhost`/`127.0.0.1` or operator explicitly sets `ABILITIES_MCP_ALLOW_INSECURE=true`. The `.mcpb` install path will refuse a non-HTTPS site URL by default.
- **Config search order preserved**: `--config` → script-dir `wp-sites.json` → `~/.abilities-mcp/wp-sites.json` → env vars → legacy `--host/--path`. Env vars only kick in when no config file exists. Confirmed by smoke test against live `wp-sites.json`.
- **Bucket of unrelated risks**: zero changes to transports, router, sanitizer, tool-catalog, or session management. Diff is config + manifest + docs.

## Test plan (for Launch Gate)

- [ ] Build bundle: `npm run pack:mcpb` → `abilities-mcp.mcpb` ~37 kB
- [ ] Double-click `.mcpb` in Claude Desktop on macOS, type 3 fields, install
- [ ] Confirm app password stored in macOS Keychain (Keychain Access → search for the manifest's identifier)
- [ ] Run `mcp-adapter/discover-abilities` from the connected client, see ability list returned
- [ ] On a separate machine with existing `wp-sites.json`: confirm bridge still loads from file, env vars are ignored
- [ ] `claude mcp add` path: install via `npm install -g @wickedevolutions/abilities-mcp`, configure with three env vars, verify connection

## Deferred to Launch Gate authorisation

- `git tag v1.4.0` and `gh release create` with `.mcpb` asset
- `npm publish @wickedevolutions/abilities-mcp@1.4.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)