### PR TITLE
fix: validate v2 apppassword sites + resolve password from keychain (#26)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -217,6 +217,37 @@ function validateSiteConfig(key, site) {
     return;
   }
 
+  // v2 App-Password sites — produced by config-migration from v1 transport-style
+  // configs. Secret lives in keychain (auth.password_ref); the legacy http.password*
+  // fields are stripped during migration so the keychain is the sole source of
+  // truth. Carrier transport (http or ssh) is preserved for the runtime.
+  if (site.auth && site.auth.method === 'apppassword') {
+    if (!site.auth.username) {
+      throw new Error(`Site "${key}" (apppassword): requires auth.username`);
+    }
+    if (!site.auth.password_ref) {
+      throw new Error(`Site "${key}" (apppassword): requires auth.password_ref`);
+    }
+    if (!site.transport) {
+      throw new Error(`Site "${key}" (apppassword): missing "transport" (ssh or http)`);
+    }
+    if (site.transport === 'ssh') {
+      if (!site.ssh || !site.ssh.host || !site.ssh.path) {
+        throw new Error(`Site "${key}" (apppassword/ssh): requires ssh.host and ssh.path`);
+      }
+    } else if (site.transport === 'http') {
+      if (!site.http || !site.http.endpoint) {
+        throw new Error(`Site "${key}" (apppassword/http): requires http.endpoint`);
+      }
+      if (!site.http.endpoint.startsWith('https://') && !site.allowInsecure) {
+        throw new Error(`Site "${key}" (apppassword/http): endpoint is not HTTPS. Set "allowInsecure": true on the site to allow HTTP`);
+      }
+    } else {
+      throw new Error(`Site "${key}" (apppassword): unknown transport "${site.transport}" (use ssh or http)`);
+    }
+    return;
+  }
+
   if (!site.transport) {
     throw new Error(`Site "${key}": missing "transport" (ssh or http)`);
   }
@@ -335,10 +366,43 @@ function resolvePassword(httpConfig) {
   throw new Error('No password, passwordEnv, or passwordCommand configured');
 }
 
