### PR TITLE
fix(.mcpb): bundle keytar prebuilds for darwin/win32/linux to enable OAuth in Claude Desktop install path (#33)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ wp-sites*.json
 *.log
 .DS_Store
 *.mcpb
+dist-mcpb/

--- a/package.json
+++ b/package.json
@@ -17,12 +17,13 @@
   "scripts": {
     "test": "node --test test/*.test.js test/auth/*.test.js test/cli/*.test.js test/transports/*.test.js",
     "validate:mcpb": "npx --yes @anthropic-ai/mcpb validate manifest.json",
-    "pack:mcpb": "npx --yes @anthropic-ai/mcpb pack . abilities-mcp.mcpb"
+    "pack:mcpb": "node scripts/pack-mcpb.js",
+    "verify:pack-isolation": "node scripts/verify-pack-isolation.js"
   },
   "engines": {
     "node": ">=18.0.0"
   },
   "optionalDependencies": {
-    "keytar": "^7.9.0"
+    "keytar": "~7.9.0"
   }
 }

--- a/scripts/pack-mcpb.js
+++ b/scripts/pack-mcpb.js
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Build the .mcpb bundle with keytar prebuilds for all supported platforms.
+ *
+ * Why a staging directory: mcpb pack does not honor `!` re-includes inside an
+ * excluded parent (verified empirically against @anthropic-ai/mcpb pack —
+ * `node_modules/` excluded with `!node_modules/keytar/` ships zero keytar
+ * entries). The locked sprint plan's literal fallback was to drop the global
+ * `node_modules/` exclusion and explicit-allowlist every shipping package by
+ * name; that works but couples the .mcpbignore to keytar's transitive deps.
+ *
+ * Instead, this script builds `dist-mcpb/staging/` with only what should ship
+ * (the runtime surface plus a keytar package carrying prebuilds for every
+ * target platform), then runs mcpb pack against staging. Single source of
+ * truth for "what ships."
+ *
+ * Why a patched lib/keytar.js in staging: keytar 7.9.0's loader is
+ * `var keytar = require('../build/Release/keytar.node')` — single hardcoded
+ * slot, no platform-arch routing, no node-gyp-build. Empirically verified
+ * against an unpatched bundle: loading `node_modules/keytar` from the
+ * extracted .mcpb throws `MODULE_NOT_FOUND - Cannot find module
+ * '../build/Release/keytar.node'` even on the host platform, because the
+ * staged binaries live at `build/Release/<platform>-<arch>/keytar.node` —
+ * keytar's loader only looks at the legacy slot. The patch is mandatory
+ * for any cross-platform bundle to work at all.
+ *
+ * Safety guards (per CTO review):
+ * - Pre-patch substring assertion on the upstream `lib/keytar.js` source.
+ *   If a future keytar bump changes the loader shape, the assertion fails
+ *   loudly here instead of silently shipping a broken bundle.
+ * - keytar pinned to `~7.9.0` in package.json (patch versions only) so the
+ *   substring assertion has a stable target.
+ * - The patch is written ONLY to the staged copy. `node_modules/keytar/` in
+ *   the project tree is byte-identical pre-pack and post-pack — `scripts/
+ *   verify-pack-isolation.js` pins this property.
+ * - CLI install paths (npx, npm install -g, source clone, headless CI,
+ *   Docker) are untouched: each runs its own `npm install` which fetches
+ *   upstream keytar verbatim. The patch never reaches any non-`.mcpb`-install
+ *   path.
+ *
+ * Copyright (C) 2026 Influencentricity | Wicked Evolutions
+ * @license GPL-2.0-or-later
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const STAGING = path.join(PROJECT_ROOT, 'dist-mcpb', 'staging');
+const OUTPUT = path.join(PROJECT_ROOT, 'abilities-mcp.mcpb');
+const KEYTAR_SRC = path.join(PROJECT_ROOT, 'node_modules', 'keytar');
+const KEYTAR_DST = path.join(STAGING, 'node_modules', 'keytar');
+
+// Platforms supported by both keytar's prebuild matrix and manifest.json's
+// compatibility.platforms. arm64 Linux / Windows ARM64 / FreeBSD are out of
+// scope for v1.5.x — keytar publishes no prebuilds, manifest declares only
+// these three OS values, and the operator's compatibility expectations are
+// already aligned with this set.
+const TARGETS = [
+  { platform: 'darwin', arch: 'x64' },
+  { platform: 'darwin', arch: 'arm64' },
+  { platform: 'win32',  arch: 'x64' },
+  { platform: 'linux',  arch: 'x64' },
+];
+
+const ROOT_FILES = [
+  'abilities-mcp.js',
+  'manifest.json',
+  'package.json',
+  'LICENSE',
+  'README.md',
+  'wp-sites.example.json',
+];
+
+function copyDir(src, dst) {
+  fs.mkdirSync(dst, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const s = path.join(src, entry.name);
+    const d = path.join(dst, entry.name);
+    if (entry.isDirectory()) copyDir(s, d);
+    else fs.copyFileSync(s, d);
+  }
+}
+
+function log(msg) {
+  process.stdout.write(`[pack-mcpb] ${msg}\n`);
+}
+
+// ---------------------------------------------------------------------------
+// 1. Build clean staging dir
+// ---------------------------------------------------------------------------
+
+log('Wiping staging dir…');
+fs.rmSync(STAGING, { recursive: true, force: true });
+fs.mkdirSync(STAGING, { recursive: true });
+
+log('Copying root runtime files…');
+for (const f of ROOT_FILES) {
+  const src = path.join(PROJECT_ROOT, f);
+  const dst = path.join(STAGING, f);
+  fs.copyFileSync(src, dst);
+}
+
+log('Copying lib/ recursively…');
+copyDir(path.join(PROJECT_ROOT, 'lib'), path.join(STAGING, 'lib'));
+
+// ---------------------------------------------------------------------------
+// 2. Stage keytar package — only the files needed at runtime
+// ---------------------------------------------------------------------------
+
+log('Staging node_modules/keytar/ runtime files…');
+fs.mkdirSync(path.join(KEYTAR_DST, 'lib'), { recursive: true });
+fs.mkdirSync(path.join(KEYTAR_DST, 'build', 'Release'), { recursive: true });
+fs.copyFileSync(
+  path.join(KEYTAR_SRC, 'package.json'),
+  path.join(KEYTAR_DST, 'package.json')
+);
+
+// ---------------------------------------------------------------------------
+// 3. Fetch keytar prebuilds for every target platform/arch into the staged
+//    keytar's build/Release/<platform>-<arch>/keytar.node. prebuild-install
+//    always writes to ${KEYTAR_SRC}/build/Release/keytar.node — we copy the
+//    binary out and into the staged subdir after each fetch, then restore
+//    the host binary at the end so local dev/test keeps working.
+// ---------------------------------------------------------------------------
+
+const HOST_BINARY = path.join(KEYTAR_SRC, 'build', 'Release', 'keytar.node');
+const HOST_BACKUP = path.join(KEYTAR_SRC, 'build', 'Release', 'keytar.node.host-backup');
+
+if (!fs.existsSync(HOST_BINARY)) {
+  log('Host keytar binary missing — fetching for current platform first…');
+  execSync('npx --yes prebuild-install --runtime napi --target 3', {
+    cwd: KEYTAR_SRC, stdio: 'inherit',
+  });
+}
+
+log('Stashing host platform binary for restoration…');
+fs.copyFileSync(HOST_BINARY, HOST_BACKUP);
+
+for (const { platform, arch } of TARGETS) {
+  log(`Fetching keytar prebuild: ${platform}-${arch}`);
+  execSync(
+    `npx --yes prebuild-install --platform ${platform} --arch ${arch} --runtime napi --target 3`,
+    { cwd: KEYTAR_SRC, stdio: 'inherit' }
+  );
+  const targetSubdir = path.join(KEYTAR_DST, 'build', 'Release', `${platform}-${arch}`);
+  fs.mkdirSync(targetSubdir, { recursive: true });
+  fs.copyFileSync(HOST_BINARY, path.join(targetSubdir, 'keytar.node'));
+}
+
+log('Restoring host platform keytar binary…');
+fs.copyFileSync(HOST_BACKUP, HOST_BINARY);
+fs.unlinkSync(HOST_BACKUP);
+
+// ---------------------------------------------------------------------------
+// 4. Patch keytar's lib/keytar.js in the staged copy with a multi-platform-
+//    aware loader. Pre-patch assertion on the upstream source guards against
+//    silent breakage if a future keytar bump changes the loader shape.
+// ---------------------------------------------------------------------------
+
+const UPSTREAM_LIB_KEYTAR = path.join(KEYTAR_SRC, 'lib', 'keytar.js');
+const STAGED_LIB_KEYTAR = path.join(KEYTAR_DST, 'lib', 'keytar.js');
+
+const upstreamSource = fs.readFileSync(UPSTREAM_LIB_KEYTAR, 'utf8');
+const EXPECTED_LOADER_LINE = "var keytar = require('../build/Release/keytar.node')";
+
+if (!upstreamSource.includes(EXPECTED_LOADER_LINE)) {
+  throw new Error(
+    `pack-mcpb.js: upstream keytar/lib/keytar.js no longer matches expected pre-patch shape.\n` +
+    `Expected substring: ${EXPECTED_LOADER_LINE}\n` +
+    `Source: ${UPSTREAM_LIB_KEYTAR}\n` +
+    `\n` +
+    `Cause: keytar version bumped past 7.9.x and the loader shape changed.\n` +
+    `Action: review the new keytar/lib/keytar.js, update the loader-patch source\n` +
+    `        in this script (LOADER constant), and update EXPECTED_LOADER_LINE to\n` +
+    `        the new pre-patch substring. Then re-run pack:mcpb.\n` +
+    `\n` +
+    `If the new keytar version routes binaries by platform-arch natively, the\n` +
+    `patch may no longer be needed at all — empirically verify by extracting an\n` +
+    `unpatched bundle and require()-ing keytar from it on the host platform.\n` +
+    `If require succeeds, drop this patch step entirely.`
+  );
+}
+
+const LOADER = `'use strict';
+// Multi-platform keytar loader — generated by scripts/pack-mcpb.js for the .mcpb bundle.
+// Routes the native binary load by process.platform-process.arch so a single bundle
+// works across darwin x64/arm64, win32 x64, linux x64. Falls back to the legacy
+// build/Release/keytar.node slot when the platform-arch subdir is absent (preserves
+// CLI-install behavior in case this loader ever runs outside the .mcpb bundle).
+
+const fs = require('fs');
+const path = require('path');
+
+const platformArch = process.platform + '-' + process.arch;
+const subdirPath = path.join(__dirname, '..', 'build', 'Release', platformArch, 'keytar.node');
+const fallbackPath = path.join(__dirname, '..', 'build', 'Release', 'keytar.node');
+const binPath = fs.existsSync(subdirPath) ? subdirPath : fallbackPath;
+const keytar = require(binPath);
+
+function checkRequired(val, name) {
+  if (!val || val.length <= 0) {
+    throw new Error(name + ' is required.');
+  }
+}
+
+module.exports = {
+  getPassword(service, account) {
+    checkRequired(service, 'Service');
+    checkRequired(account, 'Account');
+    return keytar.getPassword(service, account);
+  },
+  setPassword(service, account, password) {
+    checkRequired(service, 'Service');
+    checkRequired(account, 'Account');
+    checkRequired(password, 'Password');
+    return keytar.setPassword(service, account, password);
+  },
+  deletePassword(service, account) {
+    checkRequired(service, 'Service');
+    checkRequired(account, 'Account');
+    return keytar.deletePassword(service, account);
+  },
+  findCredentials(service) {
+    checkRequired(service, 'Service');
+    return keytar.findCredentials(service);
+  },
+  findPassword(service) {
+    checkRequired(service, 'Service');
+    return keytar.findPassword(service);
+  },
+};
+`;
+fs.writeFileSync(STAGED_LIB_KEYTAR, LOADER);
+log('Patched staged keytar/lib/keytar.js for multi-platform binary routing.');
+
+// ---------------------------------------------------------------------------
+// 5. Run mcpb pack against the staging dir.
+// ---------------------------------------------------------------------------
+
+log('Running mcpb pack against staging…');
+execSync(
+  `npx --yes @anthropic-ai/mcpb pack "${STAGING}" "${OUTPUT}"`,
+  { stdio: 'inherit' }
+);
+
+log(`Bundle written to ${path.relative(PROJECT_ROOT, OUTPUT)}`);

