### PR TITLE
chore: release v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to Abilities MCP are documented here.
 
+## [1.5.1] - 2026-05-02
+
+Stretch-to-stable release. Closes the OAuth 2.1 alpha audit pass and the two integration-seam regressions surfaced during Helena's Phase B operator verification, plus the async-config tech-debt sweep that shares the bridge's startup path. No new features, no surface changes — the v1.5.x line is now stable for broader operator adoption.
+
+Companion releases: [abilities-mcp-adapter v1.4.4](https://github.com/Wicked-Evolutions/abilities-mcp-adapter/releases/tag/v1.4.4) and [abilities-for-ai v1.9.1](https://github.com/Wicked-Evolutions/abilities-for-ai/releases/tag/v1.9.1) — coordinated multi-repo release per the Stretch to Stable sprint plan.
+
+### Fixed
+
+- **Schema v1→v2 auto-migration is now actually wired into boot** (PR #25, closes #23). `migrateFile()` shipped in v1.5.0 but the Phase 4/5 OAuth handoff missed the call sites — the migration code existed but never ran. Now invoked at two points before any consumer touches the config: (a) in `abilities-mcp.js` startup before the MCP server reads `wp-sites.json`, and (b) in `lib/cli/index.js`'s `runCommand()` before any subcommand parses the file. Both call sites share a single `KeychainSecretStore` instance. CLI subcommands no longer error with `v<unknown> but CLI expects v2` against legacy v1 configs; the OAuth `add-site` / `upgrade-auth` flows can reach the auth code path on a fresh install. Idempotent — second-run on an already-v2 file is a no-op.
+- **Post-migration v2 apppassword sites validate and connect** (PR #27, closes #26). Helena's Phase B run surfaced a regression: when PR #25's wired migration converted a multi-site v1 config to v2, every non-OAuth site moved to `auth.method: 'apppassword'` with `auth.password_ref`, and the legacy `http.password` / `http.passwordEnv` / `http.passwordCommand` fields were stripped per Appendix F.5 — keychain becomes the sole source of truth. The runtime side still spoke v1 only: `validateSiteConfig()` had no apppassword branch, so v2 sites fell through to the legacy http validator which rejected them with `requires one of http.password, http.passwordEnv, or http.passwordCommand`, and `ConnectionPool._createTransport` had no resolver for `auth.password_ref`. Two parallel branches added (validator + async `resolveSitePassword(site, secretStore)` helper that reads keychain via the SecretStore), pool dispatches on `auth.method === 'apppassword'`, and `KeychainSecretStore` is constructed lazily so SSH-only / v1-only setups still avoid loading keytar. Multi-site acceptance test (1 oauth + 2 apppassword + 1 ssh-carrier) pins the routing.
+
+### Changed
+
+- **Async config loading** (PR #28, closes #5). The boot chain — `resolveConfigFilePath`, `loadConfig`, `loadConfigFile`, `validateSiteConfig`, `resolvePassword` — is async. File reads use `fs.promises`; the `passwordCommand` shell-out goes through `util.promisify(exec)` rather than `execFile` so existing operator configs that rely on shell features (pipes, redirects, `$()` substitution — e.g. `op read 'op://Vault/foo' | tr -d '\n'`) keep working unchanged. `loadConfig` now returns a `Promise`; `abilities-mcp.js`'s bootstrap awaits it (the IIFE was already async per the migration wiring above). Pure-dispatch helpers (`resolveSiteKey`, `buildSiteKeyEnum`, `buildEnvConfig`, `buildLegacyConfig`) stayed synchronous — they have no I/O and converting them would touch every call site for no runtime benefit.
+
+### Internal
+
+- Test count: 237 (+27 since 1.5.0). Node CI matrix: 18, 20, 22.
+- Validator coverage extended: 8 acceptance/reject cases for v2 apppassword (http and ssh carriers, hand-edited reject paths), 9 cases for the async surface (`loadConfig` Promise return, `resolveConfigFilePath` async, `resolvePassword` env / command / shell-feature regression).
+
 ## [1.5.0] - 2026-04-28
 
 OAuth 2.1 release. The bridge is now a full OAuth client: it discovers the authorization server via RFC 9728, performs Dynamic Client Registration (RFC 7591), drives the authorization-code grant with PKCE S256 (RFC 7636) through a loopback browser flow (RFC 8252), persists tokens in the OS keychain, refreshes them automatically, and sends Bearer tokens through the runtime MCP transport.

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.3",
   "name": "abilities-mcp",
   "display_name": "WordPress (Abilities MCP)",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Connect AI clients to WordPress through the Abilities API. One-click bridge to your site's content, users, plugins, and Fluent ecosystem.",
   "long_description": "Abilities MCP is the open-source bridge that turns any WordPress site into a first-class MCP server. Install this bundle, type your site URL + WordPress username + application password, and your AI client gets typed access to content, users, media, plugins, themes, settings, FluentCRM/Forms/Community, and any other ability registered through the WordPress Abilities API.\n\nRequires the `abilities-mcp-adapter` and `abilities-for-ai` plugins on the WordPress site. The adapter exposes the MCP endpoint; this bundle is the client-side bridge running on your machine.",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wickedevolutions/abilities-mcp",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Open-source MCP bridge connecting AI clients to WordPress through the Abilities API — multi-site routing, zero dependencies",
   "main": "abilities-mcp.js",
   "bin": {


### PR DESCRIPTION
## Summary

Release-prep for v1.5.1. No code changes, no new tests — only `package.json`, `manifest.json`, and `CHANGELOG.md`.

- `package.json` version: `1.5.0` → `1.5.1`
- `manifest.json` (`.mcpb` manifest) version: `1.5.0` → `1.5.1`
- `CHANGELOG.md`: new `## [1.5.1] - 2026-05-02` section between the preamble and the existing `[1.5.0]` section

The CHANGELOG entry frames the three merged sprint PRs as what shipped + why, with closing PR # and issue # in each bullet, and a `Companion releases:` line at the top pointing at adapter v1.4.4 and ai v1.9.1.

`abilities-mcp.js` was intentionally not touched — the `@version 1.0.0` reference at the top of that file is a banner, not a runtime version (matches the precedent of the v1.5.0 bump commit `ec88d3f`, which also only modified these three files).

## Test plan

- [x] `node --check package.json` / `node --check manifest.json` (JSON parse): both valid.
- [x] CHANGELOG renders cleanly: section ordering preamble → [1.5.1] → [1.5.0] → [1.4.0] → …, no broken markdown, the `op read … | tr -d '\n'` example renders verbatim (no stray escape).
- [x] CI: 237/237 tests still green (no code changes since PR #28 — version-string changes don't affect the test surface).

## Deviations

None — three-file scope per dispatch.

## Release sequence (orchestrator-led, not in this PR)

Per sprint plan §F: orchestrator merges this → tags adapter v1.4.4 + bridge v1.5.1 → publishes adapter Release first → builds `.mcpb` (`npm run pack:mcpb`) → publishes bridge Release with `.mcpb` attached → publishes ai v1.9.1 Release → dispatches Issue #24 (`npm publish`) to dev chat. **I will not run `npm run pack:mcpb` or `npm publish` until the orchestrator signals release-time.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)