### PR TITLE
fix(.mcpb): seed wp-sites.json from env vars on first launch (#34)

### DIFF
--- a/lib/cli/config-store.js
+++ b/lib/cli/config-store.js
@@ -6,7 +6,11 @@ const os = require('node:os');
 
 const { SCHEMA_VERSION, validate, emptyConfig } = require('../auth/schema-v2');
 const { _atomicWrite } = require('../auth/config-migration');
+const { AUTH_STATUS } = require('../auth/events');
+const { makeRef } = require('../auth/secret-store');
 const { CliError, EXIT_CONFIG } = require('./errors');
+
+const SECRET_SERVICE = 'abilities-mcp';
 
 /**
  * Read / write the v2 wp-sites.json file from a CLI command.
@@ -152,10 +156,173 @@ function freshConfig() {
   return emptyConfig();
 }
 
+/**
+ * Derive a site-id from a URL hostname. Mirrors `add-site`'s deriveSiteId so a
+ * `.mcpb`-seeded site collides with a CLI-added entry for the same host (the
+ * file-absence guard in `seedFromEnvIfMissing` prevents the collision in
+ * practice; the parity matters for `upgrade-auth <site-id>` to be intuitive).
+ *
+ * @param {string} siteUrl
+ * @returns {string|null}  Site-id or null if URL is unparseable.
+ */
+function deriveSiteId(siteUrl) {
+  let host;
+  try { host = new URL(siteUrl).hostname; }
+  catch { return null; }
+  const trimmed = host.replace(/^www\./, '');
+  const dot = trimmed.indexOf('.');
+  return dot > 0 ? trimmed.slice(0, dot) : trimmed;
+}
+
+/**
+ * Seed wp-sites.json from env vars (`ABILITIES_MCP_URL/USERNAME/PASSWORD`)
+ * when the file doesn't yet exist. Used on first launch of the `.mcpb`
+ * extension so subsequent CLI commands (`list-sites`, `upgrade-auth`,
+ * `add-site`) operate on a single source of truth that already includes
+ * the site Claude Desktop is connected to.
+ *
+ * Behavior:
+ *  - If `configPath` already exists → no-op. Operators who manage their own
+ *    `wp-sites.json` are never overwritten.
+ *  - If keytar isn't loadable on this host (e.g. the .mcpb is somehow
+ *    running without the bundled keytar prebuild) → no-op. The bridge
+ *    falls back to env-var-only mode. Graceful degradation.
+ *  - If any of the three env vars is missing → no-op. Should not happen
+ *    in the .mcpb path (manifest user_config marks all three required) but
+ *    guards against partial env in other invocations.
+ *  - Otherwise: writes the App Password to keychain via the shared
+ *    SecretStore, builds a v2 apppassword entry shaped to pass both the
+ *    schema-v2 validator and the bridge's runtime validateSiteConfig
+ *    (matching the migration `_convertSite` pattern — preserves
+ *    `transport: 'http'` and the legacy http block alongside the v2 auth
+ *    block, with `password_ref` in both).
+ *
+ * If the keychain write succeeds but the file write fails the keychain
+ * entry is rolled back so the operator's keychain doesn't accumulate
+ * orphans on repeated failures.
+ *
+ * @param {string} configPath  Absolute path of the wp-sites.json to seed.
+ * @param {object} env         Environment shape — expects ABILITIES_MCP_URL,
+ *                             ABILITIES_MCP_USERNAME, ABILITIES_MCP_PASSWORD.
+ *                             Defaults to process.env.
+ * @param {object} [deps]
+ * @param {object} [deps.secretStore]  Inject for tests (a MemorySecretStore).
+ *                                     Defaults to a fresh KeychainSecretStore.
+ * @returns {Promise<{
+ *   seeded: boolean,
+ *   reason?: 'exists'|'missing-env-vars'|'keytar-unavailable'|'invalid-url'|'error',
+ *   siteId?: string,
+ *   configPath?: string,
+ *   error?: Error,
+ * }>}
+ */
+async function seedFromEnvIfMissing(configPath, env, deps = {}) {
+  if (!configPath) {
+    return { seeded: false, reason: 'missing-env-vars' };
+  }
+  if (fs.existsSync(configPath)) {
+    return { seeded: false, reason: 'exists' };
+  }
+
+  const url = env && env.ABILITIES_MCP_URL;
+  const username = env && env.ABILITIES_MCP_USERNAME;
+  const password = env && env.ABILITIES_MCP_PASSWORD;
+  if (!url || !username || !password) {
+    return { seeded: false, reason: 'missing-env-vars' };
+  }
+
+  let parsedUrl;
+  try { parsedUrl = new URL(url); }
+  catch { return { seeded: false, reason: 'invalid-url' }; }
+
+  const siteId = deriveSiteId(url);
+  if (!siteId) {
+    return { seeded: false, reason: 'invalid-url' };
+  }
+
+  // Lazily build a SecretStore so SSH-only / env-var-only setups never load
+  // keytar on the seed path — the no-op "missing env vars" exit above keeps
+  // them out, but keep the require deferred for symmetry with the runtime.
+  let secretStore = deps.secretStore;
+  if (!secretStore) {
+    const { KeychainSecretStore } = require('../auth/keychain-secret-store');
+    secretStore = new KeychainSecretStore();
+  }
+
+  // Probe keytar before writing. If it isn't loadable (e.g. the .mcpb
+  // somehow shipped without the bundled binary) we skip seeding — the
+  // bridge keeps working in env-var-only mode and the operator can run
+  // `abilities-mcp add-site` from a CLI install instead.
+  if (typeof secretStore.isAvailable === 'function') {
+    const available = await secretStore.isAvailable();
+    if (!available) {
+      return { seeded: false, reason: 'keytar-unavailable' };
+    }
+  }
+
+  // Build the endpoint the same way buildEnvConfig does — strip trailing
+  // slash, append the adapter route. This is the URL the runtime will hit
+  // for App-Password requests.
+  const base = (parsedUrl.origin + parsedUrl.pathname).replace(/\/+$/, '');
+  const endpoint = `${base}/wp-json/mcp/mcp-adapter-default-server`;
+  const account = `${siteId}/apppassword`;
+  const passwordRef = makeRef(SECRET_SERVICE, account);
+
+  // Write the secret to keychain first. If the file write below fails we
+  // roll this back so the keychain doesn't accumulate orphan entries on
+  // repeated seed attempts.
+  try {
+    await secretStore.set(SECRET_SERVICE, account, password);
+  } catch (err) {
+    return { seeded: false, reason: 'error', error: err };
+  }
+
+  const allowInsecure = parsedUrl.protocol === 'http:';
+  const site = {
+    label: parsedUrl.hostname,
+    url: parsedUrl.origin,
+    transport: 'http',
+    http: {
+      endpoint,
+      username,
+      password_ref: passwordRef,
+    },
+    auth: {
+      method: 'apppassword',
+      username,
+      password_ref: passwordRef,
+    },
+    auth_status: AUTH_STATUS.ACTIVE,
+  };
+  if (allowInsecure) site.allowInsecure = true;
+
+  const v2Config = {
+    $schema: 'https://wickedevolutions.com/schemas/abilities-mcp/wp-sites/v2.json',
+    schema_version: SCHEMA_VERSION,
+    defaultSite: siteId,
+    sites: { [siteId]: site },
+  };
+
+  try {
+    const dir = path.dirname(configPath);
+    await fs.promises.mkdir(dir, { recursive: true });
+    await _atomicWrite(configPath, v2Config);
+  } catch (err) {
+    // Roll back the keychain write so we don't leave an orphan secret.
+    try { await secretStore.delete(SECRET_SERVICE, account); }
+    catch { /* best-effort rollback */ }
+    return { seeded: false, reason: 'error', error: err };
+  }
+
+  return { seeded: true, siteId, configPath };
+}
+
 module.exports = {
   resolveConfigPath,
   readConfig,
   writeConfig,
   freshConfig,
+  seedFromEnvIfMissing,
+  deriveSiteId,
   HOME_DIR_REL,
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -93,7 +93,21 @@ async function loadConfig(args) {
 
   // Env-var single-site config — covers the .mcpb install path and any
   // env-var-based MCP client configuration (claude mcp add, Docker, etc.)
+  //
+  // First-launch seed (#34): if the .mcpb just installed and no home-dir
+  // wp-sites.json exists yet, seed one from the env vars so subsequent CLI
+  // commands (`list-sites`, `upgrade-auth`, `add-site`) operate on a single
+  // source of truth that already includes the site Claude Desktop is
+  // connected to. On success the bridge loads the freshly seeded file —
+  // same shape it would read on next restart — so the runtime path stays
+  // identical regardless of whether seeding just happened. On failure
+  // (keytar unavailable, file-already-exists, write error) the seed is a
+  // graceful no-op and we fall back to env-var-only mode below.
   if (process.env.ABILITIES_MCP_URL) {
+    const seedResult = await _seedFromEnvIfMissing(homeConfig, process.env);
+    if (seedResult && seedResult.seeded) {
+      return loadConfigFile(homeConfig, 'home-dir');
+    }
     return buildEnvConfig(process.env);
   }
 
@@ -433,6 +447,17 @@ async function resolveSitePassword(site, secretStore) {
   throw new Error('No password source configured for site');
 }
 
+/**
+ * Lazy wrapper around `lib/cli/config-store.js#seedFromEnvIfMissing`. Only
+ * loads the CLI config-store + KeychainSecretStore modules when the env-var
+ * branch of `loadConfig` actually fires — so SSH-only, explicit-config, and
+ * legacy-CLI install paths never pay the keytar import cost.
+ */
+async function _seedFromEnvIfMissing(configPath, env) {
+  const { seedFromEnvIfMissing } = require('./cli/config-store');
+  return seedFromEnvIfMissing(configPath, env);
+}
+
 module.exports = {
   loadConfig,
   resolveConfigFilePath,
@@ -441,4 +466,5 @@ module.exports = {
   resolveSiteKey,
   buildSiteKeyEnum,
   buildEnvConfig,
+  validateSiteConfig,
 };

--- a/test/cli/seed-from-env.test.js
+++ b/test/cli/seed-from-env.test.js
@@ -1,0 +1,212 @@
+'use strict';
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { seedFromEnvIfMissing, deriveSiteId, readConfig } = require('../../lib/cli/config-store');
+const { MemorySecretStore } = require('../../lib/auth/memory-secret-store');
+const { SECRET_SERVICE } = require('../../lib/auth/token-manager');
+const { validate, SCHEMA_VERSION } = require('../../lib/auth/schema-v2');
+const { validateSiteConfig } = require('../../lib/config');
+
+const tmpDirs = [];
+after(() => {
+  for (const d of tmpDirs) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+});
+
+function freshTmpDir() {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'abilities-mcp-seed-'));
+  tmpDirs.push(d);
+  return d;
+}
+
+function defaultEnv(overrides = {}) {
+  return {
+    ABILITIES_MCP_URL: 'https://wickedevolutions.com',
+    ABILITIES_MCP_USERNAME: 'wicked',
+    ABILITIES_MCP_PASSWORD: 'app pwd 1234',
+    ...overrides,
+  };
+}
+
+describe('seedFromEnvIfMissing — happy path (Issue #34)', () => {
+  it('writes a v2 apppassword entry when wp-sites.json does not exist', async () => {
+    const dir = freshTmpDir();
+    const configPath = path.join(dir, 'wp-sites.json');
+    const store = new MemorySecretStore();
+
+    const result = await seedFromEnvIfMissing(configPath, defaultEnv(), { secretStore: store });
+    assert.equal(result.seeded, true);
+    assert.equal(result.siteId, 'wickedevolutions');
+    assert.equal(result.configPath, configPath);
+
+    // File exists, parses, and the v2 entry is shaped per F.5.
+    const written = readConfig(configPath);
+    assert.equal(written.schema_version, SCHEMA_VERSION);
+    assert.equal(written.defaultSite, 'wickedevolutions');
+    const site = written.sites.wickedevolutions;
+    assert.equal(site.url, 'https://wickedevolutions.com');
+    assert.equal(site.label, 'wickedevolutions.com');
+    assert.equal(site.transport, 'http');
+    assert.equal(site.http.endpoint, 'https://wickedevolutions.com/wp-json/mcp/mcp-adapter-default-server');
+    assert.equal(site.http.username, 'wicked');
+    assert.equal(site.http.password_ref, `keychain://${SECRET_SERVICE}/wickedevolutions/apppassword`);
+    assert.equal(site.auth.method, 'apppassword');
+    assert.equal(site.auth.username, 'wicked');
+    assert.equal(site.auth.password_ref, `keychain://${SECRET_SERVICE}/wickedevolutions/apppassword`);
+    assert.equal(site.auth_status, 'active');
+  });
+
+  it('the password is in the keychain at the documented account path', async () => {
+    const dir = freshTmpDir();
+    const configPath = path.join(dir, 'wp-sites.json');
+    const store = new MemorySecretStore();
+
+    await seedFromEnvIfMissing(configPath, defaultEnv(), { secretStore: store });
+
+    const stored = await store.get(SECRET_SERVICE, 'wickedevolutions/apppassword');
+    assert.equal(stored, 'app pwd 1234');
+  });
+
+  it('seeded entry passes schema-v2 validate()', async () => {
+    const dir = freshTmpDir();
+    const configPath = path.join(dir, 'wp-sites.json');
+    const store = new MemorySecretStore();
+
+    await seedFromEnvIfMissing(configPath, defaultEnv(), { secretStore: store });
+
+    const written = readConfig(configPath);
+    const v = validate(written);
+    assert.equal(v.ok, true, v.ok ? '' : v.errors.join('\n'));
+  });
+
+  it('seeded entry passes the bridge runtime validateSiteConfig (apppassword/http branch)', async () => {
+    const dir = freshTmpDir();
+    const configPath = path.join(dir, 'wp-sites.json');
+    const store = new MemorySecretStore();
+
+    await seedFromEnvIfMissing(configPath, defaultEnv(), { secretStore: store });
+
+    const written = readConfig(configPath);
+    const site = written.sites.wickedevolutions;
+    // Should not throw.
+    await validateSiteConfig('wickedevolutions', site);
+  });
+});
+
+describe('seedFromEnvIfMissing — guards', () => {
+  it('is a no-op when wp-sites.json already exists', async () => {
+    const dir = freshTmpDir();
+    const configPath = path.join(dir, 'wp-sites.json');
+    fs.writeFileSync(configPath, '{"schema_version":2,"defaultSite":"x","sites":{"x":{}}}', { mode: 0o600 });
+    const store = new MemorySecretStore();
+
+    const before = fs.readFileSync(configPath, 'utf8');
+    const result = await seedFromEnvIfMissing(configPath, defaultEnv(), { secretStore: store });
+    const after = fs.readFileSync(configPath, 'utf8');
+
+    assert.equal(result.seeded, false);
+    assert.equal(result.reason, 'exists');
+    assert.equal(before, after, 'pre-existing wp-sites.json must not be overwritten');
+    // No keychain write either — operator may already manage their own.
+    const found = await store.get(SECRET_SERVICE, 'wickedevolutions/apppassword');
+    assert.equal(found, null);
+  });
+
+  it('skips seeding when keytar is unavailable (graceful degradation)', async () => {
+    const dir = freshTmpDir();
+    const configPath = path.join(dir, 'wp-sites.json');
+
+    // Stub a SecretStore whose isAvailable resolves false — mimics a .mcpb
+    // bundle that somehow shipped without the bundled keytar binary, or a
+    // CLI install on a platform where keytar's native build failed.
+    const fakeStore = {
+      isAvailable: async () => false,
+      set: async () => { throw new Error('should not be called'); },
+      get: async () => null,
+      delete: async () => false,
+    };
+
+    const result = await seedFromEnvIfMissing(configPath, defaultEnv(), { secretStore: fakeStore });
+    assert.equal(result.seeded, false);
+    assert.equal(result.reason, 'keytar-unavailable');
+    assert.equal(fs.existsSync(configPath), false, 'no file written when keychain is unavailable');
+  });
+
+  it('skips seeding when env vars are missing', async () => {
+    const dir = freshTmpDir();
+    const configPath = path.join(dir, 'wp-sites.json');
+    const store = new MemorySecretStore();
+
+    const cases = [
+      {},
+      { ABILITIES_MCP_URL: 'https://x.com' },
+      { ABILITIES_MCP_URL: 'https://x.com', ABILITIES_MCP_USERNAME: 'u' },
+      { ABILITIES_MCP_USERNAME: 'u', ABILITIES_MCP_PASSWORD: 'p' },
+    ];
+    for (const env of cases) {
+      const result = await seedFromEnvIfMissing(configPath, env, { secretStore: store });
+      assert.equal(result.seeded, false);
+      assert.equal(result.reason, 'missing-env-vars');
+    }
+    assert.equal(fs.existsSync(configPath), false);
+  });
+
+  it('skips seeding when ABILITIES_MCP_URL is malformed', async () => {
+    const dir = freshTmpDir();
+    const configPath = path.join(dir, 'wp-sites.json');
+    const store = new MemorySecretStore();
+
+    const result = await seedFromEnvIfMissing(
+      configPath,
+      defaultEnv({ ABILITIES_MCP_URL: 'not-a-valid-url' }),
+      { secretStore: store }
+    );
+    assert.equal(result.seeded, false);
+    assert.equal(result.reason, 'invalid-url');
+    assert.equal(fs.existsSync(configPath), false);
+  });
+
+  it('rolls back the keychain write when the file write fails', async () => {
+    const dir = freshTmpDir();
+    // Plant a regular file at the parent component so mkdir -p / atomicWrite
+    // fails with ENOTDIR portably across macOS / Linux / Windows.
+    const blocker = path.join(dir, 'not-a-dir');
+    fs.writeFileSync(blocker, 'I am a regular file', { mode: 0o644 });
+    const configPath = path.join(blocker, 'wp-sites.json');
+    const store = new MemorySecretStore();
+
+    const result = await seedFromEnvIfMissing(configPath, defaultEnv(), { secretStore: store });
+    assert.equal(result.seeded, false);
+    assert.equal(result.reason, 'error');
+    assert.ok(result.error instanceof Error);
+    // Keychain entry was rolled back — no orphan secret.
+    const found = await store.get(SECRET_SERVICE, 'wickedevolutions/apppassword');
+    assert.equal(found, null);
+  });
+});
+
+describe('deriveSiteId', () => {
+  it('strips the TLD off a hostname', () => {
+    assert.equal(deriveSiteId('https://wickedevolutions.com'), 'wickedevolutions');
+    assert.equal(deriveSiteId('https://helenawillow.com'), 'helenawillow');
+  });
+
+  it('strips a leading www.', () => {
+    assert.equal(deriveSiteId('https://www.example.com'), 'example');
+  });
+
+  it('returns the hostname when there is no dot', () => {
+    assert.equal(deriveSiteId('https://localhost'), 'localhost');
+  });
+
+  it('returns null for unparseable URLs', () => {
+    assert.equal(deriveSiteId('not-a-url'), null);
+    assert.equal(deriveSiteId(''), null);
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #34 — Phase C of the [v1.5.2 sprint](https://github.com/Wicked-Evolutions/abilities-mcp/milestone/2). Final bridge change in the sprint. Closes the docs/CLI mismatch the v1.5.0 Release notes Install section opened: with this PR, **`abilities-mcp upgrade-auth <site-id>`** finally works against a `.mcpb`-installed site, completing the documented operator progression (install `.mcpb` → `upgrade-auth` migrates in place → `add-site` adds more, all on the same Claude Desktop entry).
- New `seedFromEnvIfMissing(configPath, env, deps)` in [`lib/cli/config-store.js`](https://github.com/Wicked-Evolutions/abilities-mcp/blob/main/lib/cli/config-store.js). Writes a v2 apppassword entry to `~/.abilities-mcp/wp-sites.json` from `ABILITIES_MCP_URL`/`USERNAME`/`PASSWORD` when the file doesn't yet exist. Pre-existing wp-sites.json is **never overwritten**.
- Wired into [`lib/config.js`](https://github.com/Wicked-Evolutions/abilities-mcp/blob/main/lib/config.js)'s env-var branch as a lazy require — SSH-only, explicit-config, and legacy-CLI install paths never load the keychain modules.
- Reuses `_atomicWrite`, `makeRef`, `KeychainSecretStore.isAvailable` per the locked fix shape in #34's body. No new architectural surface.

## What lands

- v2 apppassword entry shape mirrors `config-migration._convertSite` (the v1→v2 migration path), so the seeded site passes both the lighter schema-v2 validator AND the bridge's runtime `validateSiteConfig` (apppassword/http branch from #26):
  ```json
  {
    "url": "https://wickedevolutions.com",
    "label": "wickedevolutions.com",
    "transport": "http",
    "http": {
      "endpoint": "https://wickedevolutions.com/wp-json/mcp/mcp-adapter-default-server",
      "username": "wicked",
      "password_ref": "keychain://abilities-mcp/wickedevolutions/apppassword"
    },
    "auth": {
      "method": "apppassword",
      "username": "wicked",
      "password_ref": "keychain://abilities-mcp/wickedevolutions/apppassword"
    },
    "auth_status": "active"
  }
  ```
- Site-id derived via the same `deriveSiteId` rule `add-site` uses (host with TLD stripped + leading `www.` stripped). Hostname → site-id parity means an operator who later runs `add-site https://wickedevolutions.com` would collide with the seeded entry under the same site-id (the file-absence guard + `add-site`'s own `--force` semantics handle this naturally).
- `loadConfig` env-var branch on a fresh `.mcpb` install: seeds the file, then `loadConfigFile(homeConfig, 'home-dir')` so the bridge runs against the freshly-seeded file in the same boot — the runtime path is identical to a normal restart against an existing home-dir config. The `Config source:` line from #32 will report `[home-dir]` instead of `ABILITIES_MCP_URL env var` after the seed, which gives operators a visible signal that seeding happened.

## Test plan

- [x] `npm test` — **265/265 green** (was 252 baseline; +13 new tests in `test/cli/seed-from-env.test.js`).
- [x] **Happy path**: writes v2 apppassword entry, password lands at `keychain://abilities-mcp/<siteId>/apppassword`, entry passes both `schema-v2.validate()` and the bridge runtime `validateSiteConfig`.
- [x] **File-absence guard**: pre-existing `wp-sites.json` is never overwritten (byte-for-byte assertion); no keychain write either when skipped.
- [x] **Graceful degradation**: skips seeding when `KeychainSecretStore.isAvailable()` returns false (stubbed). Bridge falls back to env-var-only mode; bundle keeps working.
- [x] **Missing env vars**: 4 partial-env sub-cases (none / URL only / URL+USERNAME / USERNAME+PASSWORD) all return `{ seeded: false, reason: 'missing-env-vars' }` — no file written.
- [x] **Malformed URL**: returns `{ seeded: false, reason: 'invalid-url' }`.
- [x] **Rollback on file-write failure**: forced ENOTDIR via planted regular file at parent component (portable across macOS/Linux/Windows). Result: file write fails, keychain entry rolled back via `secretStore.delete`, no orphan secret.
- [x] **`deriveSiteId` edge cases**: hostname → site-id stripping, leading `www.` removal, no-dot host (localhost), unparseable URL → null.
- [x] Smoke ran end-to-end (`seedFromEnvIfMissing` → `loadConfig` reads the seeded file): seed result `{ seeded: true, siteId: 'wickedevolutions' }` confirmed; `loadConfig` falls through to script-adjacent on this dev machine (precedence test #32 documents) so the home-dir fallthrough wasn't exercised here, but the unit tests cover the seed function exhaustively and `loadConfig`'s wiring is one branch with a single function call.

## Deviations

1. **Lazy `_seedFromEnvIfMissing` wrapper inside `lib/config.js`** rather than a top-level require. Issue body said "invoked from the env-var branch" — implementation does invoke from there, but loads the CLI config-store module on demand so SSH-only, explicit-config, and legacy-CLI install paths never pay the keytar / config-migration import cost. Mirrors the existing lazy `KeychainSecretStore` require pattern in `resolveSitePassword`.

2. **`validateSiteConfig` exported from `lib/config.js`.** Issue body didn't address test surface; the seeded-entry-passes-runtime-validator test reaches into `validateSiteConfig` directly. Function was already pure; the export is additive (no other change to its semantics) and avoids a test-only shim file under `test/`.

3. **Keychain rollback on file-write failure.** Issue body didn't mention rollback, but seeding's two side effects (keychain `set` + file write) need atomic semantics: if step 2 fails, step 1's orphan secret would accumulate on every subsequent boot retry. Catch the file-write error, `await secretStore.delete(...)` best-effort, return `{ seeded: false, reason: 'error' }`. Tested portably via planted-file ENOTDIR.

4. **`deriveSiteId` function duplicated from `lib/cli/commands/add-site.js`** rather than imported. add-site's copy is local-private (`function deriveSiteId(...)` not exported). Mirroring the rule in config-store keeps the contract local to where seeding happens; both copies are 8 lines and identical. Future cleanup could promote one to a shared util — out of scope for #34 per workflow law (no scope creep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)