--- a/scripts/verify-pack-isolation.js
+++ b/scripts/verify-pack-isolation.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * verify-pack-isolation: assert that running pack:mcpb does not mutate
+ * `node_modules/keytar/` in the project tree.
+ *
+ * The pack script writes to `dist-mcpb/staging/` and patches keytar's
+ * lib/keytar.js in the staged copy, but it also has to invoke
+ * `prebuild-install` against `node_modules/keytar/` to fetch each platform's
+ * binary (prebuild-install always writes to KEYTAR_SRC/build/Release/keytar.node).
+ * After fetching all targets the script restores the host-platform binary at
+ * the legacy slot.
+ *
+ * This script pins the property "node_modules/keytar/ ends up byte-identical
+ * to its pre-pack state" — covering both the binary restore and any other
+ * incidental mutation. Snapshots a sha256-of-sha256s before and after; fails
+ * loud with a per-file diff if any change.
+ *
+ * Run as: `npm run verify:pack-isolation`
+ *
+ * Copyright (C) 2026 Influencentricity | Wicked Evolutions
+ * @license GPL-2.0-or-later
+ */
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { execSync } = require('child_process');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const KEYTAR_DIR = path.join(PROJECT_ROOT, 'node_modules', 'keytar');
+
+function walk(dir, base = dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const abs = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walk(abs, base));
+    } else if (entry.isFile()) {
+      const rel = path.relative(base, abs);
+      const buf = fs.readFileSync(abs);
+      const hash = crypto.createHash('sha256').update(buf).digest('hex');
+      out.push({ path: rel, hash, size: buf.length });
+    }
+  }
+  return out;
+}
+
+function snapshotKeytar() {
+  if (!fs.existsSync(KEYTAR_DIR)) {
+    throw new Error(`node_modules/keytar/ does not exist — run \`npm install\` first.`);
+  }
+  return walk(KEYTAR_DIR);
+}
+
+function diff(before, after) {
+  const beforeMap = new Map(before.map((e) => [e.path, e]));
+  const afterMap = new Map(after.map((e) => [e.path, e]));
+  const changes = [];
+  for (const [p, b] of beforeMap) {
+    const a = afterMap.get(p);
+    if (!a) {
+      changes.push(`removed: ${p}`);
+    } else if (a.hash !== b.hash) {
+      changes.push(`modified: ${p}  (${b.size}B → ${a.size}B; ${b.hash.slice(0, 12)}… → ${a.hash.slice(0, 12)}…)`);
+    }
+  }
+  for (const [p] of afterMap) {
+    if (!beforeMap.has(p)) {
+      changes.push(`added: ${p}`);
+    }
+  }
+  return changes;
+}
+
+function log(msg) {
+  process.stdout.write(`[verify-pack-isolation] ${msg}\n`);
+}
+
+log('Snapshotting node_modules/keytar/ pre-pack…');
+const before = snapshotKeytar();
+log(`  ${before.length} files`);
+
+log('Running pack:mcpb…');
+execSync('node scripts/pack-mcpb.js', {
+  cwd: PROJECT_ROOT,
+  stdio: 'inherit',
+});
+
+log('Snapshotting node_modules/keytar/ post-pack…');
+const after = snapshotKeytar();
+log(`  ${after.length} files`);
+
+const changes = diff(before, after);
+if (changes.length === 0) {
+  log('PASS: node_modules/keytar/ is byte-identical pre-pack and post-pack.');
+  process.exit(0);
+} else {
+  process.stderr.write(`\n[verify-pack-isolation] FAIL: pack:mcpb mutated node_modules/keytar/\n`);
+  for (const change of changes) {
+    process.stderr.write(`  ${change}\n`);
+  }
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- Closes #33 — Phase A of the [v1.5.2 sprint](https://github.com/Wicked-Evolutions/abilities-mcp/milestone/2). The `.mcpb` bundle now ships keytar prebuilds for darwin x64, darwin arm64, win32 x64, linux x64. After this, the documented Install-section operator progression (install `.mcpb` → run `add-site`/`upgrade-auth` from terminal → restart Claude Desktop, multi-site OAuth in the same extension entry) becomes structurally possible — currently broken on every platform because `keytar` is in `optionalDependencies` and the `.mcpb` ships zero `node_modules/`.
- New `scripts/pack-mcpb.js` builds `dist-mcpb/staging/` with the runtime surface plus a keytar package carrying all four platform binaries; `mcpb pack` runs against staging.
- New `scripts/verify-pack-isolation.js` pins the property "`node_modules/keytar/` is byte-identical pre-pack and post-pack" via recursive sha256.
- Three guards (per CTO review): pre-patch substring assertion on upstream `lib/keytar.js` shape; keytar pinned `~7.9.0` (patch-only) to give the assertion a stable target; verify:pack-isolation as a re-runnable test of pack hygiene.

## Test plan

- [x] `npm test` — **237/237 green** (no regression).
- [x] `npm run verify:pack-isolation` — **PASS** (15 files in `node_modules/keytar/`, all sha256 unchanged pre-pack and post-pack).
- [x] `npm run pack:mcpb` produces a 56-file bundle, 413 kB packed / 1.2 MB unpacked.
- [x] Bundle layout verified via `unzip -l`:
  ```
  node_modules/keytar/build/Release/darwin-arm64/keytar.node    99528 B
  node_modules/keytar/build/Release/darwin-x64/keytar.node      83456 B
  node_modules/keytar/build/Release/linux-x64/keytar.node       76960 B
  node_modules/keytar/build/Release/win32-x64/keytar.node      707584 B
  node_modules/keytar/lib/keytar.js                              (patched loader)
  node_modules/keytar/package.json
  ```
- [x] Empirical host-platform load test:
  ```
  $ unzip -q abilities-mcp.mcpb -d /tmp/mcpb-empirical-patched
  $ cd /tmp/mcpb-empirical-patched
  $ node -e "const k = require('./node_modules/keytar'); console.log(Object.keys(k).join(', '))"
  getPassword, setPassword, deletePassword, findCredentials, findPassword
  ```
  Loads cleanly. Patched loader correctly routes to `build/Release/darwin-arm64/keytar.node` based on `process.platform`+`process.arch`.
- [x] Empirical pre-patch failure mode (without the lib/keytar.js patch, same multi-platform binary layout): `MODULE_NOT_FOUND - Cannot find module '../build/Release/keytar.node'`. Even on the host platform. Documented in script header + Deviations.
- [x] No-regression check on every install path in the sprint plan §5 compatibility table — code paths verified by inspection (only `dist-mcpb/staging/node_modules/keytar/` is patched; project-tree `node_modules/keytar/` is untouched per `verify:pack-isolation`; CLI install paths use upstream keytar verbatim from npm).
- [ ] **Cross-platform smoke test** (darwin x64 + arm64, win32 x64, linux x64) — orchestrator-side at Phase F.5, not in this PR.

## Deviations

1. **Staging-directory build vs literal allowlist fallback.** Sprint plan §4 Phase A specified two `.mcpbignore`-based approaches: (a) `node_modules/` excluded + `!node_modules/keytar/` re-include, (b) drop the global `node_modules/` exclusion and explicit-allowlist every shipping package. Empirically tested (a) and a children-only variant (`node_modules/*` + `!node_modules/keytar/` + `!node_modules/keytar/**`): both produce a bundle with zero keytar entries — `mcpb pack` does not honor `!` re-includes inside an excluded parent regardless of pattern shape. (b) works but couples `.mcpbignore` to keytar's transitive dep tree (37 packages today; one line per non-keytar package). Chose a third path: build a clean staging directory containing only what should ship, run `mcpb pack` against staging. Single source of truth for "what ships." `.mcpbignore` at project root is unchanged from v1.5.1 (it doesn't apply to staged-dir packs).

