### PR TITLE
fix: remove dead refresh-intent keychain code (H-7)

### DIFF
--- a/lib/auth/token-manager.js
+++ b/lib/auth/token-manager.js
@@ -131,7 +131,14 @@ class TokenManager {
   // ---------------------------------------------------------------------
 
   /**
-   * Refresh the access token. Handles H.2.1 retry semantics.
+   * Refresh the access token.
+   *
+   * Retry semantics now live entirely on the server (adapter v1.4.2 ships
+   * encrypt-at-rest grace-window retry per Wicked-Evolutions/abilities-mcp-adapter#61).
+   * A retry within 30 seconds of a successful rotation returns the original
+   * plaintext pair from a server-stored encrypted blob — the bridge does not
+   * need a mid-flight crash-recovery marker. We just retry on transport
+   * failures and 5xx; the server is idempotent within the grace window.
    *
    * @param {SiteAuthState} siteAuth
    * @returns {Promise<{tokens: TokenSet, updatedAuth: SiteAuthState}>}
@@ -158,17 +165,6 @@ class TokenManager {
     }
     const refreshToken = await resolveRef(this._store, siteAuth.refreshTokenRef);
 
-    // Persist intent-to-refresh BEFORE sending — see H.2.1 paragraph
-    // "Persist intent-to-refresh to keychain BEFORE sending the request".
-    // We mark the in-flight state as a small marker entry; the actual
-    // refresh-token value is unchanged in keychain so a crash leaves the
-    // old token recoverable.
-    const intentAccount = `${siteAuth.siteId}/refresh-intent`;
-    await this._store.set(SECRET_SERVICE, intentAccount, JSON.stringify({
-      startedAt: new Date(this._now()).toISOString(),
-      tokenEndpoint: siteAuth.tokenEndpoint,
-    }));
-
     let res;
     let attempt = 0;
     let lastNetworkError = null;
@@ -188,7 +184,6 @@ class TokenManager {
           await this._sleep(this._backoffMs(attempt));
           continue;
         }
-        await this._store.delete(SECRET_SERVICE, intentAccount).catch(() => {});
         throw new RefreshError(
           `Refresh failed after ${MAX_RETRIES + 1} network-error attempts: ${err.message}`,
           { code: 'network_error', state: 'refreshing', cause: err }
@@ -201,7 +196,6 @@ class TokenManager {
           await this._sleep(this._backoffMs(attempt));
           continue;
         }
-        await this._store.delete(SECRET_SERVICE, intentAccount).catch(() => {});
         throw new RefreshError(
           `Refresh failed after ${MAX_RETRIES + 1} attempts (last status ${res.statusCode})`,
           { code: 'server_error', state: 'refreshing', cause: { statusCode: res.statusCode, body: res.body } }
@@ -209,7 +203,6 @@ class TokenManager {
       }
       // 4xx → never retry.
       if (res.statusCode >= 400 && res.statusCode <= 499) {
-        await this._store.delete(SECRET_SERVICE, intentAccount).catch(() => {});
         const oauthError = res.json && res.json.error ? res.json.error : 'invalid_grant';
         const description = res.json && res.json.error_description;
         // Mark the site as expired so the caller can route the operator to reauth.
@@ -232,14 +225,13 @@ class TokenManager {
     }
 
     if (!res.json || typeof res.json.access_token !== 'string') {
-      await this._store.delete(SECRET_SERVICE, intentAccount).catch(() => {});
       throw new RefreshError('Token endpoint returned 2xx without access_token', {
         code: 'malformed_response', state: 'refreshing',
         cause: { body: res.body },
       });
     }
 
-    // Success — persist new tokens, then clear the intent marker.
+    // Success — persist new tokens.
     const tokens = res.json;
     const accessAccount = parseRef(siteAuth.accessTokenRef).account;
     await this._store.set(SECRET_SERVICE, accessAccount, tokens.access_token);
@@ -251,8 +243,6 @@ class TokenManager {
       await this._store.set(SECRET_SERVICE, refreshAccount, tokens.refresh_token);
       refreshTokenRef = makeRef(SECRET_SERVICE, refreshAccount);
     }
-
-    await this._store.delete(SECRET_SERVICE, intentAccount).catch(() => {});
 
     const expiresInSec = typeof tokens.expires_in === 'number' ? tokens.expires_in : null;
     const updatedAuth = {

--- a/test/auth/token-manager.test.js
+++ b/test/auth/token-manager.test.js
@@ -58,7 +58,7 @@ describe('TokenManager.getAccessToken — refresh window (H.2.1 + Token-refresh)
   });
 });
 
-describe('TokenManager.refresh — H.2.1 retry semantics', () => {
+describe('TokenManager.refresh — retry semantics', () => {
   it('retries up to 2 times on 5xx with the same refresh token', async () => {
     const server = await new MockAuthServer({ refreshFailures: 2 }).start();
     try {
@@ -74,8 +74,6 @@ describe('TokenManager.refresh — H.2.1 retry semantics', () => {
       assert.equal(updatedAuth.authStatus, 'active');
       // Server saw 3 attempts (2 failures + 1 success).
       assert.equal(server._refreshAttempts, 3);
-      // Intent marker is cleaned up.
-      assert.equal(await store.get(SECRET_SERVICE, 'siteA/refresh-intent'), null);
     } finally { await server.stop(); }
   });
 
@@ -121,10 +119,14 @@ describe('TokenManager.refresh — H.2.1 retry semantics', () => {
     } finally { await server.stop(); }
   });
 
-  it('persists intent-to-refresh BEFORE sending request (H.2.1)', async () => {
+  it('does not write a refresh-intent keychain marker (H-7)', async () => {
+    // The dead refresh-intent code (a marker written before sending and deleted
+    // on every exit path) was removed in PR #20 — server-side encrypt-at-rest
+    // grace-window retry (adapter PR #61, v1.4.2) now handles in-flight
+    // recovery. Verify no `${siteId}/refresh-intent` entry is ever written
+    // during a successful refresh.
     let intentSeenDuringRequest = null;
     const fakePostForm = async () => {
-      // Capture store contents at the moment the request is in flight.
       intentSeenDuringRequest = await store.get(SECRET_SERVICE, 'siteA/refresh-intent');
       return { statusCode: 200, headers: {}, body: '', json: {
         access_token: 'AT-new', refresh_token: 'RT-new', expires_in: 3600,
@@ -138,9 +140,8 @@ describe('TokenManager.refresh — H.2.1 retry semantics', () => {
       deps: { postForm: fakePostForm, sleep: () => Promise.resolve() },
     });
     await tm.refresh(buildSiteAuth());
-    assert.ok(intentSeenDuringRequest, 'intent must be persisted before request');
-    // After success, intent is cleared.
-    assert.equal(await store.get(SECRET_SERVICE, 'siteA/refresh-intent'), null);
+    assert.equal(intentSeenDuringRequest, null, 'no refresh-intent marker during request');
+    assert.equal(await store.get(SECRET_SERVICE, 'siteA/refresh-intent'), null, 'no refresh-intent marker after success');
   });
 
   it('refuses to refresh when authStatus is already expired', async () => {


### PR DESCRIPTION
## Why this is dead code

\`token-manager.js\` wrote a \`\${siteId}/refresh-intent\` keychain entry before each refresh request and deleted it on every exit path (network-error exhausted, 5xx exhausted, 4xx, malformed response, success). The marker was meant to signal mid-flight crash recovery per Appendix H.2.1: "on crash, the old token is still in keychain; bridge retries with it on next start."

The recovery logic was never implemented. Searching the repo for \`refresh-intent\` references outside this file and its test returns nothing — no reader, no startup recovery code, no operator surface.

## Why removing it is now safe

Adapter v1.4.2 ([Wicked-Evolutions/abilities-mcp-adapter#61](https://github.com/Wicked-Evolutions/abilities-mcp-adapter/pull/61), C-2) ships **encrypt-at-rest grace-window retry on the server**. A retry within 30 seconds of a successful rotation returns the original plaintext pair from a server-stored AES-256-GCM blob, keyed off the old refresh token plaintext. The bridge no longer needs a mid-flight intent marker — the server recovers idempotently.

The marker is now pure dead weight: a keychain write per refresh, paying serialization + IPC cost for no behavioral effect.

## Changes

Pure deletion:

| File | What changed |
|---|---|
| [lib/auth/token-manager.js](lib/auth/token-manager.js) | Drop the intent-write block in \`refresh()\`. Drop all five \`_store.delete(SECRET_SERVICE, intentAccount)\` cleanup calls. Update \`refresh()\` docblock — retry semantics now live on the server. |
| [test/auth/token-manager.test.js](test/auth/token-manager.test.js) | Drop the standalone "persists intent BEFORE sending" test, replaced by a regression guard asserting **no** marker is ever written. Drop the trailing intent-cleanup assertion in the 5xx retry test. Rename the \`H.2.1 retry semantics\` describe block (no longer accurate). |

No new code added.

## Tests

\`npm test\` — 206/206 green locally on Node 20. CI will validate the 18/20/22 matrix.

The new H-7 regression guard asserts:
- \`store.get(SECRET_SERVICE, 'siteA/refresh-intent')\` is null **during** the in-flight request (no write happened).
- It's still null **after** a successful refresh.

## Deviations

None. Pure deletion as specified in the issue.

Closes #19