### PR TITLE
refactor: async config loading in lib/config.js (#5)

### DIFF
--- a/abilities-mcp.js
+++ b/abilities-mcp.js
@@ -71,7 +71,8 @@ if (isSubcommandInvocation) {
 // ---------------------------------------------------------------------------
 // MCP server mode — the original CLI argument parsing (no subcommand).
 // Skipped when a subcommand was dispatched above; otherwise we'd race the
-// IIFE's process.exit() against the synchronous loadConfig() / connectDefault().
+// IIFE's process.exit() against the bootstrap that awaits loadConfig() and
+// connectDefault().
 // ---------------------------------------------------------------------------
 
 if (!isSubcommandInvocation) {
@@ -116,7 +117,7 @@ if (!isSubcommandInvocation) {
   // no on-disk wp-sites.json; `resolveConfigFilePath` returns null and we
   // skip migration entirely.
   (async function bootstrap() {
-    const filePath = resolveConfigFilePath(args);
+    const filePath = await resolveConfigFilePath(args);
     if (filePath) {
       try {
         const result = await migrateFile({
@@ -134,7 +135,7 @@ if (!isSubcommandInvocation) {
 
     let config;
     try {
-      config = loadConfig(args);
+      config = await loadConfig(args);
     } catch (err) {
       process.stderr.write(`abilities-mcp: ${err.message}\n`);
       process.exit(1);

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,9 +1,13 @@
 'use strict';
 
-const { execSync } = require('child_process');
+const { exec } = require('child_process');
+const { promisify } = require('util');
 const fs = require('fs');
+const fsp = require('fs').promises;
 const path = require('path');
 const os = require('os');
+
+const execAsync = promisify(exec);
 
 /**
  * Load configuration from wp-sites.json, environment variables, or CLI args.
@@ -15,9 +19,28 @@ const os = require('os');
  *   4. ABILITIES_MCP_URL/USERNAME/PASSWORD env vars (single-site, .mcpb path)
  *   5. --host/--path CLI args (legacy SSH single-site)
  *
+ * Per Issue #5 / Phase E.2 (Stretch to Stable sprint): the startup chain
+ * — `resolveConfigFilePath`, `loadConfig`, `loadConfigFile`,
+ * `validateSiteConfig`, `resolvePassword` — is async so file reads and
+ * `passwordCommand` shell-outs do not block the event loop during boot.
+ *
  * Copyright (C) 2026 Influencentricity | Wicked Evolutions
  * @license GPL-2.0-or-later
  */
+
+/**
+ * Async non-throwing existence check. Returns true iff the path resolves
+ * via fs.access(); any error (ENOENT, EACCES, …) yields false. Used by the
+ * search-order helpers which only care whether a candidate file is readable.
+ */
+async function _exists(p) {
+  try {
+    await fsp.access(p, fs.constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Resolve the on-disk wp-sites.json path that `loadConfig` would consume,
@@ -31,25 +54,25 @@ const os = require('os');
  * CLI) intentionally return `null` — there is no on-disk file to migrate.
  *
  * @param {object} args
- * @returns {string|null}  Absolute path of the resolved wp-sites.json, or null.
+ * @returns {Promise<string|null>}  Absolute path of the resolved wp-sites.json, or null.
  */
-function resolveConfigFilePath(args) {
+async function resolveConfigFilePath(args) {
   if (args && args.config) {
     return path.resolve(args.config);
   }
   const scriptDir = path.resolve(__dirname, '..');
   const scriptConfig = path.join(scriptDir, 'wp-sites.json');
-  if (fs.existsSync(scriptConfig)) {
+  if (await _exists(scriptConfig)) {
     return scriptConfig;
   }
   const homeConfig = path.join(os.homedir(), '.abilities-mcp', 'wp-sites.json');
-  if (fs.existsSync(homeConfig)) {
+  if (await _exists(homeConfig)) {
     return homeConfig;
   }
   return null;
 }
 
-function loadConfig(args) {
+async function loadConfig(args) {
   // Explicit config path
   if (args.config) {
     return loadConfigFile(args.config);
@@ -58,13 +81,13 @@ function loadConfig(args) {
   // Check alongside script (lib/ → package root)
   const scriptDir = path.resolve(__dirname, '..');
   const scriptConfig = path.join(scriptDir, 'wp-sites.json');
-  if (fs.existsSync(scriptConfig)) {
+  if (await _exists(scriptConfig)) {
     return loadConfigFile(scriptConfig);
   }
 
   // Check home directory
   const homeConfig = path.join(os.homedir(), '.abilities-mcp', 'wp-sites.json');
-  if (fs.existsSync(homeConfig)) {
+  if (await _exists(homeConfig)) {
     return loadConfigFile(homeConfig);
   }
 
@@ -157,12 +180,12 @@ function buildEnvConfig(env) {
   };
 }
 
-function loadConfigFile(filePath) {
-  const raw = fs.readFileSync(filePath, 'utf8');
+async function loadConfigFile(filePath) {
+  const raw = await fsp.readFile(filePath, 'utf8');
 
   // Warn if config file is readable by group or world
   try {
-    const stat = fs.statSync(filePath);
+    const stat = await fsp.stat(filePath);
     if (stat.mode & 0o077) {
       process.stderr.write(
         `WARNING: ${filePath} is readable by group/world (mode ${(stat.mode & 0o777).toString(8)}). ` +
@@ -187,7 +210,7 @@ function loadConfigFile(filePath) {
 
   // Validate each site
   for (const [key, site] of Object.entries(config.sites)) {
-    validateSiteConfig(key, site);
+    await validateSiteConfig(key, site);
   }
 
   config._isMultiSite = Object.keys(config.sites).length > 1 ||
@@ -197,7 +220,7 @@ function loadConfigFile(filePath) {
   return config;
 }
 
-function validateSiteConfig(key, site) {
+async function validateSiteConfig(key, site) {
   // v2 OAuth sites carry no transport block (Appendix F.5 + add-site flow).
   // The runtime treats them as HTTP — endpoint comes from auth.mcp_resource
   // or site.mcp_resource (resolved by the OAuth-aware transport).
@@ -296,6 +319,7 @@ function buildLegacyConfig(args) {
 
 /**
  * Resolve a composite site key like "wicked.community" into config + subsite URL.
+ * Pure in-memory dispatch — kept synchronous since it has no I/O.
  */
 function resolveSiteKey(config, compositeKey) {
   // Direct match — "helena" or "wicked"
@@ -348,17 +372,23 @@ function buildSiteKeyEnum(config) {
 }
 
 /**
- * Resolve the password for an HTTP transport config, supporting
- * plaintext password, environment variable, or shell command.
+ * Resolve the password for an HTTP transport config, supporting plaintext
+ * password, environment variable, or shell command.
+ *
+ * `passwordCommand` is dispatched through `util.promisify(exec)` so the shell
+ * interprets the command string the same way the previous `execSync` did
+ * (operators rely on pipes, redirects, and command chaining — e.g.
+ * `op read 'op://Vault/foo' | tr -d '\n'` — which `execFile` cannot run).
  */
-function resolvePassword(httpConfig) {
+async function resolvePassword(httpConfig) {
   if (httpConfig.passwordEnv) {
     const val = process.env[httpConfig.passwordEnv];
     if (!val) throw new Error(`Environment variable ${httpConfig.passwordEnv} is not set`);
     return val;
   }
   if (httpConfig.passwordCommand) {
-    return execSync(httpConfig.passwordCommand, { encoding: 'utf8' }).trim();
+    const { stdout } = await execAsync(httpConfig.passwordCommand, { encoding: 'utf8' });
+    return stdout.trim();
   }
   if (httpConfig.password) {
     return httpConfig.password;
@@ -371,7 +401,7 @@ function resolvePassword(httpConfig) {
  *
  * v2 App-Password sites (auth.method === 'apppassword' + auth.password_ref)
  * read the secret from the keychain via the SecretStore. v1 carriers without
- * a ref fall back to the synchronous `resolvePassword(http)` resolver.
+ * a ref fall back to the `resolvePassword(http)` resolver.
  *
  * @param {object} site
  * @param {object} [secretStore]  SecretStore instance. Lazily defaults to

--- a/test/config-async.test.js
+++ b/test/config-async.test.js
@@ -1,0 +1,144 @@
+'use strict';
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { loadConfig, resolvePassword, resolveConfigFilePath } = require('../lib/config');
+
+/**
+ * Issue #5 / Phase E.2 — async config loading.
+ *
+ * The boot chain (`resolveConfigFilePath`, `loadConfig`, `loadConfigFile`,
+ * `validateSiteConfig`, `resolvePassword`) is async so file reads and
+ * `passwordCommand` shell-outs do not block the event loop during startup.
+ * These tests pin the public surface of that conversion: each entry point
+ * returns a Promise, file reads use the async API, and `passwordCommand`
+ * still goes through a real shell so existing operator configs (pipes,
+ * `op read … | tr -d '\n'`, etc.) continue to work.
+ */
+
+const tmpFiles = [];
+after(() => {
+  for (const f of tmpFiles) {
+    try { fs.unlinkSync(f); } catch { /* ignore */ }
+  }
+});
+
+function writeTempConfig(contents) {
+  const file = path.join(
+    os.tmpdir(),
+    `wp-sites.test.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.json`
+  );
+  fs.writeFileSync(file, JSON.stringify(contents, null, 2), { mode: 0o600 });
+  tmpFiles.push(file);
+  return file;
+}
+
+describe('loadConfig — async surface (Issue #5)', () => {
+  it('returns a Promise', () => {
+    const file = writeTempConfig({
+      defaultSite: 'siteA',
+      sites: {
+        siteA: {
+          url: 'https://example.com',
+          transport: 'http',
+          http: {
+            endpoint: 'https://example.com/wp-json/mcp/mcp-adapter-default-server',
+            username: 'u',
+            password: 'pw',
+          },
+        },
+      },
+    });
+    const result = loadConfig({ config: file });
+    assert.ok(result && typeof result.then === 'function', 'loadConfig must return a Promise');
+    return result.then((cfg) => {
+      assert.equal(cfg.sites.siteA.http.username, 'u');
+    });
+  });
+
+  it('rejects when no configuration source is present', async () => {
+    // No --config, no env vars, no --host/--path. The candidate paths
+    // (script dir + ~/.abilities-mcp) may exist on the dev machine, so we
+    // pass an explicit non-existent --config to force the explicit-path
+    // branch and verify the error surface.
+    const missing = path.join(os.tmpdir(), `wp-sites.missing.${process.pid}.${Date.now()}.json`);
+    await assert.rejects(loadConfig({ config: missing }), /ENOENT|no such file/);
+  });
+});
+
+describe('resolveConfigFilePath — async surface (Issue #5)', () => {
+  it('resolves an explicit --config to an absolute path without touching disk', async () => {
+    const result = await resolveConfigFilePath({ config: './nowhere/wp-sites.json' });
+    assert.ok(path.isAbsolute(result), 'expected absolute path');
+    assert.ok(result.endsWith('wp-sites.json'));
+  });
+
+  it('returns null when no on-disk file applies (env-var single-site path)', async () => {
+    // Force the script-dir + home candidates to miss by pointing HOME at an
+    // empty tmp dir, then verify null is returned. Restored after.
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'home-'));
+    const origHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+    try {
+      // Also requires no script-adjacent wp-sites.json. The repo carries one
+      // for local dev, so we only assert behavior when we know neither path
+      // resolves — skip if it does.
+      const scriptConfig = path.resolve(__dirname, '..', 'wp-sites.json');
+      if (fs.existsSync(scriptConfig)) {
+        return; // skip — repo has a dev wp-sites.json that legitimately resolves
+      }
+      const result = await resolveConfigFilePath({});
+      assert.equal(result, null);
+    } finally {
+      if (origHome === undefined) delete process.env.HOME; else process.env.HOME = origHome;
+      try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+});
+
+describe('resolvePassword — async surface (Issue #5)', () => {
+  it('returns plaintext password as-is', async () => {
+    const pw = await resolvePassword({ password: 'plain' });
+    assert.equal(pw, 'plain');
+  });
+
+  it('reads password from passwordEnv', async () => {
+    const varName = `__ABILITIES_MCP_TEST_PWENV_${process.pid}`;
+    process.env[varName] = 'env-secret';
+    try {
+      const pw = await resolvePassword({ passwordEnv: varName });
+      assert.equal(pw, 'env-secret');
+    } finally {
+      delete process.env[varName];
+    }
+  });
+
+  it('throws when passwordEnv is unset', async () => {
+    const varName = `__ABILITIES_MCP_TEST_MISSING_${process.pid}`;
+    delete process.env[varName];
+    await assert.rejects(
+      resolvePassword({ passwordEnv: varName }),
+      /not set/,
+    );
+  });
+
+  it('runs passwordCommand through a real shell (preserves pipe/redirect semantics)', async () => {
+    // The conversion from execSync → util.promisify(exec) keeps shell
+    // dispatch — operators rely on pipes and shell builtins in
+    // `passwordCommand`. This test would fail if we'd switched to
+    // execFile, which spawns the binary directly with no shell.
+    const pw = await resolvePassword({ passwordCommand: "printf 'piped\\n' | tr -d '\\n'" });
+    assert.equal(pw, 'piped');
+  });
+
+  it('throws when no source is configured', async () => {
+    await assert.rejects(
+      resolvePassword({}),
+      /No password, passwordEnv, or passwordCommand configured/,
+    );
+  });
+});

--- a/test/config-v2-apppassword.test.js
+++ b/test/config-v2-apppassword.test.js
@@ -36,7 +36,7 @@ function writeTempConfig(contents) {
 }
 
 describe('loadConfig — v2 apppassword site acceptance (Issue #26)', () => {
-  it('accepts an apppassword/http site with auth.password_ref and no legacy http.password', () => {
+  it('accepts an apppassword/http site with auth.password_ref and no legacy http.password', async () => {
     const file = writeTempConfig({
       schema_version: 2,
       defaultSite: 'wicked',
@@ -58,11 +58,11 @@ describe('loadConfig — v2 apppassword site acceptance (Issue #26)', () => {
         },
       },
     });
-    const cfg = loadConfig({ config: file });
+    const cfg = await loadConfig({ config: file });
     assert.equal(cfg.sites.wicked.auth.method, 'apppassword');
   });
 
-  it('accepts an apppassword/ssh carrier site (no http block)', () => {
+  it('accepts an apppassword/ssh carrier site (no http block)', async () => {
     const file = writeTempConfig({
       schema_version: 2,
       defaultSite: 'sshc',
@@ -80,11 +80,11 @@ describe('loadConfig — v2 apppassword site acceptance (Issue #26)', () => {
         },
       },
     });
-    const cfg = loadConfig({ config: file });
+    const cfg = await loadConfig({ config: file });
     assert.equal(cfg.sites.sshc.transport, 'ssh');
   });
 
-  it('rejects an apppassword site missing auth.username', () => {
+  it('rejects an apppassword site missing auth.username', async () => {
     const file = writeTempConfig({
       schema_version: 2,
       defaultSite: 'x',
@@ -97,10 +97,10 @@ describe('loadConfig — v2 apppassword site acceptance (Issue #26)', () => {
         },
       },
     });
-    assert.throws(() => loadConfig({ config: file }), /auth\.username/);
+    await assert.rejects(loadConfig({ config: file }), /auth\.username/);
   });
 
-  it('rejects an apppassword site missing auth.password_ref', () => {
+  it('rejects an apppassword site missing auth.password_ref', async () => {
     const file = writeTempConfig({
       schema_version: 2,
       defaultSite: 'x',
@@ -113,10 +113,10 @@ describe('loadConfig — v2 apppassword site acceptance (Issue #26)', () => {
         },
       },
     });
-    assert.throws(() => loadConfig({ config: file }), /password_ref/);
+    await assert.rejects(loadConfig({ config: file }), /password_ref/);
   });
 
-  it('rejects an apppassword/http site missing http.endpoint', () => {
+  it('rejects an apppassword/http site missing http.endpoint', async () => {
     const file = writeTempConfig({
       schema_version: 2,
       defaultSite: 'x',
@@ -133,10 +133,10 @@ describe('loadConfig — v2 apppassword site acceptance (Issue #26)', () => {
         },
       },
     });
-    assert.throws(() => loadConfig({ config: file }), /http\.endpoint/);
+    await assert.rejects(loadConfig({ config: file }), /http\.endpoint/);
   });
 
-  it('rejects an apppassword/ssh site missing ssh.host or ssh.path', () => {
+  it('rejects an apppassword/ssh site missing ssh.host or ssh.path', async () => {
     const file = writeTempConfig({
       schema_version: 2,
       defaultSite: 'x',
@@ -153,10 +153,10 @@ describe('loadConfig — v2 apppassword site acceptance (Issue #26)', () => {
         },
       },
     });
-    assert.throws(() => loadConfig({ config: file }), /ssh\.host and ssh\.path/);
+    await assert.rejects(loadConfig({ config: file }), /ssh\.host and ssh\.path/);
   });
 
-  it('rejects an apppassword/http site whose endpoint is HTTP without allowInsecure', () => {
+  it('rejects an apppassword/http site whose endpoint is HTTP without allowInsecure', async () => {
     const file = writeTempConfig({
       schema_version: 2,
       defaultSite: 'x',
@@ -173,10 +173,10 @@ describe('loadConfig — v2 apppassword site acceptance (Issue #26)', () => {
         },
       },
     });
-    assert.throws(() => loadConfig({ config: file }), /not HTTPS/);
+    await assert.rejects(loadConfig({ config: file }), /not HTTPS/);
   });
 
-  it('still accepts a legacy v1 apppassword shape (no auth block) — no regression', () => {
+  it('still accepts a legacy v1 apppassword shape (no auth block) — no regression', async () => {
     const file = writeTempConfig({
       defaultSite: 'legacy',
       sites: {
@@ -191,7 +191,7 @@ describe('loadConfig — v2 apppassword site acceptance (Issue #26)', () => {
         },
       },
     });
-    const cfg = loadConfig({ config: file });
+    const cfg = await loadConfig({ config: file });
     assert.equal(cfg.sites.legacy.http.password, 'pw');
   });
 });

--- a/test/config-v2-oauth.test.js
+++ b/test/config-v2-oauth.test.js
@@ -30,7 +30,7 @@ function writeTempConfig(contents) {
 }
 
 describe('loadConfig — v2 OAuth site acceptance (Issue #17 gating change)', () => {
-  it('accepts an OAuth site with mcp_resource and no transport block', () => {
+  it('accepts an OAuth site with mcp_resource and no transport block', async () => {
     const file = writeTempConfig({
       schema_version: 2,
       defaultSite: 'siteA',
@@ -48,12 +48,12 @@ describe('loadConfig — v2 OAuth site acceptance (Issue #17 gating change)', ()
         },
       },
     });
-    const cfg = loadConfig({ config: file });
+    const cfg = await loadConfig({ config: file });
     assert.equal(cfg.defaultSite, 'siteA');
     assert.equal(cfg.sites.siteA.auth.method, 'oauth');
   });
 
-  it('rejects an OAuth site that is missing mcp_resource', () => {
+  it('rejects an OAuth site that is missing mcp_resource', async () => {
     const file = writeTempConfig({
       schema_version: 2,
       defaultSite: 'siteA',
@@ -70,10 +70,10 @@ describe('loadConfig — v2 OAuth site acceptance (Issue #17 gating change)', ()
         },
       },
     });
-    assert.throws(() => loadConfig({ config: file }), /mcp_resource/);
+    await assert.rejects(loadConfig({ config: file }), /mcp_resource/);
   });
 
-  it('rejects an OAuth site whose mcp_resource is HTTP without allowInsecure', () => {
+  it('rejects an OAuth site whose mcp_resource is HTTP without allowInsecure', async () => {
     const file = writeTempConfig({
       schema_version: 2,
       defaultSite: 'siteA',
@@ -91,10 +91,10 @@ describe('loadConfig — v2 OAuth site acceptance (Issue #17 gating change)', ()
         },
       },
     });
-    assert.throws(() => loadConfig({ config: file }), /not HTTPS/);
+    await assert.rejects(loadConfig({ config: file }), /not HTTPS/);
   });
 
-  it('still accepts a legacy v1 App-Password site (no regression)', () => {
+  it('still accepts a legacy v1 App-Password site (no regression)', async () => {
     const file = writeTempConfig({
       defaultSite: 'siteA',
       sites: {
@@ -109,7 +109,7 @@ describe('loadConfig — v2 OAuth site acceptance (Issue #17 gating change)', ()
         },
       },
     });
-    const cfg = loadConfig({ config: file });
+    const cfg = await loadConfig({ config: file });
     assert.equal(cfg.sites.siteA.http.username, 'wp_user');
   });
 });

--- a/test/connection-pool.test.js
+++ b/test/connection-pool.test.js
@@ -396,7 +396,7 @@ describe('ConnectionPool — multi-site v2 acceptance (Issue #26)', () => {
       },
     }), { mode: 0o600 });
     try {
-      assert.throws(() => loadConfig({ config: file }), /password_ref/);
+      await assert.rejects(loadConfig({ config: file }), /password_ref/);
     } finally {
       try { fs.unlinkSync(file); } catch { /* ignore */ }
     }

--- a/test/manual/test-session.js
+++ b/test/manual/test-session.js
@@ -21,11 +21,11 @@ HttpTransport.prototype._post = function(body) {
 const { loadConfig } = require('./lib/config');
 const { ConnectionPool } = require('./lib/connection-pool');
 
-var config = loadConfig({});
 var log = function() { process.stderr.write('[pool] ' + Array.from(arguments).join(' ') + '\n'); };
-var pool = new ConnectionPool(config, log);
 
 (async function() {
+  var config = await loadConfig({});
+  var pool = new ConnectionPool(config, log);
   var transport = pool._createTransport(config.defaultSite, null);
   transport.onMessage = function(parsed, raw) {
     if (parsed && parsed.result && parsed.result.tools) {


### PR DESCRIPTION
## Summary

- Closes #5 — Phase E.2 of the Stretch to Stable sprint. Converts the bridge's startup chain from blocking sync I/O to async so file reads and the optional `passwordCommand` shell-out do not pin the event loop during boot.
- `loadConfig`, `loadConfigFile`, `validateSiteConfig`, `resolvePassword`, `resolveConfigFilePath` are now async (use `fs.promises` + `util.promisify(exec)`).
- `abilities-mcp.js` bootstrap awaits the two new async entry points. The IIFE was already async per the migration wiring landed in PR #25, so no new async scope is introduced.
- Every test call site converted to `await`; reject-path tests now use `assert.rejects`. New `test/config-async.test.js` pins the public async surface.

## Test plan

- [x] `npm test` — 237/237 green (was 228 baseline; +9 new tests).
- [x] `loadConfig` async surface: returns a Promise; rejects with a clear error when the explicit `--config` path doesn't exist.
- [x] `resolveConfigFilePath` async surface: explicit `--config` resolves without disk access; returns null when no on-disk file applies (skips on dev machines that have a script-adjacent `wp-sites.json`).
- [x] `resolvePassword` async surface: returns plaintext as-is, reads `passwordEnv`, throws when env var is unset, runs `passwordCommand` through a real shell (verified with `printf 'piped\\n' | tr -d '\\n'` — would fail under `execFile`), throws when no source configured.
- [x] All existing v2 OAuth and v2 apppassword validation tests pass after `assert.throws` → `await assert.rejects` migration.
- [x] Pool dispatch tests (PR #26 / Issue #26 acceptance) still green — `_createTransport` already awaited `resolveSitePassword`; conversion compatible.
- [x] Syntax check: `node --check abilities-mcp.js` and `node --check lib/config.js` pass.

## Deviations

- **Sync helpers kept sync.** `resolveSiteKey`, `buildSiteKeyEnum`, `buildEnvConfig`, `buildLegacyConfig` are pure in-memory dispatch with no I/O. Sprint plan §4 E.2 lists \"Convert `loadConfig()`, `validateSiteConfig()`, callers in pool to async\" — interpreted as the I/O chain plus its direct callers. Making the in-memory helpers async would touch every call site (including `connection-pool.js` which calls `resolveSiteKey` 4 times) for no runtime benefit; left them sync. `validateSiteConfig` is async per the sprint-plan letter even though it currently performs no I/O — leaves room for future async checks (e.g. probing keychain refs) without churning callers.
- **`util.promisify(exec)` over `execFile`.** Issue body says \"async `readFile` + `execFile`\" but `execFile` does not run a shell — operators rely on shell features in `passwordCommand` (pipes, redirects, `$()` substitution; e.g. `op read 'op://Vault/foo' | tr -d '\\n'`). Switching to `execFile` would silently break those configs. Kept shell dispatch via `util.promisify(exec)` to preserve `execSync`'s semantics; pinned this with a regression test.
- **Lazy `fs` retained alongside `fs.promises`.** `_exists()` uses `fs.constants.F_OK` (sync constant) with `fs.promises.access`. Imports both `fs` and `fs.promises`; the redundancy is one line and matches the rest of the codebase's idiom.
- **`test/manual/test-session.js` minimal update.** Added `await` to its `loadConfig` call so the file isn't actively regressed by the sync→async change. The pre-existing unawaited `pool._createTransport(...)` call (latent since PR #17 / PR #26 made the pool async) is left alone — adjacent defect, will file separately for the v1.5.2 milestone per workflow law (\"Adjacent defects → new issue, never bundled\").
- **No `assert.throws` → `assert.rejects` regression.** Every reject-path test was migrated; nothing left as sync `assert.throws` against an async surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)