2. **`lib/keytar.js` loader patch (mandatory, not stylistic).** The plan property "no bridge code change required" was based on the assumption that keytar's runtime loader uses `node-gyp-build` for platform-arch routing. **That assumption is wrong for keytar 7.9.0.** Keytar's runtime loader is a single line — `var keytar = require('../build/Release/keytar.node')` — with no `node-gyp-build`, no `prebuilds/` lookup, no platform routing whatsoever. `prebuild-install` (the package keytar does use) is install-time only.

   **Empirical proof.** Built a no-patch bundle with the multi-platform binaries staged at `build/Release/<platform>-<arch>/keytar.node`, extracted to `/tmp`, ran `node -e \"require('./node_modules/keytar')\"` from the host (darwin-arm64). Result:
   ```
   FAILED: MODULE_NOT_FOUND - Cannot find module '../build/Release/keytar.node'
   ```
   Fails on the host platform, not just non-host. Without the patch the bundle is structurally unloadable on every platform because keytar's loader only looks at the legacy slot, which the multi-platform layout doesn't populate.

   **Patch is staging-only.** Written to `dist-mcpb/staging/node_modules/keytar/lib/keytar.js`, never to `node_modules/keytar/lib/keytar.js` in the project tree. CLI install paths (`npx`, `npm install -g`, source clone, headless CI, Docker) all run their own `npm install` and use upstream unpatched keytar verbatim. Confirmed by `verify:pack-isolation` (PASS, 15 files byte-identical).

3. **Three safety guards added per CTO review:**
   - **Pre-patch substring assertion** in `pack-mcpb.js` reads upstream `node_modules/keytar/lib/keytar.js` and asserts it contains the literal substring `var keytar = require('../build/Release/keytar.node')` before overwriting in staging. If a future keytar version changes the loader shape, pack fails loud with an actionable error naming the expected substring, the source path, and the steps to update (review new keytar shape; update `LOADER` and `EXPECTED_LOADER_LINE`; or drop the patch entirely if the new keytar version routes natively).
   - **keytar pinned `^7.9.0` → `~7.9.0`** in `package.json` so the substring assertion has a stable target. Patch versions only.
   - **`scripts/verify-pack-isolation.js`** snapshots `node_modules/keytar/` recursively (sha256 per file) before pack, runs `pack:mcpb`, snapshots again, asserts identical. Per-file diff on failure. Re-runnable as `npm run verify:pack-isolation` for CI / release-time checks.

4. **`.gitignore` adds `dist-mcpb/`** — build artifacts directory housing the staging dir and any future intermediate outputs. Was already implicitly excluded by `*.mcpb` for the bundle file, but the `staging/` subdirectory wasn't covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)