### PR TITLE
infra: retarget project automation

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -10,5 +10,5 @@ jobs:
     steps:
       - uses: actions/add-to-project@v1
         with:
-          project-url: https://github.com/orgs/Wicked-Evolutions/projects/3
+          project-url: https://github.com/orgs/Wicked-Evolutions/projects/4
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
## Summary

- Point the `add-to-project` workflow at the correct GitHub Project. This repo belongs on **project #4 (Abilities MCP Roadmap)**, not #3 (Abilities For Ai Roadmap).

## What changes

| File | Change |
|---|---|
| `.github/workflows/add-to-project.yml` | `project-url`: `…/projects/3` → `…/projects/4` |

One file, one line. Nothing else.

## Caveat

The `add-to-project` job will continue to fail at runtime until `secrets.ADD_TO_PROJECT_PAT` is refreshed. That refresh is a separate manual step and **out of scope here** — this PR only fixes the URL.

## Test plan

- [ ] CI: `add-to-project` will still fail (PAT-not-refreshed); ignore until Jacob handles it.
- [ ] Once PAT is live, opening a new issue / PR should auto-add it to project #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)