### PR TITLE
fix(config): emit operator-visible config-source line on startup (#32)

### DIFF
--- a/abilities-mcp.js
+++ b/abilities-mcp.js
@@ -24,6 +24,7 @@
 
 const { createLogger } = require('./lib/logger');
 const { loadConfig, buildSiteKeyEnum, resolveConfigFilePath } = require('./lib/config');
+const { formatConfigSourceLine } = require('./lib/config-source-line');
 const { ConnectionPool } = require('./lib/connection-pool');
 const { ToolCatalog } = require('./lib/tool-catalog');
 const { McpRouter } = require('./lib/router');
@@ -140,6 +141,13 @@ if (!isSubcommandInvocation) {
       process.stderr.write(`abilities-mcp: ${err.message}\n`);
       process.exit(1);
     }
+
+    // Emit a single config-source line to stderr so operators can diagnose
+    // which mode the bridge is in at a glance (Claude Desktop's MCP log
+    // captures the server's stderr stream). Always-on, not gated by --debug:
+    // operator-visibility is the entire point of #32 and createLogger is a
+    // debug-only file logger that wouldn't reach Claude Desktop's log.
+    process.stderr.write(formatConfigSourceLine(config) + '\n');
 
     const isMultiSite = config._isMultiSite;
     const siteKeys = buildSiteKeyEnum(config);

--- a/lib/config-source-line.js
+++ b/lib/config-source-line.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const os = require('os');
+
+/**
+ * Format the operator-visible startup diagnostic line that names which config
+ * source `loadConfig` resolved to and what's in it.
+ *
+ * Output goes to stderr where Claude Desktop's MCP log captures it
+ * (visible in `mcp-server-WordPress (Abilities MCP).log` on macOS), so the
+ * operator can tell at a glance:
+ *  - Whether the .mcpb extension is in env-var single-site mode or has
+ *    handed off to a home-dir wp-sites.json.
+ *  - How many sites are configured and what auth method each uses.
+ *  - Which file path or env var is the source of truth right now.
+ *
+ * Discriminants set in `lib/config.js`:
+ *  - 'explicit-config' — args.config / --config=<path>
+ *  - 'script-adjacent' — wp-sites.json next to abilities-mcp.js
+ *  - 'home-dir'        — ~/.abilities-mcp/wp-sites.json
+ *  - 'env-var'         — ABILITIES_MCP_URL injected by Claude Desktop user_config
+ *  - 'legacy-cli'      — --host / --path (mcp-ssh-bridge backward compat)
+ *
+ * The line never includes secrets — only site IDs, auth methods, hostnames,
+ * tildified file paths, and counts.
+ *
+ * Copyright (C) 2026 Influencentricity | Wicked Evolutions
+ * @license GPL-2.0-or-later
+ */
+
+/**
+ * Replace a leading $HOME prefix with `~/` so logs don't leak the operator's
+ * full username path. No-op for paths outside $HOME.
+ */
+function tildify(p) {
+  if (!p) return p;
+  const home = os.homedir();
+  if (home && (p === home || p.startsWith(home + '/'))) {
+    return '~' + p.slice(home.length);
+  }
+  return p;
+}
+
+/**
+ * Per-site short auth label: prefer auth.method (v2 schema), fall back to
+ * transport (v1 schema), 'unknown' if neither is set.
+ */
+function siteAuthLabel(site) {
+  if (site && site.auth && site.auth.method) return site.auth.method;
+  if (site && site.transport) return site.transport;
+  return 'unknown';
+}
+
+/**
+ * Build the Config-source line.
+ *
+ * @param {object} config  Output of `loadConfig` — must carry `_configSource`
+ *                         and `_configSourceLabel`.
+ * @returns {string}       One-line operator diagnostic, no trailing newline.
+ */
+function formatConfigSourceLine(config) {
+  const source = config && config._configSource;
+  const rawLabel = (config && config._configSourceLabel) || '';
+
+  if (source === 'env-var') {
+    const site = config.sites && config.sites[config.defaultSite];
+    const username = (site && site.http && site.http.username) || '?';
+    return `Config source: ABILITIES_MCP_URL env var (single-site basic auth: ${rawLabel} as ${username})`;
+  }
+
+  if (source === 'legacy-cli') {
+    return `Config source: --host/--path legacy CLI (single-site SSH: ${rawLabel})`;
+  }
+
+  // File-based: explicit-config / script-adjacent / home-dir
+  const label = tildify(rawLabel);
+  const siteEntries = Object.entries(config.sites || {}).map(
+    ([id, site]) => `${id} ${siteAuthLabel(site)}`
+  );
+  const sitesHeader = siteEntries.length === 1 ? '1 site' : `${siteEntries.length} sites`;
+  const sourcePrefix = source ? `[${source}] ` : '';
+  return `Config source: ${sourcePrefix}${label} (${sitesHeader}: ${siteEntries.join(', ')})`;
+}
+
+module.exports = { formatConfigSourceLine, tildify, siteAuthLabel };

--- a/lib/config.js
+++ b/lib/config.js
@@ -75,20 +75,20 @@ async function resolveConfigFilePath(args) {
 async function loadConfig(args) {
   // Explicit config path
   if (args.config) {
-    return loadConfigFile(args.config);
+    return loadConfigFile(args.config, 'explicit-config');
   }
 
   // Check alongside script (lib/ → package root)
   const scriptDir = path.resolve(__dirname, '..');
   const scriptConfig = path.join(scriptDir, 'wp-sites.json');
   if (await _exists(scriptConfig)) {
-    return loadConfigFile(scriptConfig);
+    return loadConfigFile(scriptConfig, 'script-adjacent');
   }
 
   // Check home directory
   const homeConfig = path.join(os.homedir(), '.abilities-mcp', 'wp-sites.json');
   if (await _exists(homeConfig)) {
-    return loadConfigFile(homeConfig);
+    return loadConfigFile(homeConfig, 'home-dir');
   }
 
   // Env-var single-site config — covers the .mcpb install path and any
@@ -173,14 +173,15 @@ function buildEnvConfig(env) {
   return {
     defaultSite: 'default',
     _isMultiSite: false,
-    _configSource: 'env',
+    _configSource: 'env-var',
+    _configSourceLabel: parsedUrl.hostname,
     sites: {
       default: siteConfig,
     },
   };
 }
 
-async function loadConfigFile(filePath) {
+async function loadConfigFile(filePath, source = 'explicit-config') {
   const raw = await fsp.readFile(filePath, 'utf8');
 
   // Warn if config file is readable by group or world
@@ -216,6 +217,8 @@ async function loadConfigFile(filePath) {
   config._isMultiSite = Object.keys(config.sites).length > 1 ||
     Object.values(config.sites).some(s => s.multisite);
   config._configPath = filePath;
+  config._configSource = source;
+  config._configSourceLabel = filePath;
 
   return config;
 }
@@ -301,6 +304,8 @@ function buildLegacyConfig(args) {
   return {
     defaultSite: 'default',
     _isMultiSite: false,
+    _configSource: 'legacy-cli',
+    _configSourceLabel: args.host,
     sites: {
       default: {
         label: args.host,

--- a/test/config-env.test.js
+++ b/test/config-env.test.js
@@ -14,7 +14,8 @@ describe('buildEnvConfig', () => {
 
     assert.equal(config.defaultSite, 'default');
     assert.equal(config._isMultiSite, false);
-    assert.equal(config._configSource, 'env');
+    assert.equal(config._configSource, 'env-var');
+    assert.equal(config._configSourceLabel, 'example.com');
 
     const site = config.sites.default;
     assert.equal(site.transport, 'http');

--- a/test/config-source.test.js
+++ b/test/config-source.test.js
@@ -1,0 +1,251 @@
+'use strict';
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { loadConfig } = require('../lib/config');
+const {
+  formatConfigSourceLine,
+  tildify,
+  siteAuthLabel,
+} = require('../lib/config-source-line');
+
+/**
+ * Issue #32 — Phase B of the v1.5.2 sprint.
+ *
+ * Pins the `_configSource` / `_configSourceLabel` discriminants emitted by
+ * every `loadConfig` branch, plus the formatter that turns them into the
+ * single operator-visible startup line on stderr.
+ */
+
+const tmpFiles = [];
+after(() => {
+  for (const f of tmpFiles) {
+    try { fs.unlinkSync(f); } catch { /* ignore */ }
+  }
+});
+
+function writeTempConfig(contents) {
+  const file = path.join(
+    os.tmpdir(),
+    `wp-sites.test.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.json`
+  );
+  fs.writeFileSync(file, JSON.stringify(contents, null, 2), { mode: 0o600 });
+  tmpFiles.push(file);
+  return file;
+}
+
+const APPPASSWORD_HTTP_SITE = {
+  defaultSite: 'siteA',
+  sites: {
+    siteA: {
+      url: 'https://example.com',
+      transport: 'http',
+      http: {
+        endpoint: 'https://example.com/wp-json/mcp/mcp-adapter-default-server',
+        username: 'wp_user',
+        password: 'pw',
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// loadConfig _configSource pinning — one assertion per branch.
+// ---------------------------------------------------------------------------
+
+describe('loadConfig — _configSource discriminant per branch (Issue #32)', () => {
+  it('explicit-config: args.config sets _configSource and _configSourceLabel', async () => {
+    const file = writeTempConfig(APPPASSWORD_HTTP_SITE);
+    const cfg = await loadConfig({ config: file });
+    assert.equal(cfg._configSource, 'explicit-config');
+    assert.equal(cfg._configSourceLabel, file);
+    assert.equal(cfg._configPath, file);
+  });
+
+  it('home-dir: ~/.abilities-mcp/wp-sites.json is picked up with home-dir discriminant', async () => {
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'abilities-mcp-home-'));
+    const homeConfigDir = path.join(fakeHome, '.abilities-mcp');
+    fs.mkdirSync(homeConfigDir, { recursive: true });
+    const homeConfigFile = path.join(homeConfigDir, 'wp-sites.json');
+    fs.writeFileSync(homeConfigFile, JSON.stringify(APPPASSWORD_HTTP_SITE, null, 2), { mode: 0o600 });
+
+    const origHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+    try {
+      // The script-adjacent path takes precedence over home-dir — skip if the repo
+      // happens to carry a script-adjacent wp-sites.json (dev machines often do).
+      const scriptAdjacent = path.resolve(__dirname, '..', 'wp-sites.json');
+      if (fs.existsSync(scriptAdjacent)) {
+        return;
+      }
+      const cfg = await loadConfig({});
+      assert.equal(cfg._configSource, 'home-dir');
+      assert.equal(cfg._configSourceLabel, homeConfigFile);
+    } finally {
+      if (origHome === undefined) delete process.env.HOME;
+      else process.env.HOME = origHome;
+      try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+
+  it('env-var: ABILITIES_MCP_URL sets _configSource=env-var and label is hostname', async () => {
+    const origUrl = process.env.ABILITIES_MCP_URL;
+    const origUser = process.env.ABILITIES_MCP_USERNAME;
+    const origPass = process.env.ABILITIES_MCP_PASSWORD;
+
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'abilities-mcp-home-'));
+    const origHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+    process.env.ABILITIES_MCP_URL = 'https://wickedevolutions.com';
+    process.env.ABILITIES_MCP_USERNAME = 'wicked';
+    process.env.ABILITIES_MCP_PASSWORD = 'app-pw';
+
+    try {
+      const scriptAdjacent = path.resolve(__dirname, '..', 'wp-sites.json');
+      if (fs.existsSync(scriptAdjacent)) return;
+      const cfg = await loadConfig({});
+      assert.equal(cfg._configSource, 'env-var');
+      assert.equal(cfg._configSourceLabel, 'wickedevolutions.com');
+    } finally {
+      if (origHome === undefined) delete process.env.HOME; else process.env.HOME = origHome;
+      if (origUrl === undefined) delete process.env.ABILITIES_MCP_URL; else process.env.ABILITIES_MCP_URL = origUrl;
+      if (origUser === undefined) delete process.env.ABILITIES_MCP_USERNAME; else process.env.ABILITIES_MCP_USERNAME = origUser;
+      if (origPass === undefined) delete process.env.ABILITIES_MCP_PASSWORD; else process.env.ABILITIES_MCP_PASSWORD = origPass;
+      try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+
+  it('legacy-cli: --host / --path sets _configSource=legacy-cli and label is host', async () => {
+    const origUrl = process.env.ABILITIES_MCP_URL;
+    delete process.env.ABILITIES_MCP_URL;
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'abilities-mcp-home-'));
+    const origHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+    try {
+      const scriptAdjacent = path.resolve(__dirname, '..', 'wp-sites.json');
+      if (fs.existsSync(scriptAdjacent)) return;
+      const cfg = await loadConfig({ host: 'legacy.example', path: '/var/www/wp' });
+      assert.equal(cfg._configSource, 'legacy-cli');
+      assert.equal(cfg._configSourceLabel, 'legacy.example');
+    } finally {
+      if (origHome === undefined) delete process.env.HOME; else process.env.HOME = origHome;
+      if (origUrl !== undefined) process.env.ABILITIES_MCP_URL = origUrl;
+      try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Formatter — every source produces a sensible operator-visible line.
+// ---------------------------------------------------------------------------
+
+describe('formatConfigSourceLine — per-source output format', () => {
+  it('formats env-var single-site basic auth', () => {
+    const line = formatConfigSourceLine({
+      _configSource: 'env-var',
+      _configSourceLabel: 'wickedevolutions.com',
+      defaultSite: 'default',
+      sites: {
+        default: {
+          transport: 'http',
+          http: { endpoint: 'https://wickedevolutions.com/wp-json/mcp/mcp-adapter-default-server', username: 'wicked', password: 'pw' },
+        },
+      },
+    });
+    assert.match(line, /^Config source: ABILITIES_MCP_URL env var/);
+    assert.match(line, /wickedevolutions\.com/);
+    assert.match(line, /as wicked/);
+  });
+
+  it('formats legacy-cli single-site SSH', () => {
+    const line = formatConfigSourceLine({
+      _configSource: 'legacy-cli',
+      _configSourceLabel: 'legacy.example',
+      defaultSite: 'default',
+      sites: { default: { transport: 'ssh', ssh: { host: 'legacy.example', path: '/var/www/wp' } } },
+    });
+    assert.match(line, /^Config source: --host\/--path legacy CLI/);
+    assert.match(line, /legacy\.example/);
+  });
+
+  it('formats home-dir multi-site with per-site auth methods', () => {
+    const fakeFile = path.join(os.homedir(), '.abilities-mcp', 'wp-sites.json');
+    const line = formatConfigSourceLine({
+      _configSource: 'home-dir',
+      _configSourceLabel: fakeFile,
+      defaultSite: 'helena',
+      sites: {
+        helena: { url: 'https://helenawillow.com', auth: { method: 'oauth' } },
+        wicked: { url: 'https://wickedevolutions.com', auth: { method: 'oauth' } },
+        legacy: { url: 'https://legacy.example', transport: 'http', http: {} },
+      },
+    });
+    assert.match(line, /^Config source: \[home-dir\]/);
+    assert.match(line, /~\/\.abilities-mcp\/wp-sites\.json/);
+    assert.match(line, /3 sites:/);
+    assert.match(line, /helena oauth/);
+    assert.match(line, /wicked oauth/);
+    assert.match(line, /legacy http/);
+  });
+
+  it('formats explicit-config single-site (1 site, not 1 sites)', () => {
+    const line = formatConfigSourceLine({
+      _configSource: 'explicit-config',
+      _configSourceLabel: '/tmp/wp-sites.json',
+      defaultSite: 'siteA',
+      sites: { siteA: { auth: { method: 'apppassword' } } },
+    });
+    assert.match(line, /^Config source: \[explicit-config\] \/tmp\/wp-sites\.json/);
+    assert.match(line, /\(1 site: siteA apppassword\)/);
+  });
+
+  it('formats script-adjacent the same shape as home-dir but with a different prefix', () => {
+    const line = formatConfigSourceLine({
+      _configSource: 'script-adjacent',
+      _configSourceLabel: '/abs/path/wp-sites.json',
+      defaultSite: 'siteA',
+      sites: { siteA: { auth: { method: 'oauth' } } },
+    });
+    assert.match(line, /^Config source: \[script-adjacent\]/);
+    assert.match(line, /siteA oauth/);
+  });
+});
+
+describe('tildify', () => {
+  it('replaces leading $HOME with ~', () => {
+    const home = os.homedir();
+    assert.equal(tildify(`${home}/foo/bar`), '~/foo/bar');
+    assert.equal(tildify(home), '~');
+  });
+
+  it('leaves paths outside $HOME untouched', () => {
+    assert.equal(tildify('/tmp/foo'), '/tmp/foo');
+    assert.equal(tildify('/etc/passwd'), '/etc/passwd');
+  });
+
+  it('handles empty / null input', () => {
+    assert.equal(tildify(''), '');
+    assert.equal(tildify(null), null);
+  });
+});
+
+describe('siteAuthLabel', () => {
+  it('prefers auth.method when present (v2 schema)', () => {
+    assert.equal(siteAuthLabel({ auth: { method: 'oauth' }, transport: 'http' }), 'oauth');
+    assert.equal(siteAuthLabel({ auth: { method: 'apppassword' }, transport: 'ssh' }), 'apppassword');
+  });
+
+  it('falls back to transport when no auth block (v1 schema)', () => {
+    assert.equal(siteAuthLabel({ transport: 'ssh' }), 'ssh');
+    assert.equal(siteAuthLabel({ transport: 'http' }), 'http');
+  });
+
+  it('returns "unknown" when neither auth.method nor transport is set', () => {
+    assert.equal(siteAuthLabel({}), 'unknown');
+    assert.equal(siteAuthLabel(null), 'unknown');
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #32 — Phase B of the [v1.5.2 sprint](https://github.com/Wicked-Evolutions/abilities-mcp/milestone/2). Bridge now emits one stderr line on startup naming which `loadConfig` source it picked, the file path / hostname, and the per-site auth methods. Captured by Claude Desktop's MCP log.
- `lib/config.js`: every `loadConfig` branch sets `_configSource` + `_configSourceLabel`. Discriminants: `explicit-config`, `script-adjacent`, `home-dir`, `env-var`, `legacy-cli`. Aligns the pre-existing `buildEnvConfig` hint (was `'env'`) with the documented value (`'env-var'`).
- New `lib/config-source-line.js` exports `formatConfigSourceLine` (plus `tildify` and `siteAuthLabel` helpers) — small testable module.
- `abilities-mcp.js`: bootstrap emits the formatted line via `process.stderr.write` right after `loadConfig` returns. Always-on, not gated by `--debug`.

## Sample output

Env-var single-site (Claude Desktop `.mcpb` install):
```
Config source: ABILITIES_MCP_URL env var (single-site basic auth: example.com as wp_user)
```

Home-dir multi-site (after CLI `add-site` / `upgrade-auth`):
```
Config source: [home-dir] ~/.abilities-mcp/wp-sites.json (3 sites: helena oauth, wicked oauth, tnn apppassword)
```

Explicit `--config`:
```
Config source: [explicit-config] /tmp/wp-sites.json (1 site: siteA apppassword)
```

Legacy CLI:
```
Config source: --host/--path legacy CLI (single-site SSH: legacy.example)
```

The line never includes secrets — only site IDs, auth methods, hostnames, tildified file paths, and counts.

## Test plan

- [x] `npm test` — **252/252 green** (was 237 baseline; +15 new tests).
- [x] One assertion per `loadConfig` source branch pins `_configSource` + `_configSourceLabel`:
  - `explicit-config` (always exercises the explicit path), `home-dir` / `env-var` / `legacy-cli` (skipped when a script-adjacent `wp-sites.json` exists, which it does on dev machines; CI checkouts don't have one so all four run).
- [x] Formatter coverage: env-var, legacy-cli, home-dir multi-site, explicit-config singular ("1 site" not "1 sites"), script-adjacent prefix.
- [x] `tildify` edge cases: leading `$HOME` replacement, exact `$HOME` match, paths outside `$HOME`, null/empty.
- [x] `siteAuthLabel` fallback chain: `auth.method` → `transport` → `'unknown'`.
- [x] Pre-existing `test/config-env.test.js` `_configSource: 'env'` assertion updated to `'env-var'` (the rename).
- [x] `node --check abilities-mcp.js` and `node --check lib/config-source-line.js` pass.
- [x] End-to-end smoke from CLI:
  ```
  $ ABILITIES_MCP_URL=https://wickedevolutions.com … node -e "…"
  Config source: [script-adjacent] /Users/wicked/my-agent/abilities-mcp/wp-sites.json (7 sites: …)
  ```
  Line emitted to stderr; format matches spec.

## Deviations

1. **`process.stderr.write` instead of the existing `createLogger(debug)`.** Issue body and sprint plan §4 Phase B both say "via the existing `createLogger(debug)` logger." Inspection of `lib/logger.js` showed createLogger is a **no-op when debug is false** and writes to a **file** (`~/.abilities-mcp/logs/abilities-mcp.log`) when enabled — never to stderr. Claude Desktop's MCP log captures the server's stderr stream, not the home-dir log file. Using createLogger as written would mean the line only appears for `--debug` operators in a file Claude Desktop doesn't read — which defeats the entire operator-visibility goal of #32. Switched to `process.stderr.write` (matches the established pattern for error paths in `abilities-mcp.js`); always-on, reaches Claude Desktop's MCP log capture. Same channel as the existing `process.stderr.write(\`abilities-mcp: ${err.message}\`)` error pathway. Issue body's "operator-visible log line" intent is honored; the literal "via createLogger" wording is not.

2. **New `lib/config-source-line.js` module rather than inline helper in `abilities-mcp.js`.** The plan didn't specify where the formatter lives. Pulled into a dedicated module so the formatter is unit-testable directly (entry-point bootstrap is harder to test cleanly) and so the entry point stays focused on orchestration. Adds one require line; the module is 90 lines including doc.

3. **Renamed `_configSource: 'env'` → `'env-var'`.** The plan's documented discriminant values were `'explicit-config'`, `'script-adjacent'`, `'home-dir'`, `'env-var'`, `'legacy-cli'`. The pre-existing `buildEnvConfig` hint used `'env'`. Updated buildEnvConfig + the one test that asserted the old value (`test/config-env.test.js`). The discriminant is internal (underscore-prefixed); only the test was reading it externally.

4. **Source prefix `[home-dir]` / `[explicit-config]` / `[script-adjacent]` in the file-based output.** Plan example didn't show this prefix — only `Config source: ~/.abilities-mcp/wp-sites.json (...)` — but with three file-based source variants it's useful for operators to know which precedence rule won. The env-var and legacy-cli outputs don't need a prefix because the source descriptor is already in the message body (`ABILITIES_MCP_URL env var`, `--host/--path legacy CLI`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)