### PR TITLE
hotfix: wire OAuth tokens into runtime MCP transport

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -167,6 +167,25 @@ function loadConfigFile(filePath) {
 }
 
 function validateSiteConfig(key, site) {
+  // v2 OAuth sites carry no transport block (Appendix F.5 + add-site flow).
+  // The runtime treats them as HTTP — endpoint comes from auth.mcp_resource
+  // or site.mcp_resource (resolved by the OAuth-aware transport).
+  if (site.auth && site.auth.method === 'oauth') {
+    if (!site.url) {
+      throw new Error(`Site "${key}" (oauth): requires "url"`);
+    }
+    if (!site.auth.access_token_ref || !site.auth.refresh_token_ref) {
+      throw new Error(`Site "${key}" (oauth): requires auth.access_token_ref and auth.refresh_token_ref`);
+    }
+    if (!site.mcp_resource) {
+      throw new Error(`Site "${key}" (oauth): requires mcp_resource (set during add-site / reauth)`);
+    }
+    if (!site.mcp_resource.startsWith('https://') && !site.allowInsecure) {
+      throw new Error(`Site "${key}" (oauth): mcp_resource is not HTTPS. Set "allowInsecure": true on the site to allow HTTP`);
+    }
+    return;
+  }
+
   if (!site.transport) {
     throw new Error(`Site "${key}": missing "transport" (ssh or http)`);
   }

--- a/lib/connection-pool.js
+++ b/lib/connection-pool.js
@@ -10,6 +10,23 @@ const { resolveSiteKey, resolvePassword } = require('./config');
 let _synthIdCounter = 1000;
 
 /**
+ * Build a TokenManager-shaped siteAuth object from a v2 OAuth site block.
+ * The OAuthHttpTransport and TokenManager use this shape.
+ */
+function _siteAuthFromConfig(siteId, siteConfig, asMetadata) {
+  return {
+    siteId,
+    tokenEndpoint: asMetadata && asMetadata.token_endpoint,
+    clientId: siteConfig.auth.client_id,
+    accessTokenRef: siteConfig.auth.access_token_ref,
+    refreshTokenRef: siteConfig.auth.refresh_token_ref,
+    accessTokenExpiresAt: siteConfig.auth.access_token_expires_at,
+    refreshTokenExpiresAt: siteConfig.auth.refresh_token_expires_at,
+    authStatus: siteConfig.auth_status || 'active',
+  };
+}
+
+/**
  * Connection Pool — manages one transport per site, lazily instantiated.
  *
  * Each site gets its own independent SSH (or HTTP) connection with its own
@@ -21,11 +38,37 @@ let _synthIdCounter = 1000;
  */
 class ConnectionPool {
 
-  constructor(config, logger) {
+  /**
+   * @param {object} config
+   * @param {function} logger
+   * @param {object} [deps]                   Optional injection seam for tests
+   * @param {object} [deps.secretStore]       Defaults to KeychainSecretStore
+   * @param {object} [deps.tokenManager]      Defaults to a TokenManager built from secretStore
+   * @param {function} [deps.discover]        Defaults to lib/auth/discovery-client.discover
+   * @param {function} [deps.persistAuthStatus] (siteId, newStatus) => void
+   *                                          Persists to wp-sites.json. Defaults to
+   *                                          atomic write via config-migration._atomicWrite
+   *                                          when config._configPath is set.
+   * @param {boolean} [deps.allowInsecure]    For local-dev OAuth over HTTP
+   */
+  constructor(config, logger, deps = {}) {
     this.config = config;
     this.log = logger;
     this.transports = new Map();      // compositeKey -> Transport
     this.connecting = new Map();      // compositeKey -> Promise<Transport>
+
+    // OAuth-runtime deps. Built lazily so SSH-only / App-Password-only setups
+    // never load keytar or the auth modules at all.
+    this._deps = deps;
+    this._secretStore = deps.secretStore || null;
+    this._tokenManager = deps.tokenManager || null;
+    this._discover = deps.discover || null;
+    this._allowInsecure = !!deps.allowInsecure;
+    this._persistAuthStatus = deps.persistAuthStatus || null;
+
+    // Cache of OAuth AS metadata per site URL — avoids re-probing .well-known
+    // on every transport rebuild. Refreshed when the transport is recreated.
+    this._asMetadataCache = new Map();   // siteUrl -> { asMetadata, prMetadata }
 
     // Handshake cache — set after the default site completes init
     this.cachedInitRequest = null;
@@ -98,7 +141,7 @@ class ConnectionPool {
    */
   async connectDefault(onMessage) {
     const key = this.config.defaultSite;
-    const transport = this._createTransport(key, null);
+    const transport = await this._createTransport(key, null);
     transport.onMessage = onMessage;
     await transport.connect();
     this.transports.set(key, transport);
@@ -144,6 +187,28 @@ class ConnectionPool {
     const { resolveSiteKey } = require('./config');
     try {
       const { siteConfig } = resolveSiteKey(this.config, compositeKey);
+
+      // v2 OAuth site — probe the resource URL with HEAD. We do NOT mint a
+      // token here; this is just a reachability check, the real auth happens
+      // on first MCP request via OAuthHttpTransport.
+      if (siteConfig.auth && siteConfig.auth.method === 'oauth') {
+        const target = siteConfig.mcp_resource;
+        if (!target) {
+          return { status: 'unreachable', latencyMs: Date.now() - start, error: 'no mcp_resource configured' };
+        }
+        const mod = target.startsWith('https://') ? require('https') : require('http');
+        const url = new URL(target);
+        await new Promise((resolve, reject) => {
+          const req = mod.request({
+            hostname: url.hostname, port: url.port,
+            path: url.pathname, method: 'HEAD', timeout: 10000,
+          }, (res) => resolve(res.statusCode));
+          req.on('error', reject);
+          req.on('timeout', () => { req.destroy(); reject(new Error('timeout')); });
+          req.end();
+        });
+        return { status: 'reachable', latencyMs: Date.now() - start };
+      }
 
       if (siteConfig.transport === 'ssh') {
         const { execFileSync } = require('child_process');
@@ -199,7 +264,7 @@ class ConnectionPool {
 
     this.log(`Lazy-connecting to site: ${compositeKey}`);
 
-    const transport = this._createTransport(compositeKey, subsiteUrl);
+    const transport = await this._createTransport(compositeKey, subsiteUrl);
 
     // Set up message callback — route responses back to main
     // The main entry will set this after getting the transport
@@ -220,9 +285,17 @@ class ConnectionPool {
     return transport;
   }
 
-  _createTransport(compositeKey, subsiteUrl) {
+  async _createTransport(compositeKey, subsiteUrl) {
     const { siteConfig, subsiteUrl: resolvedSubsiteUrl, resolvedEndpoint } = resolveSiteKey(this.config, compositeKey);
     const finalSubsiteUrl = subsiteUrl || resolvedSubsiteUrl;
+
+    // v2 OAuth dispatch — single branch per Issue #17 acceptance criteria.
+    // Sites with auth.method === 'oauth' use the OAuth-aware HTTP transport;
+    // every other site (App Password, SSH carrier-only) keeps the existing
+    // legacy code paths untouched.
+    if (siteConfig.auth && siteConfig.auth.method === 'oauth') {
+      return this._createOAuthHttpTransport(compositeKey, siteConfig);
+    }
 
     if (siteConfig.transport === 'ssh') {
       return new SshTransport({
@@ -251,14 +324,132 @@ class ConnectionPool {
   }
 
   /**
+   * Build an OAuthHttpTransport for a v2 OAuth site. Lazily resolves AS
+   * metadata via the discovery client (passing capability-pin state per
+   * Appendix H.2.3 — pinned-then-404 throws CapabilityPinningError, which
+   * we let propagate so the bridge fails loud rather than silently
+   * downgrading to App Password).
+   */
+  async _createOAuthHttpTransport(compositeKey, siteConfig) {
+    const { OAuthHttpTransport } = require('./transports/oauth-http-transport');
+    const { TokenManager } = require('./auth/token-manager');
+    const { discover } = require('./auth/discovery-client');
+
+    if (!siteConfig.mcp_resource) {
+      throw new Error(
+        `Site "${compositeKey}" (oauth): no mcp_resource configured — ` +
+        `re-run \`abilities-mcp reauth ${compositeKey}\` to repopulate it`
+      );
+    }
+    if (!siteConfig.url) {
+      throw new Error(`Site "${compositeKey}" (oauth): no url configured`);
+    }
+
+    if (!this._secretStore) {
+      const { KeychainSecretStore } = require('./auth/keychain-secret-store');
+      this._secretStore = new KeychainSecretStore();
+    }
+    if (!this._tokenManager) {
+      this._tokenManager = new TokenManager({
+        secretStore: this._secretStore,
+        allowInsecure: this._allowInsecure,
+      });
+    }
+    const discoverFn = this._discover || discover;
+
+    let asMetadata = (this._asMetadataCache.get(siteConfig.url) || {}).asMetadata;
+    if (!asMetadata) {
+      const result = await discoverFn(siteConfig.url, {
+        pinned: !!siteConfig.oauth_capability_pinned,
+        pinnedFirstSeenAt: siteConfig.oauth_capability_pinned
+          && siteConfig.oauth_capability_pinned.first_seen_at,
+        allowInsecure: this._allowInsecure,
+      });
+      asMetadata = result.asMetadata;
+      this._asMetadataCache.set(siteConfig.url, {
+        asMetadata: result.asMetadata,
+        prMetadata: result.prMetadata,
+      });
+    }
+
+    if (!asMetadata || !asMetadata.token_endpoint) {
+      throw new Error(
+        `Site "${compositeKey}" (oauth): discovery did not yield a token_endpoint`
+      );
+    }
+
+    const siteAuth = _siteAuthFromConfig(compositeKey, siteConfig, asMetadata);
+
+    return new OAuthHttpTransport({
+      endpoint: siteConfig.mcp_resource,
+      tokenManager: this._tokenManager,
+      siteAuth,
+      onAuthStatusChange: (newStatus, info) => {
+        // In-memory update first so subsequent transport rebuilds see it.
+        try {
+          siteConfig.auth_status = newStatus;
+        } catch { /* siteConfig may be frozen in tests — ignore */ }
+        this.log(
+          `OAuth auth_status change: ${compositeKey} → ${newStatus} (${info && info.reason || 'unknown'})`
+        );
+        // Persist to wp-sites.json best-effort. A failure to write should
+        // not break the request path that triggered this change.
+        if (this._persistAuthStatus) {
+          Promise.resolve()
+            .then(() => this._persistAuthStatus(compositeKey, newStatus, info))
+            .catch((err) => this.log(`OAuth auth_status persist failed: ${err.message}`));
+        } else if (this.config && this.config._configPath) {
+          this._defaultPersistAuthStatus(compositeKey, newStatus)
+            .catch((err) => this.log(`OAuth auth_status persist failed: ${err.message}`));
+        }
+      },
+      logger: this.log,
+    });
+  }
+
+  /**
+   * Default auth_status persistor — atomic rewrite of wp-sites.json. Used
+   * when the pool was constructed without a custom persistAuthStatus.
+   */
+  async _defaultPersistAuthStatus(siteId, newStatus) {
+    const { _atomicWrite } = require('./auth/config-migration');
+    const fs = require('node:fs');
+    const filePath = this.config._configPath;
+    if (!filePath) return;
+    let raw;
+    try {
+      raw = await fs.promises.readFile(filePath, 'utf8');
+    } catch (err) {
+      throw new Error(`read ${filePath}: ${err.message}`);
+    }
+    let parsed;
+    try { parsed = JSON.parse(raw); }
+    catch (err) {
+      throw new Error(`parse ${filePath}: ${err.message}`);
+    }
+    if (parsed && parsed.sites && parsed.sites[siteId]) {
+      parsed.sites[siteId].auth_status = newStatus;
+      await _atomicWrite(filePath, parsed);
+    }
+  }
+
+  /**
    * Check if a composite key resolves to the same HTTP endpoint as an
    * already-connected transport. Returns { key, transport } or null.
+   *
+   * Covers both v1 App-Password HTTP sites and v2 OAuth sites — the dedup
+   * target is whichever URL the eventual transport will POST to.
    */
   _findExistingHttpTransport(compositeKey) {
     const { siteConfig, resolvedEndpoint } = resolveSiteKey(this.config, compositeKey);
-    if (siteConfig.transport !== 'http') return null;
 
-    const targetEndpoint = resolvedEndpoint || siteConfig.http.endpoint;
+    let targetEndpoint = null;
+    if (siteConfig.auth && siteConfig.auth.method === 'oauth') {
+      targetEndpoint = siteConfig.mcp_resource;
+    } else if (siteConfig.transport === 'http') {
+      targetEndpoint = resolvedEndpoint || (siteConfig.http && siteConfig.http.endpoint);
+    }
+    if (!targetEndpoint) return null;
 
     for (const [key, transport] of this.transports) {
       if (transport.endpoint === targetEndpoint) {

--- a/lib/transports/oauth-http-transport.js
+++ b/lib/transports/oauth-http-transport.js
@@ -1,0 +1,601 @@
+'use strict';
+
+const https = require('https');
+const http = require('http');
+const { URL } = require('url');
+
+const MAX_QUEUE = 100;
+
+/**
+ * OAuthHttpTransport — HTTP transport for sites authenticated with
+ * OAuth 2.1 bearer tokens.
+ *
+ * Sibling to HttpTransport (which handles Basic / App-Password). Selected by
+ * ConnectionPool when `siteConfig.auth.method === 'oauth'`.
+ *
+ * Surface compatible with HttpTransport: connect / send / isReady /
+ * performHandshake / shutdown / onMessage / endpoint, so the rest of the
+ * bridge (router, connection-pool reuse logic, healthcheck) cannot tell
+ * the two apart.
+ *
+ * Auth:
+ *   - Before each POST, resolve a usable access token via TokenManager.
+ *     TokenManager handles the 300-second pre-expiry refresh per H.2.1.
+ *   - Build `Authorization: Bearer ${accessToken}`.
+ *   - On 401 from the resource, call TokenManager with `forceRefresh: true`
+ *     and retry the request once. If the retry also returns 401, emit an
+ *     auth_failed event (caller updates auth_status to "expired") and
+ *     surface a structured error to the request — no third attempt.
+ *
+ * Queue / batch / cookie / session-token semantics mirror HttpTransport.
+ * The duplication is intentional for this hotfix: extracting a shared base
+ * across both transports would touch HttpTransport mid-hotfix and risk
+ * regressing the App-Password runtime path. A future refactor can pull a
+ * BaseHttpTransport once both implementations have stabilised.
+ *
+ * Out of scope for this transport (per Appendix H.2.3):
+ *   - Capability pinning enforcement. The pin lives on `siteConfig` and is
+ *     written by the OAuth flow (oauth-client.js) during add-site / reauth.
+ *     Pinned-then-404 fail-loud belongs to the discovery layer, not to
+ *     runtime MCP traffic. The transport never probes .well-known/*.
+ *   - apppassword_fallback at runtime. When `auth.method === 'oauth'`,
+ *     OAuth always wins — see Appendix F.5 "Precedence rule". The fallback
+ *     block exists for the operator-driven `upgrade-auth` workflow only;
+ *     it is NOT a runtime "if OAuth fails, try Basic" branch.
+ *
+ * @param {object} opts
+ * @param {string} opts.endpoint              MCP resource URL (https)
+ * @param {object} opts.tokenManager          TokenManager instance
+ * @param {object} opts.siteAuth              SiteAuthState (see TokenManager)
+ * @param {function} opts.onAuthStatusChange  Optional. Called with
+ *                                            (newStatus, { reason, siteId })
+ *                                            when transport detects a terminal
+ *                                            auth failure. Caller persists.
+ * @param {function} opts.logger              Logger function
+ *
+ * Copyright (C) 2026 Influencentricity | Wicked Evolutions
+ * @license GPL-2.0-or-later
+ */
+class OAuthHttpTransport {
+
+  constructor(opts) {
+    if (!opts || !opts.endpoint) {
+      throw new Error('OAuthHttpTransport requires an endpoint');
+    }
+    if (!opts.tokenManager) {
+      throw new Error('OAuthHttpTransport requires a tokenManager');
+    }
+    if (!opts.siteAuth) {
+      throw new Error('OAuthHttpTransport requires siteAuth');
+    }
+
+    this.endpoint = opts.endpoint;
+    this._tokenManager = opts.tokenManager;
+    this._siteAuth = opts.siteAuth;
+    this._onAuthStatusChange = opts.onAuthStatusChange || null;
+    this.log = opts.logger || function noop() {};
+
+    const parsedUrl = new URL(this.endpoint);
+    this.parsedUrl = parsedUrl;
+    this.isHttps = parsedUrl.protocol === 'https:';
+    this.httpModule = this.isHttps ? https : http;
+
+    // State
+    this.sessionId = null;
+    this.sessionToken = null;
+    this.clientProtocolVersion = null;
+    this.ready = false;
+    this.onMessage = null;
+
+    // Message queue — serialized processing
+    this.messageQueue = [];
+    this.processing = false;
+
+    // Batch coalescing
+    this._coalesceTimer = null;
+    this._coalesceWindowMs = 10;
+
+    // Healthcheck
+    this.healthcheckTimer = null;
+
+    // 5xx retry config (separate from the 401-once-refresh path)
+    this.maxRetries = 3;
+    this.baseRetryDelay = 1000;
+
+    // Handshake cache for session recovery
+    this.cachedInitRequest = null;
+    this.cachedInitNotification = null;
+
+    // Cookie jar — per-host
+    this._cookies = new Map();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public surface (mirrors HttpTransport)
+  // ---------------------------------------------------------------------------
+
+  async connect() {
+    this.ready = true;
+    this.log(`OAuth HTTP transport ready: ${this.parsedUrl.hostname}`);
+    this._startHealthcheck();
+  }
+
+  send(line) {
+    if (this.messageQueue.length >= MAX_QUEUE) {
+      this.log('OAuth HTTP queue full — rejecting');
+      try {
+        const msg = JSON.parse(line);
+        if (msg.id !== undefined && this.onMessage) {
+          this.onMessage({
+            jsonrpc: '2.0', id: msg.id,
+            error: { code: -32603, message: 'OAuth HTTP transport queue full' }
+          }, null);
+        }
+      } catch (e) { /* ignore */ }
+      return;
+    }
+    this.messageQueue.push(line);
+    this._drainQueue();
+  }
+
+  isReady() {
+    return this.ready;
+  }
+
+  async performHandshake(initRequest, initNotification) {
+    this.cachedInitRequest = initRequest;
+    this.cachedInitNotification = initNotification;
+
+    if (initRequest.params && initRequest.params.protocolVersion) {
+      this.clientProtocolVersion = initRequest.params.protocolVersion;
+    }
+
+    const initLine = JSON.stringify(initRequest);
+    const initResult = await this._postWithRetry(initLine);
+    if (initResult && initResult.body && initResult.body.trim()) {
+      this.log(`OAuth HTTP handshake init response: ${initResult.statusCode}`);
+    }
+    if (initResult && initResult.sessionId) {
+      this.sessionId = initResult.sessionId;
+    }
+
+    if (initNotification) {
+      const notifLine = JSON.stringify(initNotification);
+      await this._postWithRetry(notifLine);
+    }
+  }
+
+  async shutdown() {
+    this._stopHealthcheck();
+    this.ready = false;
+    this.log(`OAuth HTTP transport shutdown: ${this.parsedUrl.hostname}`);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal — queue / batch (mirrors HttpTransport)
+  // ---------------------------------------------------------------------------
+
+  _drainQueue() {
+    if (this.processing || this._coalesceTimer) return;
+
+    this._coalesceTimer = setTimeout(async () => {
+      this._coalesceTimer = null;
+      if (this.processing || this.messageQueue.length === 0) return;
+
+      this.processing = true;
+      const batch = this.messageQueue.splice(0);
+
+      if (batch.length === 1) {
+        await this._processMessage(batch[0]);
+      } else {
+        await this._processBatch(batch);
+      }
+
+      this.processing = false;
+
+      if (this.messageQueue.length > 0) {
+        this._drainQueue();
+      }
+    }, this._coalesceWindowMs);
+  }
+
+  async _processBatch(lines) {
+    const parsed = [];
+    const fallback = [];
+    for (const line of lines) {
+      try {
+        parsed.push({ line, msg: JSON.parse(line) });
+      } catch {
+        fallback.push(line);
+      }
+    }
+
+    for (const { msg } of parsed) {
+      if (msg.method === 'initialize') {
+        this.cachedInitRequest = msg;
+        if (msg.params && msg.params.protocolVersion) {
+          this.clientProtocolVersion = msg.params.protocolVersion;
+        }
+      }
+      if (msg.method === 'initialized' || msg.method === 'notifications/initialized') {
+        this.cachedInitNotification = msg;
+      }
+    }
+
+    const requests = parsed.filter(({ msg }) => 'id' in msg);
+    const notifications = parsed.filter(({ msg }) => !('id' in msg));
+
+    for (const { line } of notifications) {
+      try { await this._postWithRetry(line); } catch { /* ignore */ }
+    }
+
+    if (requests.length === 0) {
+      for (const line of fallback) await this._processMessage(line);
+      return;
+    }
+
+    const batchBody = JSON.stringify(requests.map(({ msg }) => msg));
+
+    const pending = new Map();
+    const resultPromises = requests.map(({ msg }) => {
+      return new Promise((resolve) => { pending.set(String(msg.id), resolve); });
+    });
+
+    try {
+      const result = await this._postWithRetry(batchBody);
+
+      if (result.body && result.body.trim()) {
+        let batchResponse;
+        try {
+          batchResponse = JSON.parse(result.body.trim());
+        } catch {
+          for (const { msg } of requests) {
+            pending.get(String(msg.id))?.({
+              jsonrpc: '2.0', id: msg.id,
+              error: { code: -32700, message: 'Batch response parse error' },
+            });
+          }
+          return;
+        }
+
+        if (Array.isArray(batchResponse)) {
+          for (let resp of batchResponse) {
+            const resolver = pending.get(String(resp.id));
+            if (resolver) {
+              resolver(resp);
+              pending.delete(String(resp.id));
+            }
+          }
+        } else {
+          const resp = batchResponse;
+          const resolver = pending.get(String(resp.id));
+          if (resolver) {
+            resolver(resp);
+            pending.delete(String(resp.id));
+          }
+        }
+      }
+    } catch (err) {
+      this.log(`OAuth HTTP batch error: ${err.message}`);
+      for (const { msg } of requests) {
+        pending.get(String(msg.id))?.({
+          jsonrpc: '2.0', id: msg.id,
+          error: { code: -32000, message: `OAuth HTTP batch error: ${err.message}` },
+        });
+      }
+    }
+
+    for (const [id, resolve] of pending.entries()) {
+      resolve({ jsonrpc: '2.0', id, error: { code: -32000, message: 'No response in batch' } });
+    }
+
+    const responses = await Promise.all(resultPromises);
+    for (const resp of responses) {
+      if (this.onMessage) this.onMessage(resp, JSON.stringify(resp));
+    }
+
+    for (const line of fallback) {
+      await this._processMessage(line);
+    }
+  }
+
+  async _processMessage(line) {
+    let msg;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      if (this.onMessage) {
+        this.onMessage({
+          jsonrpc: '2.0', id: null,
+          error: { code: -32700, message: 'Parse error' },
+        }, null);
+      }
+      return;
+    }
+
+    if (msg.method === 'initialize') {
+      this.cachedInitRequest = msg;
+      if (msg.params && msg.params.protocolVersion) {
+        this.clientProtocolVersion = msg.params.protocolVersion;
+      }
+    }
+    if (msg.method === 'initialized' || msg.method === 'notifications/initialized') {
+      this.cachedInitNotification = msg;
+    }
+
+    const isNotification = msg.method && !('id' in msg);
+
+    try {
+      const result = await this._postWithRetry(line);
+
+      if (result.body && result.body.trim()) {
+        const rawLine = result.body.trim();
+        let parsed;
+        try {
+          parsed = JSON.parse(rawLine);
+        } catch {
+          if (this.onMessage) this.onMessage(null, rawLine);
+          return;
+        }
+
+        if (parsed.result && parsed.result.isError && parsed.result._metadata && parsed.result._metadata.input_schema) {
+          const content = parsed.result.content;
+          if (Array.isArray(content) && content.length > 0 && content[0].type === 'text') {
+            const schema = parsed.result._metadata.input_schema;
+            const required = schema.required || [];
+            const props = schema.properties || {};
+            const paramList = Object.entries(props).map(([k, v]) => {
+              const req = required.includes(k) ? ' (required)' : '';
+              return `  ${k}: ${v.type || 'any'}${req} — ${v.description || ''}`;
+            }).join('\n');
+            content[0].text += `\n\nExpected parameters:\n${paramList}`;
+          }
+        }
+
+        if (this.onMessage) this.onMessage(parsed, JSON.stringify(parsed));
+      }
+    } catch (err) {
+      this.log(`OAuth HTTP error for ${msg.method || 'unknown'}: ${err.message}`);
+      if (!isNotification && this.onMessage) {
+        this.onMessage({
+          jsonrpc: '2.0', id: msg.id,
+          error: { code: -32000, message: `OAuth HTTP bridge error: ${err.message}` },
+        }, null);
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal — POST with retry
+  //
+  // Two distinct retry concerns layered on top of each other:
+  //   1. Bearer freshness: TokenManager refreshes within 300s of expiry on
+  //      the way in. On a 401 from the resource we do exactly one
+  //      forceRefresh + retry — second 401 is terminal and fails the request.
+  //   2. Transport-level retries on 5xx and network errors, mirroring the
+  //      App-Password transport so basic robustness matches.
+  // ---------------------------------------------------------------------------
+
+  async _postWithRetry(body, attempt = 0, retryAfterRefresh = false) {
+    let bearer;
+    try {
+      const tok = await this._tokenManager.getAccessToken(this._siteAuth, {
+        forceRefresh: retryAfterRefresh,
+      });
+      bearer = tok.accessToken;
+      if (tok.refreshed && tok.updatedAuth) {
+        // Adopt the rotated refs / new expiry locally so subsequent calls
+        // skip the refresh window check until next pre-expiry. The on-disk
+        // config is updated by the auth_status_change consumer if wired.
+        this._siteAuth = {
+          ...this._siteAuth,
+          accessTokenRef: tok.updatedAuth.accessTokenRef,
+          refreshTokenRef: tok.updatedAuth.refreshTokenRef,
+          accessTokenExpiresAt: tok.updatedAuth.accessTokenExpiresAt,
+          authStatus: tok.updatedAuth.authStatus,
+        };
+      }
+    } catch (err) {
+      // Refresh failure (e.g. RefreshError 4xx → expired). Emit auth status
+      // change so caller can update wp-sites.json, then surface to caller.
+      if (err && err.updatedAuth && this._onAuthStatusChange) {
+        try {
+          this._onAuthStatusChange(err.updatedAuth.authStatus, {
+            reason: 'refresh_failed',
+            siteId: this._siteAuth.siteId,
+            cause: err,
+          });
+        } catch { /* observer must not break the request path */ }
+      }
+      const reauthHint = err && err.reauthHint
+        ? ` (run: ${err.reauthHint.command})`
+        : '';
+      const wrapped = new Error(`OAuth refresh failed${reauthHint}: ${err && err.message || err}`);
+      wrapped.cause = err;
+      wrapped.code = (err && err.code) || 'oauth_refresh_failed';
+      wrapped.reauth = true;
+      throw wrapped;
+    }
+
+    let result;
+    try {
+      result = await this._post(body, bearer);
+    } catch (err) {
+      // Network error — retry with backoff (mirror HttpTransport).
+      if (attempt < this.maxRetries) {
+        const delay = this.baseRetryDelay * Math.pow(2, attempt);
+        this.log(`OAuth HTTP network error — retrying in ${delay}ms: ${err.message}`);
+        await this._sleep(delay);
+        return this._postWithRetry(body, attempt + 1, false);
+      }
+      throw err;
+    }
+
+    // 401 from resource — bearer is stale. Force-refresh once and retry.
+    // Per Appendix H.2.1 + Issue #17 acceptance: do this exactly once. A
+    // second 401 marks the site expired and surfaces a reauth hint.
+    if (result.statusCode === 401 && !retryAfterRefresh) {
+      this.log('OAuth HTTP 401 from resource — forcing token refresh and retrying once');
+      return this._postWithRetry(body, attempt, true);
+    }
+    if (result.statusCode === 401 && retryAfterRefresh) {
+      // Two 401s in a row with a freshly-minted token — token is dead or the
+      // server has revoked. Treat as terminal, mark expired, fail the request.
+      const expiredErr = new Error(
+        `OAuth bearer rejected after refresh (HTTP 401). ` +
+        `Run: abilities-mcp reauth ${this._siteAuth.siteId}`
+      );
+      expiredErr.code = 'oauth_bearer_rejected';
+      expiredErr.reauth = true;
+      expiredErr.statusCode = 401;
+      if (this._onAuthStatusChange) {
+        try {
+          this._onAuthStatusChange('expired', {
+            reason: 'bearer_rejected_after_refresh',
+            siteId: this._siteAuth.siteId,
+          });
+        } catch { /* observer must not break the request path */ }
+      }
+      throw expiredErr;
+    }
+
+    // Session recovery — same triggers as HttpTransport, except 401/403 with
+    // an active session is now AT MOST a stale-session signal. Bearer staleness
+    // is already handled above, so a 401 reaching this branch means the token
+    // is fresh but the MCP session expired. We still allow one re-handshake.
+    const isExplicitExpiry = result.statusCode === 404 || result.statusCode === 410;
+    const isStaleSession = result.statusCode === 403 && this.sessionId !== null;
+    if ((isExplicitExpiry || isStaleSession) && attempt === 0) {
+      this.log(`OAuth HTTP session expired (HTTP ${result.statusCode}) — attempting recovery`);
+      this.sessionId = null;
+      this.sessionToken = null;
+      if (this.cachedInitRequest) {
+        await this.performHandshake(this.cachedInitRequest, this.cachedInitNotification);
+        return this._postWithRetry(body, attempt + 1, false);
+      }
+    }
+
+    // 5xx retry with backoff
+    if (result.statusCode >= 500 && attempt < this.maxRetries) {
+      const delay = this.baseRetryDelay * Math.pow(2, attempt);
+      this.log(`OAuth HTTP ${result.statusCode} — retrying in ${delay}ms (attempt ${attempt + 1}/${this.maxRetries})`);
+      await this._sleep(delay);
+      return this._postWithRetry(body, attempt + 1, false);
+    }
+
+    return result;
+  }
+
+  _post(body, bearer) {
+    return new Promise((resolve, reject) => {
+      const headers = {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${bearer}`,
+        'Accept': 'application/json',
+      };
+
+      if (this.sessionId) headers['Mcp-Session-Id'] = this.sessionId;
+      if (this.sessionToken) headers['Mcp-Session-Token'] = this.sessionToken;
+
+      const hostCookies = this._cookies.get(this.parsedUrl.hostname);
+      if (hostCookies && hostCookies.size > 0) {
+        headers['Cookie'] = Array.from(hostCookies.entries())
+          .map(([name, value]) => `${name}=${value}`)
+          .join('; ');
+      }
+
+      const options = {
+        hostname: this.parsedUrl.hostname,
+        port: this.parsedUrl.port || (this.isHttps ? 443 : 80),
+        path: this.parsedUrl.pathname + this.parsedUrl.search,
+        method: 'POST',
+        headers,
+      };
+
+      const req = this.httpModule.request(options, (res) => {
+        const chunks = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => {
+          const newSessionId = res.headers['mcp-session-id'];
+          if (newSessionId) this.sessionId = newSessionId;
+          const newSessionToken = res.headers['mcp-session-token'];
+          if (newSessionToken) this.sessionToken = newSessionToken;
+
+          const setCookieHeader = res.headers['set-cookie'];
+          if (setCookieHeader) {
+            const cookies = Array.isArray(setCookieHeader) ? setCookieHeader : [setCookieHeader];
+            if (!this._cookies.has(this.parsedUrl.hostname)) {
+              this._cookies.set(this.parsedUrl.hostname, new Map());
+            }
+            const jar = this._cookies.get(this.parsedUrl.hostname);
+            for (const raw of cookies) {
+              const nameValue = raw.split(';')[0].trim();
+              const eqIdx = nameValue.indexOf('=');
+              if (eqIdx > 0) {
+                jar.set(nameValue.slice(0, eqIdx), nameValue.slice(eqIdx + 1));
+              }
+            }
+          }
+
+          resolve({
+            statusCode: res.statusCode,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString('utf8'),
+            sessionId: newSessionId || this.sessionId,
+          });
+        });
+      });
+
+      req.on('error', (err) => reject(err));
+      req.setTimeout(120000, () => {
+        req.destroy(new Error('Request timeout (120s)'));
+      });
+
+      req.write(body);
+      req.end();
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal — healthcheck (matches HttpTransport cadence)
+  // ---------------------------------------------------------------------------
+
+  _startHealthcheck() {
+    this._stopHealthcheck();
+    this.healthcheckTimer = setInterval(() => {
+      this._sendPing();
+    }, 45000);
+    if (this.healthcheckTimer.unref) this.healthcheckTimer.unref();
+  }
+
+  _stopHealthcheck() {
+    if (this.healthcheckTimer) {
+      clearInterval(this.healthcheckTimer);
+      this.healthcheckTimer = null;
+    }
+  }
+
+  async _sendPing() {
+    const pingMsg = JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'ping',
+      id: `__healthcheck_${Date.now()}`,
+    });
+    try {
+      const result = await this._postWithRetry(pingMsg);
+      this.log(`OAuth HTTP healthcheck: ${result.statusCode}`);
+    } catch (err) {
+      this.log(`OAuth HTTP healthcheck failed: ${err.message}`);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal — utils
+  // ---------------------------------------------------------------------------
+
+  _sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+}
+
+module.exports = { OAuthHttpTransport };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/Wicked-Evolutions/abilities-mcp.git"
   },
   "scripts": {
-    "test": "node --test test/*.test.js test/auth/*.test.js test/cli/*.test.js",
+    "test": "node --test test/*.test.js test/auth/*.test.js test/cli/*.test.js test/transports/*.test.js",
     "validate:mcpb": "npx --yes @anthropic-ai/mcpb validate manifest.json",
     "pack:mcpb": "npx --yes @anthropic-ai/mcpb pack . abilities-mcp.mcpb"
   },

--- a/test/auth/helpers/mock-auth-server.js
+++ b/test/auth/helpers/mock-auth-server.js
@@ -252,6 +252,12 @@ class MockAuthServer {
         this.config.refreshFailures--;
         return send(503, '');
       }
+      // Tests can pin the response by setting `tokenJson`. When set, the
+      // refresh path returns it verbatim — useful for asserting that the
+      // resource sees the post-refresh bearer.
+      if (this.config.tokenJson) {
+        return send(200, this.config.tokenJson);
+      }
       const tokens = {
         access_token: `at-${randomBytes(8).toString('hex')}`,
         token_type: 'Bearer',

--- a/test/config-v2-oauth.test.js
+++ b/test/config-v2-oauth.test.js
@@ -1,0 +1,115 @@
+'use strict';
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { loadConfig } = require('../lib/config');
+
+/**
+ * The runtime config loader must accept v2 OAuth sites (which carry no
+ * `transport` block, only `auth.method === 'oauth'` + `mcp_resource`). This
+ * is the gating change for Issue #17 — without it, the bridge cannot even
+ * boot when its config contains an OAuth site.
+ */
+
+const tmpFiles = [];
+after(() => {
+  for (const f of tmpFiles) {
+    try { fs.unlinkSync(f); } catch {}
+  }
+});
+
+function writeTempConfig(contents) {
+  const file = path.join(os.tmpdir(), `wp-sites.test.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.json`);
+  fs.writeFileSync(file, JSON.stringify(contents, null, 2), { mode: 0o600 });
+  tmpFiles.push(file);
+  return file;
+}
+
+describe('loadConfig — v2 OAuth site acceptance (Issue #17 gating change)', () => {
+  it('accepts an OAuth site with mcp_resource and no transport block', () => {
+    const file = writeTempConfig({
+      schema_version: 2,
+      defaultSite: 'siteA',
+      sites: {
+        siteA: {
+          url: 'https://example.com',
+          mcp_resource: 'https://example.com/wp-json/mcp/mcp-adapter-default-server',
+          auth: {
+            method: 'oauth',
+            client_id: 'client-x',
+            access_token_ref: 'keychain://abilities-mcp/siteA/access',
+            refresh_token_ref: 'keychain://abilities-mcp/siteA/refresh',
+          },
+          auth_status: 'active',
+        },
+      },
+    });
+    const cfg = loadConfig({ config: file });
+    assert.equal(cfg.defaultSite, 'siteA');
+    assert.equal(cfg.sites.siteA.auth.method, 'oauth');
+  });
+
+  it('rejects an OAuth site that is missing mcp_resource', () => {
+    const file = writeTempConfig({
+      schema_version: 2,
+      defaultSite: 'siteA',
+      sites: {
+        siteA: {
+          url: 'https://example.com',
+          auth: {
+            method: 'oauth',
+            client_id: 'x',
+            access_token_ref: 'keychain://abilities-mcp/siteA/access',
+            refresh_token_ref: 'keychain://abilities-mcp/siteA/refresh',
+          },
+          auth_status: 'active',
+        },
+      },
+    });
+    assert.throws(() => loadConfig({ config: file }), /mcp_resource/);
+  });
+
+  it('rejects an OAuth site whose mcp_resource is HTTP without allowInsecure', () => {
+    const file = writeTempConfig({
+      schema_version: 2,
+      defaultSite: 'siteA',
+      sites: {
+        siteA: {
+          url: 'http://example.com',
+          mcp_resource: 'http://example.com/wp-json/mcp/mcp-adapter-default-server',
+          auth: {
+            method: 'oauth',
+            client_id: 'x',
+            access_token_ref: 'keychain://abilities-mcp/siteA/access',
+            refresh_token_ref: 'keychain://abilities-mcp/siteA/refresh',
+          },
+          auth_status: 'active',
+        },
+      },
+    });
+    assert.throws(() => loadConfig({ config: file }), /not HTTPS/);
+  });
+
+  it('still accepts a legacy v1 App-Password site (no regression)', () => {
+    const file = writeTempConfig({
+      defaultSite: 'siteA',
+      sites: {
+        siteA: {
+          url: 'https://example.com',
+          transport: 'http',
+          http: {
+            endpoint: 'https://example.com/wp-json/mcp/mcp-adapter-default-server',
+            username: 'wp_user',
+            password: 'pw',
+          },
+        },
+      },
+    });
+    const cfg = loadConfig({ config: file });
+    assert.equal(cfg.sites.siteA.http.username, 'wp_user');
+  });
+});

--- a/test/connection-pool.test.js
+++ b/test/connection-pool.test.js
@@ -1,0 +1,235 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { ConnectionPool } = require('../lib/connection-pool');
+const { OAuthHttpTransport } = require('../lib/transports/oauth-http-transport');
+const { HttpTransport } = require('../lib/transports/http-transport');
+const { SshTransport } = require('../lib/transports/ssh-transport');
+const { TokenManager, SECRET_SERVICE } = require('../lib/auth/token-manager');
+const { MemorySecretStore } = require('../lib/auth/memory-secret-store');
+const { makeRef } = require('../lib/auth/secret-store');
+
+/**
+ * ConnectionPool dispatch — Issue #17 acceptance criteria.
+ *
+ * The pool must select OAuthHttpTransport for v2 OAuth sites and leave
+ * App-Password / SSH sites on their existing legacy transports unchanged.
+ */
+
+function fakeDiscover() {
+  return async (siteUrl) => ({
+    asMetadata: {
+      issuer: siteUrl,
+      token_endpoint: `${siteUrl}/oauth/token`,
+      authorization_endpoint: `${siteUrl}/oauth/authorize`,
+    },
+    asMetadataUrl: `${siteUrl}/.well-known/oauth-authorization-server`,
+    prMetadata: { resource: `${siteUrl}/wp-json/mcp/mcp-adapter-default-server` },
+    prMetadataUrl: `${siteUrl}/.well-known/oauth-protected-resource`,
+    probeResults: [],
+  });
+}
+
+describe('ConnectionPool dispatch — auth.method === "oauth"', () => {
+  it('builds an OAuthHttpTransport for OAuth sites', async () => {
+    const store = new MemorySecretStore();
+    await store.set(SECRET_SERVICE, 'siteA/access', 'AT');
+    await store.set(SECRET_SERVICE, 'siteA/refresh', 'RT');
+    const tm = new TokenManager({ secretStore: store, allowInsecure: true });
+
+    const config = {
+      defaultSite: 'siteA',
+      sites: {
+        siteA: {
+          url: 'https://example.com',
+          mcp_resource: 'https://example.com/wp-json/mcp/mcp-adapter-default-server',
+          auth: {
+            method: 'oauth',
+            client_id: 'client-x',
+            access_token_ref: makeRef(SECRET_SERVICE, 'siteA/access'),
+            refresh_token_ref: makeRef(SECRET_SERVICE, 'siteA/refresh'),
+            access_token_expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+            refresh_token_expires_at: new Date(Date.now() + 90 * 24 * 3600 * 1000).toISOString(),
+          },
+          auth_status: 'active',
+        },
+      },
+    };
+
+    const pool = new ConnectionPool(config, () => {}, {
+      secretStore: store,
+      tokenManager: tm,
+      discover: fakeDiscover(),
+      allowInsecure: true,
+    });
+
+    const transport = await pool._createTransport('siteA', null);
+    assert.ok(transport instanceof OAuthHttpTransport,
+      `expected OAuthHttpTransport, got ${transport && transport.constructor && transport.constructor.name}`);
+    assert.equal(transport.endpoint, 'https://example.com/wp-json/mcp/mcp-adapter-default-server');
+  });
+
+  it('routes App-Password sites to legacy HttpTransport unchanged (no regression)', async () => {
+    const config = {
+      defaultSite: 'siteB',
+      sites: {
+        siteB: {
+          url: 'https://siteB.com',
+          transport: 'http',
+          http: {
+            endpoint: 'https://siteB.com/wp-json/mcp/mcp-adapter-default-server',
+            username: 'wp_user',
+            password: 'pw',
+          },
+          auth: {
+            method: 'apppassword',
+            username: 'wp_user',
+            password_ref: makeRef(SECRET_SERVICE, 'siteB/apppassword'),
+          },
+          auth_status: 'active',
+        },
+      },
+    };
+
+    const pool = new ConnectionPool(config, () => {});
+    const transport = await pool._createTransport('siteB', null);
+    assert.ok(transport instanceof HttpTransport,
+      `expected HttpTransport, got ${transport && transport.constructor && transport.constructor.name}`);
+    assert.ok(!(transport instanceof OAuthHttpTransport));
+    assert.equal(transport.endpoint, 'https://siteB.com/wp-json/mcp/mcp-adapter-default-server');
+  });
+
+  it('routes SSH carrier-only sites to SshTransport unchanged', async () => {
+    const config = {
+      defaultSite: 'siteC',
+      sites: {
+        siteC: {
+          url: 'ssh://siteC.example',
+          transport: 'ssh',
+          ssh: { host: 'siteC.example', path: '/var/www/wp', user: 'ssh' },
+          auth: {
+            method: 'apppassword',
+            username: 'ssh',
+            password_ref: makeRef(SECRET_SERVICE, 'siteC/apppassword'),
+          },
+          auth_status: 'active',
+        },
+      },
+    };
+    const pool = new ConnectionPool(config, () => {});
+    const transport = await pool._createTransport('siteC', null);
+    assert.ok(transport instanceof SshTransport);
+  });
+
+  it('throws a clear error when an OAuth site is missing mcp_resource', async () => {
+    const store = new MemorySecretStore();
+    await store.set(SECRET_SERVICE, 'siteA/access', 'AT');
+    await store.set(SECRET_SERVICE, 'siteA/refresh', 'RT');
+    const config = {
+      defaultSite: 'siteA',
+      sites: {
+        siteA: {
+          url: 'https://example.com',
+          // mcp_resource intentionally missing
+          auth: {
+            method: 'oauth',
+            client_id: 'x',
+            access_token_ref: makeRef(SECRET_SERVICE, 'siteA/access'),
+            refresh_token_ref: makeRef(SECRET_SERVICE, 'siteA/refresh'),
+          },
+          auth_status: 'active',
+        },
+      },
+    };
+    const pool = new ConnectionPool(config, () => {}, {
+      secretStore: store, discover: fakeDiscover(), allowInsecure: true,
+    });
+    await assert.rejects(
+      pool._createTransport('siteA', null),
+      /no mcp_resource configured|reauth siteA/,
+    );
+  });
+
+  it('propagates CapabilityPinningError from discovery (H.2.3 fail-loud)', async () => {
+    const store = new MemorySecretStore();
+    await store.set(SECRET_SERVICE, 'siteA/access', 'AT');
+    await store.set(SECRET_SERVICE, 'siteA/refresh', 'RT');
+    const { CapabilityPinningError } = require('../lib/auth/errors');
+
+    const failingDiscover = async () => {
+      throw new CapabilityPinningError(
+        'Site previously supported OAuth but now reports no OAuth.',
+        { state: 'discovering' }
+      );
+    };
+
+    const config = {
+      defaultSite: 'siteA',
+      sites: {
+        siteA: {
+          url: 'https://example.com',
+          mcp_resource: 'https://example.com/wp-json/mcp/mcp-adapter-default-server',
+          auth: {
+            method: 'oauth',
+            client_id: 'x',
+            access_token_ref: makeRef(SECRET_SERVICE, 'siteA/access'),
+            refresh_token_ref: makeRef(SECRET_SERVICE, 'siteA/refresh'),
+          },
+          auth_status: 'active',
+          oauth_capability_pinned: {
+            first_seen_at: '2026-01-15T10:00:00Z',
+            last_confirmed_at: '2026-04-01T10:00:00Z',
+          },
+        },
+      },
+    };
+    const pool = new ConnectionPool(config, () => {}, {
+      secretStore: store, discover: failingDiscover, allowInsecure: true,
+    });
+    await assert.rejects(
+      pool._createTransport('siteA', null),
+      (err) => err instanceof CapabilityPinningError,
+    );
+  });
+});
+
+describe('ConnectionPool — _findExistingHttpTransport handles both transport variants', () => {
+  it('dedupes OAuth sites by mcp_resource', async () => {
+    const config = {
+      defaultSite: 'siteA',
+      sites: {
+        siteA: {
+          url: 'https://example.com',
+          mcp_resource: 'https://example.com/wp-json/mcp/mcp-adapter-default-server',
+          auth: { method: 'oauth', client_id: 'x',
+            access_token_ref: 'keychain://abilities-mcp/siteA/access',
+            refresh_token_ref: 'keychain://abilities-mcp/siteA/refresh' },
+          auth_status: 'active',
+        },
+      },
+    };
+    const pool = new ConnectionPool(config, () => {});
+    pool.transports.set('siteA', { endpoint: 'https://example.com/wp-json/mcp/mcp-adapter-default-server' });
+    const found = pool._findExistingHttpTransport('siteA');
+    assert.ok(found, 'expected to find existing transport for OAuth site');
+    assert.equal(found.key, 'siteA');
+  });
+
+  it('returns null for non-HTTP / non-OAuth sites with no endpoint', async () => {
+    const config = {
+      defaultSite: 'ssh1',
+      sites: {
+        ssh1: {
+          url: 'ssh://x', transport: 'ssh', ssh: { host: 'x', path: '/' },
+          auth: { method: 'apppassword', username: 'u', password_ref: 'keychain://abilities-mcp/ssh1/apppassword' },
+          auth_status: 'active',
+        },
+      },
+    };
+    const pool = new ConnectionPool(config, () => {});
+    const found = pool._findExistingHttpTransport('ssh1');
+    assert.equal(found, null);
+  });
+});

--- a/test/transports/helpers/mock-mcp-resource.js
+++ b/test/transports/helpers/mock-mcp-resource.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const http = require('node:http');
+const { URL } = require('node:url');
+
+/**
+ * Tiny MCP-resource-shaped HTTP server for transport tests.
+ *
+ * Validates an `Authorization: Bearer …` header against `acceptedTokens`
+ * (a Set). Anything not in the set yields 401 with WWW-Authenticate.
+ *
+ * Behavior is deterministic and easy to manipulate from tests:
+ *   server.acceptedTokens = new Set(['AT-NEW']);   // rotate accepted set
+ *   server.config.statusOverride = 503;           // force 5xx
+ *   server.config.statusForCount = 2;             // first N requests → override
+ *   server.history                                // [{ headers, body, ... }]
+ *
+ * Defaults: returns a JSON-RPC echo-style response { jsonrpc, id, result: { ok: true } }.
+ *
+ * Copyright (C) 2026 Influencentricity | Wicked Evolutions
+ * @license GPL-2.0-or-later
+ */
+class MockMcpResource {
+  constructor(opts = {}) {
+    this.acceptedTokens = new Set(opts.acceptedTokens || ['AT-VALID']);
+    this.config = {
+      statusOverride: null,
+      statusForCount: 0,
+      successBodyFor: null,    // (req, body) => string
+      ...opts.config,
+    };
+    this.history = [];
+    this._server = null;
+    this._port = null;
+  }
+
+  async start() {
+    return new Promise((resolve, reject) => {
+      const server = http.createServer((req, res) => this._onRequest(req, res));
+      server.on('error', reject);
+      server.listen({ host: '127.0.0.1', port: 0 }, () => {
+        this._server = server;
+        this._port = server.address().port;
+        resolve(this);
+      });
+    });
+  }
+
+  async stop() {
+    if (!this._server) return;
+    await new Promise((resolve) => this._server.close(() => resolve()));
+    this._server = null;
+  }
+
+  get origin() { return `http://127.0.0.1:${this._port}`; }
+  get endpoint() { return `${this.origin}/wp-json/mcp/mcp-adapter-default-server`; }
+
+  _onRequest(req, res) {
+    const chunks = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => {
+      const body = Buffer.concat(chunks).toString('utf8');
+      const auth = req.headers['authorization'] || '';
+      const bearer = auth.startsWith('Bearer ') ? auth.slice(7) : null;
+      this.history.push({
+        method: req.method,
+        url: req.url,
+        headers: { ...req.headers },
+        bearer,
+        body,
+      });
+
+      if (this.config.statusOverride && this.config.statusForCount > 0) {
+        this.config.statusForCount--;
+        res.statusCode = this.config.statusOverride;
+        res.setHeader('Content-Type', 'application/json');
+        res.end('');
+        return;
+      }
+
+      if (!bearer || !this.acceptedTokens.has(bearer)) {
+        res.statusCode = 401;
+        res.setHeader('WWW-Authenticate', 'Bearer error="invalid_token"');
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ error: 'invalid_token' }));
+        return;
+      }
+
+      let parsed = null;
+      try { parsed = JSON.parse(body); } catch { /* non-JSON */ }
+      const id = parsed && parsed.id;
+      const responseBody = this.config.successBodyFor
+        ? this.config.successBodyFor(req, body)
+        : JSON.stringify({ jsonrpc: '2.0', id: id !== undefined ? id : null, result: { ok: true } });
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(responseBody);
+    });
+  }
+}
+
+module.exports = { MockMcpResource };

--- a/test/transports/oauth-http-transport.test.js
+++ b/test/transports/oauth-http-transport.test.js
@@ -1,0 +1,285 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { OAuthHttpTransport } = require('../../lib/transports/oauth-http-transport');
+const { TokenManager, SECRET_SERVICE, REFRESH_WINDOW_SECONDS } = require('../../lib/auth/token-manager');
+const { MemorySecretStore } = require('../../lib/auth/memory-secret-store');
+const { makeRef } = require('../../lib/auth/secret-store');
+const { AUTH_STATUS } = require('../../lib/auth/events');
+const { MockAuthServer } = require('../auth/helpers/mock-auth-server');
+const { MockMcpResource } = require('./helpers/mock-mcp-resource');
+
+/**
+ * OAuthHttpTransport — runtime bearer + refresh on 401 (Issue #17).
+ *
+ * Coverage:
+ *   1. Bearer header construction with the resolved access token
+ *   2. Pre-expiry refresh (300s window per H.2.1) fires before the request
+ *   3. 401 → forceRefresh → retry succeeds with new token
+ *   4. 401 → forceRefresh → retry still 401 → typed error, auth_status=expired,
+ *      no third attempt
+ *   5. 5xx retry on transport-level errors does not double-mint tokens
+ */
+
+function buildSiteAuth(server, overrides = {}) {
+  return {
+    siteId: 'siteA',
+    tokenEndpoint: `${server.origin}/oauth/token`,
+    clientId: 'client-x',
+    accessTokenRef: makeRef(SECRET_SERVICE, 'siteA/access'),
+    refreshTokenRef: makeRef(SECRET_SERVICE, 'siteA/refresh'),
+    accessTokenExpiresAt: new Date(Date.now() + 3600 * 1000).toISOString(),
+    refreshTokenExpiresAt: new Date(Date.now() + 90 * 24 * 3600 * 1000).toISOString(),
+    authStatus: AUTH_STATUS.ACTIVE,
+    ...overrides,
+  };
+}
+
+async function buildStack({ accessToken = 'AT-OK', acceptTokens, expiresInSec = 3600 } = {}) {
+  const server = await new MockAuthServer().start();
+  const resource = await new MockMcpResource({
+    acceptedTokens: acceptTokens || [accessToken],
+  }).start();
+  const store = new MemorySecretStore();
+  await store.set(SECRET_SERVICE, 'siteA/access', accessToken);
+  await store.set(SECRET_SERVICE, 'siteA/refresh', 'RT-OK');
+
+  const tm = new TokenManager({
+    secretStore: store, allowInsecure: true,
+    deps: { sleep: () => Promise.resolve() },
+  });
+
+  const siteAuth = buildSiteAuth(server, {
+    accessTokenExpiresAt: new Date(Date.now() + expiresInSec * 1000).toISOString(),
+  });
+
+  return { server, resource, store, tm, siteAuth };
+}
+
+function send(transport, line) {
+  return new Promise((resolve) => {
+    transport.onMessage = (parsedMsg, rawLine) => resolve({ parsedMsg, rawLine });
+    transport.send(line);
+  });
+}
+
+describe('OAuthHttpTransport — bearer header construction', () => {
+  it('attaches Authorization: Bearer <token> built from TokenManager', async () => {
+    const { server, resource, tm, siteAuth } = await buildStack({ accessToken: 'AT-CACHED' });
+    try {
+      const t = new OAuthHttpTransport({
+        endpoint: resource.endpoint, tokenManager: tm, siteAuth, logger: () => {},
+      });
+      await t.connect();
+      const req = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+      const result = await send(t, req);
+      assert.equal(result.parsedMsg && result.parsedMsg.result && result.parsedMsg.result.ok, true);
+
+      const seen = resource.history[0];
+      assert.equal(seen.bearer, 'AT-CACHED');
+      assert.equal(seen.headers['authorization'], 'Bearer AT-CACHED');
+      // The original request body is what we POSTed.
+      assert.match(seen.body, /"method":"tools\/list"/);
+      await t.shutdown();
+    } finally {
+      await server.stop(); await resource.stop();
+    }
+  });
+});
+
+describe('OAuthHttpTransport — pre-expiry refresh (H.2.1, 300s window)', () => {
+  it('refreshes when access_token_expires_at is inside the 300s window, then uses the new token', async () => {
+    // Seed the resource to accept ONLY the freshly-minted token. The cached
+    // 'AT-OLD' must not work — proving the transport refreshed.
+    const server = await new MockAuthServer().start();
+    server.config.tokenJson = {
+      access_token: 'AT-NEW-ROTATED',
+      refresh_token: 'RT-NEW-ROTATED',
+      token_type: 'Bearer',
+      expires_in: 3600,
+    };
+    const resource = await new MockMcpResource({ acceptedTokens: ['AT-NEW-ROTATED'] }).start();
+    const store = new MemorySecretStore();
+    await store.set(SECRET_SERVICE, 'siteA/access', 'AT-OLD');
+    await store.set(SECRET_SERVICE, 'siteA/refresh', 'RT-OLD');
+    const tm = new TokenManager({
+      secretStore: store, allowInsecure: true,
+      deps: { sleep: () => Promise.resolve() },
+    });
+    const siteAuth = buildSiteAuth(server, {
+      // Inside the 300s window — TokenManager will refresh on getAccessToken.
+      accessTokenExpiresAt: new Date(Date.now() + (REFRESH_WINDOW_SECONDS - 60) * 1000).toISOString(),
+    });
+
+    try {
+      const t = new OAuthHttpTransport({
+        endpoint: resource.endpoint, tokenManager: tm, siteAuth, logger: () => {},
+      });
+      await t.connect();
+      const req = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping' });
+      const result = await send(t, req);
+      assert.ok(result.parsedMsg.result, 'expected success');
+      // The bearer the resource saw must be the newly-rotated one.
+      const seen = resource.history[0];
+      assert.equal(seen.bearer, 'AT-NEW-ROTATED');
+      // Token endpoint was hit exactly once by the pre-expiry refresh.
+      assert.equal(server._refreshAttempts, 1);
+      await t.shutdown();
+    } finally {
+      await server.stop(); await resource.stop();
+    }
+  });
+});
+
+describe('OAuthHttpTransport — 401 → forceRefresh → retry-once', () => {
+  it('on 401 from resource, force-refreshes once and retries with the new token', async () => {
+    const server = await new MockAuthServer().start();
+    server.config.tokenJson = {
+      access_token: 'AT-AFTER-REFRESH',
+      refresh_token: 'RT-AFTER-REFRESH',
+      token_type: 'Bearer',
+      expires_in: 3600,
+    };
+    // Resource accepts only the post-refresh token.
+    const resource = await new MockMcpResource({ acceptedTokens: ['AT-AFTER-REFRESH'] }).start();
+    const store = new MemorySecretStore();
+    await store.set(SECRET_SERVICE, 'siteA/access', 'AT-STALE');
+    await store.set(SECRET_SERVICE, 'siteA/refresh', 'RT-STALE');
+    const tm = new TokenManager({
+      secretStore: store, allowInsecure: true,
+      deps: { sleep: () => Promise.resolve() },
+    });
+    // Comfortably outside the refresh window — only the 401 should trigger refresh.
+    const siteAuth = buildSiteAuth(server);
+
+    try {
+      const t = new OAuthHttpTransport({
+        endpoint: resource.endpoint, tokenManager: tm, siteAuth, logger: () => {},
+      });
+      await t.connect();
+      const req = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: {} });
+      const result = await send(t, req);
+      assert.equal(result.parsedMsg && result.parsedMsg.result && result.parsedMsg.result.ok, true);
+
+      // The resource saw at least two requests: stale → 401, then fresh → 200.
+      const bearersSeen = resource.history.map((h) => h.bearer);
+      assert.deepEqual(
+        bearersSeen.slice(0, 2),
+        ['AT-STALE', 'AT-AFTER-REFRESH'],
+        `expected stale-then-fresh bearer sequence, got ${JSON.stringify(bearersSeen)}`
+      );
+      // Exactly one refresh was performed — not two.
+      assert.equal(server._refreshAttempts, 1);
+      await t.shutdown();
+    } finally {
+      await server.stop(); await resource.stop();
+    }
+  });
+});
+
+describe('OAuthHttpTransport — terminal 401 after refresh', () => {
+  it('second 401 with a freshly-minted token surfaces typed error, sets auth_status=expired, no third attempt', async () => {
+    const server = await new MockAuthServer().start();
+    server.config.tokenJson = {
+      access_token: 'AT-DOA',           // dead-on-arrival; resource will reject
+      refresh_token: 'RT-NEW',
+      token_type: 'Bearer',
+      expires_in: 3600,
+    };
+    const resource = await new MockMcpResource({ acceptedTokens: ['AT-NEVER-VALID'] }).start();
+    const store = new MemorySecretStore();
+    await store.set(SECRET_SERVICE, 'siteA/access', 'AT-STALE');
+    await store.set(SECRET_SERVICE, 'siteA/refresh', 'RT');
+    const tm = new TokenManager({
+      secretStore: store, allowInsecure: true,
+      deps: { sleep: () => Promise.resolve() },
+    });
+    const siteAuth = buildSiteAuth(server);
+
+    let observedStatusChange = null;
+    const t = new OAuthHttpTransport({
+      endpoint: resource.endpoint, tokenManager: tm, siteAuth, logger: () => {},
+      onAuthStatusChange: (newStatus, info) => {
+        observedStatusChange = { newStatus, info };
+      },
+    });
+    try {
+      await t.connect();
+      const req = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/call' });
+      const result = await send(t, req);
+
+      // The transport surfaces a structured error to the caller.
+      assert.ok(result.parsedMsg && result.parsedMsg.error, 'expected error on terminal 401');
+      assert.match(
+        String(result.parsedMsg.error.message || ''),
+        /OAuth bearer rejected|reauth siteA/,
+        `error must mention reauth: ${JSON.stringify(result.parsedMsg.error)}`,
+      );
+
+      // Resource was hit exactly twice (initial + retry-after-refresh). NO third.
+      assert.equal(resource.history.length, 2, 'expected exactly two attempts at the resource');
+      // Token endpoint was hit exactly once (the forced refresh).
+      assert.equal(server._refreshAttempts, 1);
+      // auth_status_change was emitted with 'expired'.
+      assert.ok(observedStatusChange, 'expected onAuthStatusChange callback to fire');
+      assert.equal(observedStatusChange.newStatus, 'expired');
+      assert.equal(observedStatusChange.info.siteId, 'siteA');
+    } finally {
+      await t.shutdown(); await server.stop(); await resource.stop();
+    }
+  });
+
+  it('a refresh that 4xxs surfaces error and emits onAuthStatusChange(expired)', async () => {
+    const server = await new MockAuthServer({
+      refresh4xx: { error: 'invalid_grant' },
+    }).start();
+    const resource = await new MockMcpResource({ acceptedTokens: ['AT-NOT-USED'] }).start();
+    const store = new MemorySecretStore();
+    await store.set(SECRET_SERVICE, 'siteA/access', 'AT');
+    await store.set(SECRET_SERVICE, 'siteA/refresh', 'RT');
+    const tm = new TokenManager({
+      secretStore: store, allowInsecure: true,
+      deps: { sleep: () => Promise.resolve() },
+    });
+    // Force the refresh-window path so getAccessToken hits the token endpoint.
+    const siteAuth = buildSiteAuth(server, {
+      accessTokenExpiresAt: new Date(Date.now() - 1000).toISOString(),
+    });
+
+    let observed = null;
+    const t = new OAuthHttpTransport({
+      endpoint: resource.endpoint, tokenManager: tm, siteAuth, logger: () => {},
+      onAuthStatusChange: (newStatus, info) => { observed = { newStatus, info }; },
+    });
+    try {
+      await t.connect();
+      const req = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/call' });
+      const result = await send(t, req);
+      assert.ok(result.parsedMsg && result.parsedMsg.error);
+      assert.match(String(result.parsedMsg.error.message), /OAuth refresh failed|reauth/);
+      assert.ok(observed);
+      assert.equal(observed.newStatus, 'expired');
+    } finally {
+      await t.shutdown(); await server.stop(); await resource.stop();
+    }
+  });
+});
+
+describe('OAuthHttpTransport — surface compatibility with HttpTransport', () => {
+  it('exposes endpoint, isReady, onMessage, send, connect, shutdown', () => {
+    const t = new OAuthHttpTransport({
+      endpoint: 'http://127.0.0.1:1/mcp',
+      tokenManager: { getAccessToken: () => Promise.resolve({ accessToken: 'X', refreshed: false }) },
+      siteAuth: { siteId: 'x' },
+    });
+    assert.equal(typeof t.connect, 'function');
+    assert.equal(typeof t.send, 'function');
+    assert.equal(typeof t.isReady, 'function');
+    assert.equal(typeof t.performHandshake, 'function');
+    assert.equal(typeof t.shutdown, 'function');
+    assert.equal(t.endpoint, 'http://127.0.0.1:1/mcp');
+    assert.equal(t.isReady(), false);
+  });
+});


### PR DESCRIPTION
Closes #17.

## Summary

The runtime MCP transport — the code path AI clients hit when they connect to the bridge as their MCP server — did not use OAuth tokens. It still built `Authorization: Basic …` from `siteConfig.http.password` and ignored every OAuth field Phases 4 and 5 introduced. The full Phase 6 matrix is paused until this is merged and reinstalled.

## Architecture decision: Option B

Per Issue #17, two layers were considered:

- **A** — extend `HttpTransport` with a `mode` flag.
- **B** — new `OAuthHttpTransport` sibling class (default recommendation).

Picked B. `HttpTransport` is 558 lines and already encodes substantial logic for queue coalescing, batching, session tokens, cookie jar, session recovery on 404/410, and healthcheck. Mixing OAuth's bearer-and-refresh semantics into the same `_post` / `_postWithRetry` would force conditional branches across multiple methods — bloating one class with two distinct auth concerns. The 401 path in particular has different meaning under Basic (stale session) vs Bearer (token rotation).

To keep the hotfix tight, `OAuthHttpTransport` re-implements the queue + batch + healthcheck internals rather than extracting a shared `BaseHttpTransport`. The duplication is intentional — extracting a base class mid-hotfix would touch the App-Password runtime path and risk a regression. A future refactor can pull `BaseHttpTransport` once both classes have stabilised in production.

`HttpTransport` is **completely unchanged**. App-Password operators see no diff in behaviour.

## ConnectionPool dispatch

Per the contract in Issue #17, the dispatch is exactly one branch:

```js
// lib/connection-pool.js _createTransport
if (siteConfig.auth && siteConfig.auth.method === 'oauth') {
  return this._createOAuthHttpTransport(compositeKey, siteConfig);
}
// existing v1 SSH / HTTP paths unchanged
```

## TokenManager integration (H.2.1)

- Before each POST, `tokenManager.getAccessToken(siteAuth)` returns a usable bearer. If `access_token_expires_at` is within 300 s, it refreshes first.
- On 401 from the resource: `getAccessToken({ forceRefresh: true })` exactly once, then retry. A second 401 with the freshly-minted token sets `auth_status: 'expired'`, surfaces a typed error that names `reauth` as the operator action, and stops — no third attempt.

## apppassword_fallback runtime semantics

Documented in `OAuthHttpTransport` source. **OAuth always wins when `auth.method === 'oauth'`.** The presence of `apppassword_fallback` in the OAuth site block does NOT enable a runtime "if OAuth fails, try Basic" branch. The fallback is exercised by the operator-driven `upgrade-auth` workflow only (per Appendix F.5 step sequence). At runtime the only fallback gate is the discovery layer, where a 404 from `.well-known` on a previously-OAuth-pinned site fails loud per H.2.3 — and that gate lives in `discovery-client`, not in this transport.

## Capability pinning runtime stance (H.2.3)

The pin lives on `siteConfig.oauth_capability_pinned` and is written by the OAuth flow during `add-site` / `reauth`. The transport itself **never probes `.well-known/*`** at runtime, so a 404 here would not be a discovery 404 — it would be a missing MCP-session signal, which the existing session-recovery path handles. The pool passes `pinned` and `pinnedFirstSeenAt` to `discover()` once at transport creation; if discovery throws `CapabilityPinningError` (pinned site, all probes 404'd), it propagates and the bridge fails loud rather than silently downgrading. There is no second runtime path that could quietly fall back.

## Schema gating change

`lib/config.js validateSiteConfig` previously required `site.transport`. v2 OAuth sites carry no `transport` block — only `url`, `auth.method = 'oauth'`, the keychain refs, and `mcp_resource`. Without teaching the runtime loader to accept this shape, the bridge could not boot at all on a config containing an OAuth site. The new branch validates `mcp_resource` is present and HTTPS (or `allowInsecure`).

## Persistence on terminal auth failure

When the transport detects a terminal auth failure (refresh 4xx, or 401 after force-refresh), it fires an `onAuthStatusChange('expired', { reason, siteId })` callback. The pool wires this to an atomic rewrite of `wp-sites.json` so the next CLI invocation sees `auth_status: 'expired'` without operator edits. Persistence is best-effort — a write failure is logged but does not break the request path.

## Tests

189 → 206 passing on the hotfix branch (+17). New coverage:

**OAuthHttpTransport**
- Bearer header constructed from the resolved access token
- Pre-expiry refresh fires when within 300 s and the next request uses the new token
- 401 from resource → `forceRefresh` → retry succeeds with new token
- Two consecutive 401s (terminal) → typed error, `auth_status` set to `expired`, exactly two attempts at the resource and one at the token endpoint
- Refresh that 4xxs → error surfaced, `auth_status` updated
- Surface compatibility (endpoint / isReady / send / connect / shutdown / performHandshake / onMessage)

**ConnectionPool dispatch**
- OAuth sites get `OAuthHttpTransport`
- App-Password sites still get `HttpTransport` (no regression)
- SSH carrier-only sites still get `SshTransport` (no regression)
- Missing `mcp_resource` raises a clear error pointing at `reauth`
- `CapabilityPinningError` propagates from discovery (H.2.3 fail-loud)
- `_findExistingHttpTransport` dedupes OAuth sites by `mcp_resource`

**Config loader**
- v2 OAuth site with `mcp_resource` is accepted
- v2 OAuth site without `mcp_resource` is rejected
- v2 OAuth site with HTTP `mcp_resource` and no `allowInsecure` is rejected
- v1 App-Password site still loads (no regression)

CI matrix `[18, 20, 22]` should remain green — all new code uses Node-18-stable APIs (no `Array.prototype.with`, no top-level await, no v22-only features).

## Out of scope (separate issues, per #17)

- `family_id` rotation (adapter side)
- Revocation cascade across rotation chain (adapter side)
- Phase 5 'Authenticated as' label cosmetics
- Adapter issues #39 and #40 (`ExecuteAbilityAbility`, `prompts/get` bypasses)
- OAuth boundary events `EVENT_SEVERITY` allowlist gap (abilities-for-ai)

## Test plan

- [ ] CI green on Node 18 / 20 / 22
- [ ] Reinstall bridge from `main` after merge (`npm link`)
- [ ] Phase 6 matrix item 13: AI client → bridge → adapter call uses `Authorization: Bearer <oauth_token>` (verifiable via adapter access-token `last_used_at`)
- [ ] Phase 6 long-session refresh: set `expires_in: 60` in adapter, observe pre-expiry refresh + new access-token row server-side
- [ ] Phase 6 401 path: revoke the token mid-session adapter-side; bridge surfaces `reauth siteX` in error and writes `auth_status: 'expired'` to `wp-sites.json`
- [ ] App-Password operator regression check (one site on `apppassword`, confirm tools/list still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)