+/**
+ * Resolve a site's HTTP password, dispatching on schema shape.
+ *
+ * v2 App-Password sites (auth.method === 'apppassword' + auth.password_ref)
+ * read the secret from the keychain via the SecretStore. v1 carriers without
+ * a ref fall back to the synchronous `resolvePassword(http)` resolver.
+ *
+ * @param {object} site
+ * @param {object} [secretStore]  SecretStore instance. Lazily defaults to
+ *                                KeychainSecretStore when an apppassword path
+ *                                runs and no store was supplied — preserves
+ *                                the "no keytar for SSH-only / v1-only setups"
+ *                                property by deferring the require to the
+ *                                point of need.
+ * @returns {Promise<string>}
+ */
+async function resolveSitePassword(site, secretStore) {
+  if (site && site.auth && site.auth.method === 'apppassword' && site.auth.password_ref) {
+    let store = secretStore;
+    if (!store) {
+      const { KeychainSecretStore } = require('./auth/keychain-secret-store');
+      store = new KeychainSecretStore();
+    }
+    const { resolveRef } = require('./auth/secret-store');
+    return resolveRef(store, site.auth.password_ref);
+  }
+  if (site && site.http) {
+    return resolvePassword(site.http);
+  }
+  throw new Error('No password source configured for site');
+}
+
 module.exports = {
   loadConfig,
   resolveConfigFilePath,
   resolvePassword,
+  resolveSitePassword,
   resolveSiteKey,
   buildSiteKeyEnum,
   buildEnvConfig,

--- a/lib/connection-pool.js
+++ b/lib/connection-pool.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { SshTransport } = require('./transports/ssh-transport');
-const { resolveSiteKey, resolvePassword } = require('./config');
+const { resolveSiteKey, resolveSitePassword } = require('./config');
 
 // Incrementing counter for synthetic handshake IDs.
 // Avoids integer overflow from Date.now() (13-digit ms timestamps exceed
@@ -309,13 +309,25 @@ class ConnectionPool {
     }
 
     if (siteConfig.transport === 'http') {
-      // HTTP transport — loaded lazily to avoid requiring it when only SSH is used
+      // HTTP transport — loaded lazily to avoid requiring it when only SSH is used.
+      // v2 apppassword sites resolve the secret from keychain via auth.password_ref;
+      // v1 sites fall through to the legacy synchronous resolver. KeychainSecretStore
+      // is only constructed when an apppassword path actually runs, preserving the
+      // "no keytar for SSH-only / v1-only setups" property.
       const { HttpTransport } = require('./transports/http-transport');
-      const password = resolvePassword(siteConfig.http);
+      const isV2AppPassword = siteConfig.auth
+        && siteConfig.auth.method === 'apppassword'
+        && siteConfig.auth.password_ref;
+      if (isV2AppPassword && !this._secretStore) {
+        const { KeychainSecretStore } = require('./auth/keychain-secret-store');
+        this._secretStore = new KeychainSecretStore();
+      }
+      const password = await resolveSitePassword(siteConfig, this._secretStore);
+      const username = (siteConfig.auth && siteConfig.auth.username) || siteConfig.http.username;
       return new HttpTransport({
         endpoint: resolvedEndpoint || siteConfig.http.endpoint,
-        username: siteConfig.http.username,
-        password: password,
+        username,
+        password,
         logger: this.log,
       });
     }

--- a/test/config-v2-apppassword.test.js
+++ b/test/config-v2-apppassword.test.js
@@ -1,0 +1,241 @@
+'use strict';
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { loadConfig, resolveSitePassword } = require('../lib/config');
+const { MemorySecretStore } = require('../lib/auth/memory-secret-store');
+const { makeRef } = require('../lib/auth/secret-store');
+const { SECRET_SERVICE } = require('../lib/auth/token-manager');
+
+/**
+ * Issue #26 — post-migration v2 apppassword sites must validate successfully
+ * and the runtime resolver must read the secret from keychain via
+ * auth.password_ref. The migration strips legacy http.password* fields per
+ * F.5, so any validator path that still requires one of them is a regression.
+ */
+
+const tmpFiles = [];
+after(() => {
+  for (const f of tmpFiles) {
+    try { fs.unlinkSync(f); } catch { /* ignore */ }
+  }
+});
+
+function writeTempConfig(contents) {
+  const file = path.join(
+    os.tmpdir(),
+    `wp-sites.test.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.json`
+  );
+  fs.writeFileSync(file, JSON.stringify(contents, null, 2), { mode: 0o600 });
+  tmpFiles.push(file);
+  return file;
+}
+
+describe('loadConfig — v2 apppassword site acceptance (Issue #26)', () => {
+  it('accepts an apppassword/http site with auth.password_ref and no legacy http.password', () => {
+    const file = writeTempConfig({
+      schema_version: 2,
+      defaultSite: 'wicked',
+      sites: {
+        wicked: {
+          url: 'https://wickedevolutions.com',
+          transport: 'http',
+          http: {
+            endpoint: 'https://wickedevolutions.com/wp-json/mcp/mcp-adapter-default-server',
+            username: 'wicked_user',
+            password_ref: makeRef(SECRET_SERVICE, 'wicked/apppassword'),
+          },
+          auth: {
+            method: 'apppassword',
+            username: 'wicked_user',
+            password_ref: makeRef(SECRET_SERVICE, 'wicked/apppassword'),
+          },
+          auth_status: 'active',
+        },
+      },
+    });
+    const cfg = loadConfig({ config: file });
+    assert.equal(cfg.sites.wicked.auth.method, 'apppassword');
+  });
+
+  it('accepts an apppassword/ssh carrier site (no http block)', () => {
+    const file = writeTempConfig({
+      schema_version: 2,
+      defaultSite: 'sshc',
+      sites: {
+        sshc: {
+          url: 'ssh://shared.example',
+          transport: 'ssh',
+          ssh: { host: 'shared.example', path: '/var/www/wp', user: 'deploy' },
+          auth: {
+            method: 'apppassword',
+            username: 'deploy',
+            password_ref: makeRef(SECRET_SERVICE, 'sshc/apppassword'),
+          },
+          auth_status: 'active',
+        },
+      },
+    });
+    const cfg = loadConfig({ config: file });
+    assert.equal(cfg.sites.sshc.transport, 'ssh');
+  });
+
+  it('rejects an apppassword site missing auth.username', () => {
+    const file = writeTempConfig({
+      schema_version: 2,
+      defaultSite: 'x',
+      sites: {
+        x: {
+          url: 'https://x.example',
+          transport: 'http',
+          http: { endpoint: 'https://x.example/wp-json/mcp/mcp-adapter-default-server', username: 'u' },
+          auth: { method: 'apppassword', password_ref: makeRef(SECRET_SERVICE, 'x/apppassword') },
+        },
+      },
+    });
+    assert.throws(() => loadConfig({ config: file }), /auth\.username/);
+  });
+
+  it('rejects an apppassword site missing auth.password_ref', () => {
+    const file = writeTempConfig({
+      schema_version: 2,
+      defaultSite: 'x',
+      sites: {
+        x: {
+          url: 'https://x.example',
+          transport: 'http',
+          http: { endpoint: 'https://x.example/wp-json/mcp/mcp-adapter-default-server', username: 'u' },
+          auth: { method: 'apppassword', username: 'u' },
+        },
+      },
+    });
+    assert.throws(() => loadConfig({ config: file }), /password_ref/);
+  });
+
+  it('rejects an apppassword/http site missing http.endpoint', () => {
+    const file = writeTempConfig({
+      schema_version: 2,
+      defaultSite: 'x',
+      sites: {
+        x: {
+          url: 'https://x.example',
+          transport: 'http',
+          http: { username: 'u' },
+          auth: {
+            method: 'apppassword',
+            username: 'u',
+            password_ref: makeRef(SECRET_SERVICE, 'x/apppassword'),
+          },
+        },
+      },
+    });
+    assert.throws(() => loadConfig({ config: file }), /http\.endpoint/);
+  });
+
+  it('rejects an apppassword/ssh site missing ssh.host or ssh.path', () => {
+    const file = writeTempConfig({
+      schema_version: 2,
+      defaultSite: 'x',
+      sites: {
+        x: {
+          url: 'ssh://x',
+          transport: 'ssh',
+          ssh: { host: 'x' },
+          auth: {
+            method: 'apppassword',
+            username: 'u',
+            password_ref: makeRef(SECRET_SERVICE, 'x/apppassword'),
+          },
+        },
+      },
+    });
+    assert.throws(() => loadConfig({ config: file }), /ssh\.host and ssh\.path/);
+  });
+
+  it('rejects an apppassword/http site whose endpoint is HTTP without allowInsecure', () => {
+    const file = writeTempConfig({
+      schema_version: 2,
+      defaultSite: 'x',
+      sites: {
+        x: {
+          url: 'http://x.example',
+          transport: 'http',
+          http: { endpoint: 'http://x.example/wp-json/mcp/mcp-adapter-default-server', username: 'u' },
+          auth: {
+            method: 'apppassword',
+            username: 'u',
+            password_ref: makeRef(SECRET_SERVICE, 'x/apppassword'),
+          },
+        },
+      },
+    });
+    assert.throws(() => loadConfig({ config: file }), /not HTTPS/);
+  });
+
+  it('still accepts a legacy v1 apppassword shape (no auth block) — no regression', () => {
+    const file = writeTempConfig({
+      defaultSite: 'legacy',
+      sites: {
+        legacy: {
+          url: 'https://legacy.example',
+          transport: 'http',
+          http: {
+            endpoint: 'https://legacy.example/wp-json/mcp/mcp-adapter-default-server',
+            username: 'u',
+            password: 'pw',
+          },
+        },
+      },
+    });
+    const cfg = loadConfig({ config: file });
+    assert.equal(cfg.sites.legacy.http.password, 'pw');
+  });
+});
+
+describe('resolveSitePassword (Issue #26)', () => {
+  it('reads the secret from the SecretStore for v2 apppassword sites', async () => {
+    const store = new MemorySecretStore();
+    await store.set(SECRET_SERVICE, 'siteA/apppassword', 'topsecret');
+    const site = {
+      transport: 'http',
+      http: { endpoint: 'https://x', username: 'u' },
+      auth: {
+        method: 'apppassword',
+        username: 'u',
+        password_ref: makeRef(SECRET_SERVICE, 'siteA/apppassword'),
+      },
+    };
+    const pw = await resolveSitePassword(site, store);
+    assert.equal(pw, 'topsecret');
+  });
+
+  it('falls back to the legacy http.password resolver for v1 sites with no auth block', async () => {
+    const site = {
+      transport: 'http',
+      http: { endpoint: 'https://x', username: 'u', password: 'plain' },
+    };
+    const pw = await resolveSitePassword(site, null);
+    assert.equal(pw, 'plain');
+  });
+
+  it('throws a clear error when the keychain reference is missing in the store', async () => {
+    const store = new MemorySecretStore();
+    const site = {
+      transport: 'http',
+      http: { endpoint: 'https://x', username: 'u' },
+      auth: {
+        method: 'apppassword',
+        username: 'u',
+        password_ref: makeRef(SECRET_SERVICE, 'missing/apppassword'),
+      },
+    };
+    await assert.rejects(
+      resolveSitePassword(site, store),
+      /Keychain reference not found/,
+    );
+  });
+});

--- a/test/connection-pool.test.js
+++ b/test/connection-pool.test.js
@@ -72,6 +72,12 @@ describe('ConnectionPool dispatch — auth.method === "oauth"', () => {
   });
 
   it('routes App-Password sites to legacy HttpTransport unchanged (no regression)', async () => {
+    // Post-migration v2 apppassword shape: legacy http.password* fields stripped,
+    // secret in keychain via auth.password_ref. Pool resolves it via the injected
+    // SecretStore.
+    const store = new MemorySecretStore();
+    await store.set(SECRET_SERVICE, 'siteB/apppassword', 'pw');
+
     const config = {
       defaultSite: 'siteB',
       sites: {
@@ -81,7 +87,7 @@ describe('ConnectionPool dispatch — auth.method === "oauth"', () => {
           http: {
             endpoint: 'https://siteB.com/wp-json/mcp/mcp-adapter-default-server',
             username: 'wp_user',
-            password: 'pw',
+            password_ref: makeRef(SECRET_SERVICE, 'siteB/apppassword'),
           },
           auth: {
             method: 'apppassword',
@@ -93,12 +99,37 @@ describe('ConnectionPool dispatch — auth.method === "oauth"', () => {
       },
     };
 
-    const pool = new ConnectionPool(config, () => {});
+    const pool = new ConnectionPool(config, () => {}, { secretStore: store });
     const transport = await pool._createTransport('siteB', null);
     assert.ok(transport instanceof HttpTransport,
       `expected HttpTransport, got ${transport && transport.constructor && transport.constructor.name}`);
     assert.ok(!(transport instanceof OAuthHttpTransport));
     assert.equal(transport.endpoint, 'https://siteB.com/wp-json/mcp/mcp-adapter-default-server');
+    assert.equal(transport.username, 'wp_user');
+    assert.equal(transport.password, 'pw');
+  });
+
+  it('routes legacy v1 HTTP sites (no auth block) to HttpTransport via sync resolver', async () => {
+    // No SecretStore should be needed — falls through to resolvePassword(http).
+    const config = {
+      defaultSite: 'siteV1',
+      sites: {
+        siteV1: {
+          url: 'https://v1.example.com',
+          transport: 'http',
+          http: {
+            endpoint: 'https://v1.example.com/wp-json/mcp/mcp-adapter-default-server',
+            username: 'v1_user',
+            password: 'v1_pw',
+          },
+        },
+      },
+    };
+    const pool = new ConnectionPool(config, () => {});
+    const transport = await pool._createTransport('siteV1', null);
+    assert.ok(transport instanceof HttpTransport);
+    assert.equal(transport.username, 'v1_user');
+    assert.equal(transport.password, 'v1_pw');
   });
 
   it('routes SSH carrier-only sites to SshTransport unchanged', async () => {
@@ -231,5 +262,143 @@ describe('ConnectionPool — _findExistingHttpTransport handles both transport v
     const pool = new ConnectionPool(config, () => {});
     const found = pool._findExistingHttpTransport('ssh1');
     assert.equal(found, null);
+  });
+});
+
+/**
+ * Issue #26 acceptance — post-migration multi-site v2 config routes every site to
+ * the correct transport. Mirrors the operator-side Phase B reproduction: a v1
+ * config with multiple http sites + an ssh site is migrated to v2 (legacy
+ * http.password* fields stripped, secrets lifted to keychain), and the bridge
+ * must boot and route each site without falling through to the legacy http
+ * validator's "requires one of http.password..." check.
+ */
+describe('ConnectionPool — multi-site v2 acceptance (Issue #26)', () => {
+  it('routes 1 oauth + 2 apppassword (http) + 1 ssh-carrier site to the correct transports', async () => {
+    const store = new MemorySecretStore();
+    await store.set(SECRET_SERVICE, 'helena/access', 'AT');
+    await store.set(SECRET_SERVICE, 'helena/refresh', 'RT');
+    await store.set(SECRET_SERVICE, 'wicked/apppassword', 'wicked-pw');
+    await store.set(SECRET_SERVICE, 'tnn/apppassword', 'tnn-pw');
+    await store.set(SECRET_SERVICE, 'sshcarrier/apppassword', '');
+
+    const tm = new TokenManager({ secretStore: store, allowInsecure: true });
+
+    const config = {
+      schema_version: 2,
+      defaultSite: 'helena',
+      sites: {
+        helena: {
+          url: 'https://helenawillow.com',
+          mcp_resource: 'https://helenawillow.com/wp-json/mcp/mcp-adapter-default-server',
+          auth: {
+            method: 'oauth',
+            client_id: 'client-h',
+            access_token_ref: makeRef(SECRET_SERVICE, 'helena/access'),
+            refresh_token_ref: makeRef(SECRET_SERVICE, 'helena/refresh'),
+            access_token_expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+            refresh_token_expires_at: new Date(Date.now() + 90 * 24 * 3600 * 1000).toISOString(),
+          },
+          auth_status: 'active',
+        },
+        wicked: {
+          url: 'https://wickedevolutions.com',
+          transport: 'http',
+          http: {
+            endpoint: 'https://wickedevolutions.com/wp-json/mcp/mcp-adapter-default-server',
+            username: 'wicked_user',
+            password_ref: makeRef(SECRET_SERVICE, 'wicked/apppassword'),
+          },
+          auth: {
+            method: 'apppassword',
+            username: 'wicked_user',
+            password_ref: makeRef(SECRET_SERVICE, 'wicked/apppassword'),
+          },
+          auth_status: 'active',
+        },
+        tnn: {
+          url: 'https://thinknicenow.com',
+          transport: 'http',
+          http: {
+            endpoint: 'https://thinknicenow.com/wp-json/mcp/mcp-adapter-default-server',
+            username: 'tnn_user',
+            password_ref: makeRef(SECRET_SERVICE, 'tnn/apppassword'),
+          },
+          auth: {
+            method: 'apppassword',
+            username: 'tnn_user',
+            password_ref: makeRef(SECRET_SERVICE, 'tnn/apppassword'),
+          },
+          auth_status: 'active',
+        },
+        sshcarrier: {
+          url: 'ssh://shared.example',
+          transport: 'ssh',
+          ssh: { host: 'shared.example', path: '/var/www/wp', user: 'deploy' },
+          auth: {
+            method: 'apppassword',
+            username: 'deploy',
+            password_ref: makeRef(SECRET_SERVICE, 'sshcarrier/apppassword'),
+          },
+          auth_status: 'active',
+        },
+      },
+    };
+
+    const pool = new ConnectionPool(config, () => {}, {
+      secretStore: store,
+      tokenManager: tm,
+      discover: fakeDiscover(),
+      allowInsecure: true,
+    });
+
+    const helenaT = await pool._createTransport('helena', null);
+    assert.ok(helenaT instanceof OAuthHttpTransport, 'helena should route to OAuthHttpTransport');
+    assert.equal(helenaT.endpoint, 'https://helenawillow.com/wp-json/mcp/mcp-adapter-default-server');
+
+    const wickedT = await pool._createTransport('wicked', null);
+    assert.ok(wickedT instanceof HttpTransport, 'wicked should route to HttpTransport');
+    assert.ok(!(wickedT instanceof OAuthHttpTransport));
+    assert.equal(wickedT.username, 'wicked_user');
+    assert.equal(wickedT.password, 'wicked-pw');
+
+    const tnnT = await pool._createTransport('tnn', null);
+    assert.ok(tnnT instanceof HttpTransport, 'tnn should route to HttpTransport');
+    assert.equal(tnnT.username, 'tnn_user');
+    assert.equal(tnnT.password, 'tnn-pw');
+
+    const sshT = await pool._createTransport('sshcarrier', null);
+    assert.ok(sshT instanceof SshTransport, 'sshcarrier should route to SshTransport');
+  });
+
+  it('rejects v2 apppassword http sites that lost auth.password_ref during a hand-edit', async () => {
+    // Defensive — operator-edited configs should fail validation rather than
+    // crash deeper in the resolver.
+    const { loadConfig } = require('../lib/config');
+    const fs = require('node:fs');
+    const os = require('node:os');
+    const path = require('node:path');
+    const file = path.join(os.tmpdir(), `wp-sites.test.${process.pid}.${Date.now()}.json`);
+    fs.writeFileSync(file, JSON.stringify({
+      schema_version: 2,
+      defaultSite: 'broken',
+      sites: {
+        broken: {
+          url: 'https://broken.example',
+          transport: 'http',
+          http: {
+            endpoint: 'https://broken.example/wp-json/mcp/mcp-adapter-default-server',
+            username: 'u',
+          },
+          auth: { method: 'apppassword', username: 'u' },
+          auth_status: 'active',
+        },
+      },
+    }), { mode: 0o600 });
+    try {
+      assert.throws(() => loadConfig({ config: file }), /password_ref/);
+    } finally {
+      try { fs.unlinkSync(file); } catch { /* ignore */ }
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Closes #26 — post-migration validation rejected v2 apppassword sites because `validateSiteConfig()` had no `auth.method === 'apppassword'` branch and `resolvePassword()` did not read `auth.password_ref`. After PR #25 wired `migrateFile()` into boot, multi-site v1 configs migrated to v2 (legacy `http.password*` stripped per F.5) but the bridge then failed validation with `requires one of http.password, http.passwordEnv, or http.passwordCommand`.
- Adds a parallel apppassword validator branch (mirrors the OAuth branch's shape) plus a new async `resolveSitePassword(site, secretStore)` helper that reads keychain via `auth.password_ref` and falls back to the synchronous v1 resolver for legacy carriers.
- `ConnectionPool._createTransport` http branch now awaits the new resolver and prefers `auth.username` over `http.username`. `KeychainSecretStore` is required lazily so SSH-only / v1-only setups still don't load keytar.

## Test plan

- [x] `npm test` — 228/228 green (was 214 baseline; +14 new tests).
- [x] Validator branch: 1 accept (apppassword/http with `password_ref`, no legacy `http.password`), 1 accept (apppassword/ssh carrier), 6 reject cases (missing `auth.username`, missing `auth.password_ref`, missing `http.endpoint`, missing `ssh.host+path`, plain HTTP without `allowInsecure`, hand-edited config that lost `password_ref`).
- [x] `resolveSitePassword`: reads from `MemorySecretStore` via `password_ref`; falls back to legacy `resolvePassword(http)`; throws clear error when keychain ref is absent.
- [x] Multi-site acceptance test (1 oauth + 2 apppassword/http + 1 ssh-carrier) — every site routes to the correct transport.
- [x] No-regression: existing "App-Password sites routes to legacy HttpTransport" test now seeds the SecretStore (documents the wiring); existing legacy v1 site (no `auth` block) still routes to `HttpTransport` via the synchronous resolver path with no `SecretStore` constructed.
- [x] End-to-end smoke (offline): v1 multi-site config (2 http + 1 ssh) → `migrateFile` → `loadConfig` → `resolveSitePassword` for each http site against the seeded `MemorySecretStore` returns the expected secret. The reproduction in the issue body no longer occurs.

## Deviations

- **`http.username` source of truth.** Issue body says "Pass `siteConfig.auth.username` when present." I prefer `auth.username` over `http.username` (`auth.username || http.username`). Both are populated to the same value by `_convertSite` in `config-migration.js`, but the spec (F.5) treats `auth.username` as the v2 source of truth, so the resolver follows it.
- **Lazy `KeychainSecretStore` construction.** `resolveSitePassword` requires `KeychainSecretStore` only when an apppassword path actually runs and the caller did not pass a store. The pool also gates lazy construction on the v2 apppassword shape so SSH-only / v1-only setups still avoid loading keytar. Issue body did not prescribe this; chosen to preserve the property already established for the OAuth path in `_createOAuthHttpTransport`.
- **Defensive operator-edited-config test** added (rejects v2 apppassword/http with no `password_ref`). Not in the issue body but covers the validator's reject branches the same way the OAuth tests do.
- **Sprint plan mismatch (informational).** Issue #26 is in milestone `v1.5.1 — Stretch to Stable` and was queued by the orchestrator as PR-1, but it is not listed in §1 of the locked sprint plan (which lists bridge #23, #24, #5). Treating the milestone label and dispatch as authoritative; sub-issue scope reconciliation is the orchestrator's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)