### PR TITLE
fix(.mcpbignore): exclude operator-private wp-sites backups + Claude Code worktree artifacts

### DIFF
--- a/.mcpbignore
+++ b/.mcpbignore
@@ -12,9 +12,17 @@ test/
 .nvmrc
 
 # Operator-specific configs (the bundle uses env vars from manifest user_config)
+# Patterns must catch the dot-form variants the migration helper produces:
+#   wp-sites.json.v1.bak                — created by config-migration's migrateFile()
+#   wp-sites.json.pre-helena-oauth.bak  — operator-side pre-OAuth backup
+# as well as hyphen-suffix variants like wp-sites-antigravity.json.
 wp-sites.json
+wp-sites.json.*
 wp-sites-*.json
 !wp-sites.example.json
+
+# Claude Code worktree artifacts — local agent state, not part of the bundle.
+.claude/
 
 # Docs that don't need to ship inside the bundle
 docs/


### PR DESCRIPTION
## Summary

Phase F release blocker. `npm run pack:mcpb` against v1.5.1 (commit `5394acb`) leaks four classes of operator-private files into the bundle:

- `wp-sites.json` — operator's site registry
- `wp-sites.json.pre-helena-oauth.bak` — operator-side pre-OAuth backup
- `wp-sites.json.v1.bak` — created by `config-migration`'s `migrateFile()` itself, so this re-leaks on every operator's machine that has run the migration
- `.claude/worktrees/agent-*/` — Claude Code worktree mirror dirs containing duplicate `wp-sites.example.json` and other agent state

The existing `wp-sites.json` + `wp-sites-*.json` patterns miss the dot-suffix variants because `wp-sites-*.json` catches hyphen-form (e.g. `wp-sites-antigravity.json`) but not the dot-form backups (`.bak`, `.v1.bak`, `.pre-*.bak`).

## Fix

- Add `wp-sites.json.*` alongside the existing patterns so every dot-form backup is excluded, including the migration helper's auto-generated `.v1.bak`.
- Add `.claude/` to exclude Claude Code worktree state.
- Keep the `!wp-sites.example.json` allowlist exception so the example config still ships at the repo root.

## Verification (post-fix)

Ran `npm run pack:mcpb` locally against this branch:

```
$ unzip -l abilities-mcp.mcpb | grep -E "wp-sites|\.claude"
     1436  05-02-2026 08:55   wp-sites.example.json
```

Single match — only the example config, repo-root only. No `wp-sites.json`, no `.bak` variants, no `.claude/`. Bundle stats: 50 files, 115.6 kB packed (319.9 kB unpacked); 72 ignored entries.

Sanity check on the runtime bundle (head of `unzip -l` confirms the actual ship is intact):

```
LICENSE
README.md
abilities-mcp.js
lib/auth/...   (full set)
lib/cli/...    (full set)
lib/transports/...
manifest.json
package.json
wp-sites.example.json
```

## Test plan

- [x] `npm test` not affected — no code changes; `.mcpbignore` only.
- [x] `npm run pack:mcpb` + `unzip -l | grep -E "wp-sites|\.claude"` returns only `wp-sites.example.json` (verified above).
- [x] Bundle still contains the full runtime surface (`abilities-mcp.js`, `lib/`, `manifest.json`, `package.json`, `LICENSE`, `README.md`, `wp-sites.example.json`).

## Deviations

None.

## Release-sequence note

No version bump — this lands on top of v1.5.1's CHANGELOG / `package.json` / `manifest.json` content unchanged. Per dispatch: orchestrator handles the destructive `git tag -f v1.5.1 && git push origin v1.5.1 --force` after merge to move the pushed tag to the post-fix commit; safe because no Release is published yet so no consumer points at the old SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)