### PR TITLE
fix(.mcpb): darwin security-CLI fallback for hardened-runtime keytar rejection (#39)

### DIFF
--- a/lib/auth/keychain-secret-store.js
+++ b/lib/auth/keychain-secret-store.js
@@ -1,16 +1,36 @@
 'use strict';
 
+const { execFile } = require('node:child_process');
+
 const { SecretStoreError } = require('./errors');
 
 /**
- * KeychainSecretStore — keytar-backed SecretStore.
+ * KeychainSecretStore — keytar-backed SecretStore with a darwin-only
+ * `security` CLI fallback for Claude Desktop's hardened-runtime barrier.
  *
- * keytar wraps macOS Keychain, Windows Credential Manager, and Linux libsecret.
- * It is declared as an `optionalDependency` so a failed native build does not
- * break `npm install` for env-var-only operators. If keytar is unavailable at
- * runtime, every method on this store throws `SecretStoreError` with code
- * `keytar_unavailable` — callers can detect that and fall back to a different
- * store (e.g. MemorySecretStore for tests, or surface to the user).
+ * keytar wraps macOS Keychain, Windows Credential Manager, and Linux libsecret
+ * via a native binding (`build/Release/keytar.node`). It is declared as an
+ * `optionalDependency` so a failed native build does not break `npm install`
+ * for env-var-only operators.
+ *
+ * **The darwin fallback (issue #39).** When the bundled keytar binary fails
+ * to dlopen inside Claude Desktop's hardened-runtime process — the macOS
+ * code-signing rejects native binaries with mismatched Team IDs, Anthropic-
+ * signed Claude Desktop refuses to load npm-distribution-signed keytar.node —
+ * we fall back to shelling out to the macOS `security` CLI via
+ * `child_process.execFile`. `security` is always installed on macOS, doesn't
+ * require dynamic native loading, operates against the same macOS Keychain,
+ * and runs as a child process out from under Claude Desktop's hardened-
+ * runtime restrictions. The fallback fires only on darwin; on linux/win32 a
+ * keytar load failure still throws `keytar_unavailable` (current behavior).
+ *
+ * Outside the .mcpb path — system Node, CLI install, npx, source clone —
+ * keytar loads normally and the fallback never engages.
+ *
+ * If keytar is unavailable at runtime AND the darwin fallback also can't run,
+ * every method throws `SecretStoreError` with code `keytar_unavailable` —
+ * callers can detect that and fall back to a different store (e.g.
+ * MemorySecretStore for tests, or surface to the user).
  *
  * Implements the SecretStore interface defined in `secret-store.js`.
  *
@@ -21,38 +41,67 @@ const { SecretStoreError } = require('./errors');
 class KeychainSecretStore {
   /**
    * @param {object} [opts]
-   * @param {object} [opts.keytar]  Inject a keytar module — primarily for tests.
-   *                                When omitted, keytar is required lazily on
-   *                                first use.
+   * @param {object} [opts.keytar]         Inject a keytar module — primarily for tests.
+   *                                       When omitted, keytar is required lazily on
+   *                                       first use.
+   * @param {Function} [opts.requireKeytar] Override the require call used to load
+   *                                       keytar. Test seam: pass a function that
+   *                                       throws to simulate the .mcpb-path dlopen
+   *                                       rejection without breaking the real
+   *                                       require('keytar') in the test runtime.
+   * @param {string} [opts.platform]       Override `process.platform` for the
+   *                                       fallback-eligibility decision. Test seam.
+   * @param {Function} [opts.exec]         Override `child_process.execFile`. Test
+   *                                       seam for the security-CLI fallback path.
    */
   constructor(opts = {}) {
     this._injected = opts.keytar || null;
     this._keytar = null;
     this._loadAttempted = false;
     this._loadError = null;
+    this._fallbackMode = null; // null | 'security-cli'
+
+    this._requireKeytar = opts.requireKeytar || ((id) => require(id));
+    this._platform = opts.platform || process.platform;
+    this._exec = opts.exec || execFile;
   }
 
+  /**
+   * Lazy load. Sets one of three terminal states:
+   *  - `this._keytar` populated (keytar loaded normally; primary path)
+   *  - `this._fallbackMode === 'security-cli'` (darwin fallback engaged)
+   *  - `this._loadError` set + throws (non-darwin keytar failure)
+   */
   _load() {
-    if (this._keytar) return this._keytar;
+    if (this._keytar || this._fallbackMode) {
+      return;
+    }
     if (this._loadAttempted) {
-      if (this._loadError) {
-        throw new SecretStoreError(
-          `OS keychain unavailable: ${this._loadError.message}`,
-          { code: 'keytar_unavailable', cause: this._loadError }
-        );
-      }
-      return this._keytar;
+      // Previously failed and we cached the error.
+      throw new SecretStoreError(
+        `OS keychain unavailable: ${this._loadError.message}`,
+        { code: 'keytar_unavailable', cause: this._loadError }
+      );
     }
     this._loadAttempted = true;
+
     if (this._injected) {
       this._keytar = this._injected;
-      return this._keytar;
+      return;
     }
+
     try {
-      // eslint-disable-next-line global-require
-      this._keytar = require('keytar');
-      return this._keytar;
+      this._keytar = this._requireKeytar('keytar');
+      return;
     } catch (err) {
+      // darwin: Claude Desktop's hardened-runtime rejects bundled keytar.node
+      // with a Team ID mismatch (issue #39). Fall back to the `security` CLI
+      // rather than throwing — the bridge keeps working against the same
+      // macOS Keychain, just via shell-out.
+      if (this._platform === 'darwin') {
+        this._fallbackMode = 'security-cli';
+        return;
+      }
       this._loadError = err;
       throw new SecretStoreError(
         `OS keychain unavailable: ${err.message}`,
@@ -61,7 +110,10 @@ class KeychainSecretStore {
     }
   }
 
-  /** @returns {Promise<boolean>} true if keytar can be loaded on this host. */
+  /**
+   * @returns {Promise<boolean>} true if keytar can be loaded on this host OR
+   *                             the darwin security-CLI fallback is engaged.
+   */
   async isAvailable() {
     try {
       this._load();
@@ -72,27 +124,142 @@ class KeychainSecretStore {
   }
 
   async get(service, account) {
-    const keytar = this._load();
-    return keytar.getPassword(service, account);
+    this._load();
+    if (this._fallbackMode === 'security-cli') {
+      return this._securityGet(service, account);
+    }
+    return this._keytar.getPassword(service, account);
   }
 
   async set(service, account, secret) {
     if (typeof secret !== 'string') {
       throw new TypeError('SecretStore.set: secret must be a string');
     }
-    const keytar = this._load();
-    await keytar.setPassword(service, account, secret);
+    this._load();
+    if (this._fallbackMode === 'security-cli') {
+      return this._securitySet(service, account, secret);
+    }
+    await this._keytar.setPassword(service, account, secret);
   }
 
   async delete(service, account) {
-    const keytar = this._load();
-    return keytar.deletePassword(service, account);
+    this._load();
+    if (this._fallbackMode === 'security-cli') {
+      return this._securityDelete(service, account);
+    }
+    return this._keytar.deletePassword(service, account);
   }
 
   async findAll(service) {
-    const keytar = this._load();
-    return keytar.findCredentials(service);
+    this._load();
+    if (this._fallbackMode === 'security-cli') {
+      // The macOS `security` CLI has no clean enumerate-by-service mode.
+      // Returning [] here is safe because the bridge runtime path never
+      // calls findAll — only the CLI subcommand `list-sites` does, and that
+      // runs in system Node where keytar loads normally and this branch
+      // is never taken. Documented in the issue body's "findAll" note.
+      return [];
+    }
+    return this._keytar.findCredentials(service);
   }
+
+  // ---------------------------------------------------------------------
+  // darwin `security` CLI fallback — internal helpers.
+  // ---------------------------------------------------------------------
+
+  /**
+   * Run the `security` CLI with the given args. Returns { stdout, stderr }
+   * on success, rejects with an error carrying `.stderr` / `.stdout` /
+   * `.code` (exit code) on failure. Uses `execFile` (not `exec`) so args
+   * are not shell-interpreted — the password / account / service strings
+   * pass through verbatim, no shell injection surface.
+   */
+  _execSecurity(args) {
+    return new Promise((resolve, reject) => {
+      this._exec('security', args, {}, (err, stdout, stderr) => {
+        const stdoutStr = typeof stdout === 'string'
+          ? stdout
+          : (stdout ? stdout.toString() : '');
+        const stderrStr = typeof stderr === 'string'
+          ? stderr
+          : (stderr ? stderr.toString() : '');
+        if (err) {
+          // Real child_process.execFile populates err.stderr / err.stdout
+          // and ALSO passes them as cb args. Preserve whichever the caller
+          // already attached (some test doubles attach to the err object
+          // and don't pass via cb args); fall back to the cb args otherwise.
+          if (typeof err.stderr !== 'string') err.stderr = stderrStr;
+          if (typeof err.stdout !== 'string') err.stdout = stdoutStr;
+          return reject(err);
+        }
+        resolve({ stdout: stdoutStr, stderr: stderrStr });
+      });
+    });
+  }
+
+  async _securityGet(service, account) {
+    try {
+      const { stdout } = await this._execSecurity([
+        'find-generic-password', '-s', service, '-a', account, '-w',
+      ]);
+      // -w prints just the password to stdout, terminated by a newline.
+      return stdout.replace(/\n$/, '');
+    } catch (err) {
+      if (_isNotFound(err)) return null;
+      throw new SecretStoreError(
+        `security find-generic-password failed: ${(err.stderr || err.message || '').trim()}`,
+        { code: 'security_cli_failed', cause: err }
+      );
+    }
+  }
+
+  async _securitySet(service, account, secret) {
+    // -U updates the existing entry if present, adds it otherwise.
+    // Note: passing the password as the last argv element is the standard
+    // pattern for non-interactive `security` use; the macOS `security` CLI
+    // exposes no stdin-only password input mode for non-interactive callers.
+    // This is the same trade-off keytar's own native binding makes — the
+    // password lives in process memory until the syscall completes.
+    try {
+      await this._execSecurity([
+        'add-generic-password', '-U', '-s', service, '-a', account, '-w', secret,
+      ]);
+    } catch (err) {
+      throw new SecretStoreError(
+        `security add-generic-password failed: ${(err.stderr || err.message || '').trim()}`,
+        { code: 'security_cli_failed', cause: err }
+      );
+    }
+  }
+
+  async _securityDelete(service, account) {
+    try {
+      await this._execSecurity([
+        'delete-generic-password', '-s', service, '-a', account,
+      ]);
+      return true;
+    } catch (err) {
+      if (_isNotFound(err)) return false;
+      throw new SecretStoreError(
+        `security delete-generic-password failed: ${(err.stderr || err.message || '').trim()}`,
+        { code: 'security_cli_failed', cause: err }
+      );
+    }
+  }
+}
+
+/**
+ * Detect the macOS `security` CLI's "entry not found" condition. Stderr from
+ * `find-generic-password` / `delete-generic-password` against a missing entry
+ * looks like:
+ *   security: SecKeychainSearchCopyNext: The specified item could not be
+ *   found in the keychain.
+ * Match on the substring "could not be found" (case-insensitive) to map it
+ * to keytar's null/false return semantics.
+ */
+function _isNotFound(err) {
+  const stderr = (err && err.stderr) || '';
+  return /could not be found/i.test(stderr);
 }
 
 module.exports = { KeychainSecretStore };

--- a/test/auth/keychain-secret-store-darwin-fallback.test.js
+++ b/test/auth/keychain-secret-store-darwin-fallback.test.js
@@ -1,0 +1,256 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { KeychainSecretStore } = require('../../lib/auth/keychain-secret-store');
+
+/**
+ * Issue #39 — darwin security-CLI fallback.
+ *
+ * macOS's hardened-runtime rejects bundled keytar.node inside Claude Desktop
+ * with a Team ID mismatch. The store detects this at `_load()` time and falls
+ * back to the macOS `security` CLI via `child_process.execFile`. Tests cover:
+ *
+ *  - Keytar-success path is preserved on every platform (existing tests in
+ *    `secret-store.test.js` cover the basic round-trip; this file adds
+ *    fallback-specific coverage).
+ *  - On darwin, when `require('keytar')` throws (simulated via the
+ *    `requireKeytar` injection seam), the store enters fallback mode and
+ *    dispatches get/set/delete to a mocked `execFile`.
+ *  - The "could not be found" stderr from `security` maps to keytar's
+ *    null (get) / false (delete) return semantics.
+ *  - Other stderr propagates as `SecretStoreError` with code
+ *    `security_cli_failed`.
+ *  - `isAvailable()` returns true in both keytar and fallback modes.
+ *  - On linux/win32, a keytar load failure still throws `keytar_unavailable`
+ *    (no fallback engaged — the security CLI is darwin-only).
+ *  - `findAll` returns [] in fallback mode.
+ */
+
+/**
+ * Build a fake `child_process.execFile`-shaped function backed by an
+ * in-memory keychain. Captures all calls for assertion.
+ */
+function fakeSecurityExec(seed = {}) {
+  const store = new Map(Object.entries(seed));
+  const calls = [];
+
+  function exec(file, args, opts, cb) {
+    calls.push({ file, args: args.slice(), opts });
+
+    if (file !== 'security') {
+      return cb(Object.assign(new Error('unexpected exec'), {
+        code: 1,
+        stderr: 'unexpected exec',
+      }));
+    }
+
+    const sub = args[0];
+    const sIdx = args.indexOf('-s');
+    const aIdx = args.indexOf('-a');
+    const wIdx = args.indexOf('-w');
+    const service = sIdx >= 0 ? args[sIdx + 1] : null;
+    const account = aIdx >= 0 ? args[aIdx + 1] : null;
+    const key = `${service}|${account}`;
+
+    if (sub === 'find-generic-password') {
+      // -w with a value would be at wIdx+1; -w as the last arg means "print
+      // password only, no surrounding metadata."
+      if (!store.has(key)) {
+        return cb(Object.assign(new Error('exit 44'), {
+          code: 44,
+          stderr: 'security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.\n',
+          stdout: '',
+        }));
+      }
+      return cb(null, `${store.get(key)}\n`, '');
+    }
+
+    if (sub === 'add-generic-password') {
+      // -U updates if exists, adds otherwise. Password is wIdx+1.
+      const password = wIdx >= 0 ? args[wIdx + 1] : '';
+      store.set(key, password);
+      return cb(null, '', '');
+    }
+
+    if (sub === 'delete-generic-password') {
+      if (!store.has(key)) {
+        return cb(Object.assign(new Error('exit 44'), {
+          code: 44,
+          stderr: 'security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.\n',
+          stdout: '',
+        }));
+      }
+      store.delete(key);
+      return cb(null, '', '');
+    }
+
+    return cb(Object.assign(new Error(`unknown subcommand ${sub}`), {
+      code: 1, stderr: `unknown subcommand ${sub}`,
+    }));
+  }
+
+  return { exec, store, calls };
+}
+
+const REJECT_KEYTAR = () => {
+  throw new Error("dlopen(keytar.node, 0x0001): code signature in mapping process and mapped file (non-platform) have different Team IDs");
+};
+
+describe('KeychainSecretStore — darwin security-CLI fallback (#39)', () => {
+  it('falls back to security-CLI on darwin when keytar require fails', async () => {
+    const harness = fakeSecurityExec();
+    const store = new KeychainSecretStore({
+      requireKeytar: REJECT_KEYTAR,
+      platform: 'darwin',
+      exec: harness.exec,
+    });
+    assert.equal(await store.isAvailable(), true);
+  });
+
+  it('round-trips set/get/delete via security CLI in fallback mode', async () => {
+    const harness = fakeSecurityExec();
+    const store = new KeychainSecretStore({
+      requireKeytar: REJECT_KEYTAR,
+      platform: 'darwin',
+      exec: harness.exec,
+    });
+
+    await store.set('abilities-mcp', 'siteA/access', 'AT-12345');
+    assert.equal(await store.get('abilities-mcp', 'siteA/access'), 'AT-12345');
+    assert.equal(await store.delete('abilities-mcp', 'siteA/access'), true);
+    assert.equal(await store.get('abilities-mcp', 'siteA/access'), null);
+  });
+
+  it('get returns null when the security CLI reports "could not be found"', async () => {
+    const harness = fakeSecurityExec();
+    const store = new KeychainSecretStore({
+      requireKeytar: REJECT_KEYTAR,
+      platform: 'darwin',
+      exec: harness.exec,
+    });
+    assert.equal(await store.get('abilities-mcp', 'missing/account'), null);
+  });
+
+  it('delete returns false when the security CLI reports "could not be found"', async () => {
+    const harness = fakeSecurityExec();
+    const store = new KeychainSecretStore({
+      requireKeytar: REJECT_KEYTAR,
+      platform: 'darwin',
+      exec: harness.exec,
+    });
+    assert.equal(await store.delete('abilities-mcp', 'missing/account'), false);
+  });
+
+  it('propagates unexpected security-CLI errors as SecretStoreError code=security_cli_failed', async () => {
+    function brokenExec(file, args, opts, cb) {
+      cb(Object.assign(new Error('exit 1'), {
+        code: 1,
+        stderr: 'security: some other failure happened\n',
+        stdout: '',
+      }));
+    }
+    const store = new KeychainSecretStore({
+      requireKeytar: REJECT_KEYTAR,
+      platform: 'darwin',
+      exec: brokenExec,
+    });
+    await assert.rejects(
+      store.get('abilities-mcp', 'siteA/access'),
+      (err) => err && err.code === 'security_cli_failed'
+        && /security find-generic-password failed/.test(err.message)
+    );
+    await assert.rejects(
+      store.set('abilities-mcp', 'siteA/access', 'pw'),
+      (err) => err && err.code === 'security_cli_failed'
+        && /security add-generic-password failed/.test(err.message)
+    );
+    await assert.rejects(
+      store.delete('abilities-mcp', 'siteA/access'),
+      (err) => err && err.code === 'security_cli_failed'
+        && /security delete-generic-password failed/.test(err.message)
+    );
+  });
+
+  it('findAll returns [] in fallback mode (security CLI has no enumerate-by-service)', async () => {
+    const harness = fakeSecurityExec({
+      'abilities-mcp|siteA/access': 'AT',
+      'abilities-mcp|siteA/refresh': 'RT',
+    });
+    const store = new KeychainSecretStore({
+      requireKeytar: REJECT_KEYTAR,
+      platform: 'darwin',
+      exec: harness.exec,
+    });
+    assert.deepEqual(await store.findAll('abilities-mcp'), []);
+  });
+
+  it('passes service/account/password through execFile args verbatim (no shell interpretation)', async () => {
+    const harness = fakeSecurityExec();
+    const store = new KeychainSecretStore({
+      requireKeytar: REJECT_KEYTAR,
+      platform: 'darwin',
+      exec: harness.exec,
+    });
+    // Password contains shell metachars that would explode under exec().
+    const trickyPassword = 'p$wd "with" `dangerous` chars; rm -rf /';
+    await store.set('abilities-mcp', 'siteX/apppassword', trickyPassword);
+    assert.equal(await store.get('abilities-mcp', 'siteX/apppassword'), trickyPassword);
+
+    // Verify the execFile call carried the password as a separate argv element,
+    // not concatenated into a shell string.
+    const setCall = harness.calls.find((c) => c.args[0] === 'add-generic-password');
+    const wIdx = setCall.args.indexOf('-w');
+    assert.equal(setCall.args[wIdx + 1], trickyPassword);
+  });
+
+  it('on darwin, when keytar IS available, fallback is NOT engaged', async () => {
+    function fakeKeytar() {
+      const map = new Map();
+      return {
+        async getPassword(s, a) { return map.has(`${s}|${a}`) ? map.get(`${s}|${a}`) : null; },
+        async setPassword(s, a, v) { map.set(`${s}|${a}`, v); },
+        async deletePassword(s, a) { return map.delete(`${s}|${a}`); },
+        async findCredentials() { return [{ account: 'sentinel', password: 'x' }]; },
+      };
+    }
+    let execCalls = 0;
+    const trapExec = () => { execCalls += 1; };
+    const store = new KeychainSecretStore({
+      keytar: fakeKeytar(),
+      platform: 'darwin',
+      exec: trapExec,
+    });
+    await store.set('abilities-mcp', 'siteA/access', 'AT');
+    assert.equal(await store.get('abilities-mcp', 'siteA/access'), 'AT');
+    const found = await store.findAll('abilities-mcp');
+    assert.deepEqual(found, [{ account: 'sentinel', password: 'x' }]);
+    assert.equal(execCalls, 0, 'security CLI must not be called when keytar loads normally');
+  });
+});
+
+describe('KeychainSecretStore — non-darwin keytar failure still throws (#39)', () => {
+  for (const platform of ['linux', 'win32']) {
+    it(`on ${platform}, keytar load failure throws keytar_unavailable (no fallback)`, async () => {
+      const store = new KeychainSecretStore({
+        requireKeytar: REJECT_KEYTAR,
+        platform,
+        exec: () => { throw new Error('exec must not be called'); },
+      });
+      assert.equal(await store.isAvailable(), false);
+      await assert.rejects(
+        store.get('abilities-mcp', 'siteA/access'),
+        (err) => err && err.code === 'keytar_unavailable'
+      );
+      await assert.rejects(
+        store.set('abilities-mcp', 'siteA/access', 'pw'),
+        (err) => err && err.code === 'keytar_unavailable'
+      );
+      await assert.rejects(
+        store.delete('abilities-mcp', 'siteA/access'),
+        (err) => err && err.code === 'keytar_unavailable'
+      );
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- Closes #39 — hotfix off `main` for the post-v1.5.2-release macOS blocker. The v1.5.2 `.mcpb` ships keytar prebuilds for darwin/win32/linux but Claude Desktop's hardened-runtime rejects the bundled `keytar.node` on macOS with a Team ID mismatch (Anthropic-signed Claude Desktop process refuses to load npm-distribution-signed keytar). Validated end-to-end via hot patch on the affected user's machine before this PR.
- `KeychainSecretStore._load()` now falls back to the macOS `security` CLI via `child_process.execFile` when `require('keytar')` throws **on darwin**. Other platforms are untouched — keytar is still the primary path everywhere; the fallback engages only when keytar's native dlopen actually fails.
- All v1.5.2 install paths preserved: system Node CLI install, npx, source clone, .mcpb env-var-only mode (App Password without ever touching keychain) — the fallback only fires when keychain access is actually needed AND keytar can't be required.

## Test plan

- [x] `npm test` — **275/275 green** (was 265 baseline; +10 new tests in `test/auth/keychain-secret-store-darwin-fallback.test.js`).
- [x] **Darwin fallback path**:
  - Fallback engages when `require('keytar')` throws on darwin (`requireKeytar` injection seam simulates the .mcpb dlopen rejection without touching the real require).
  - `isAvailable()` returns true in both keytar mode and fallback mode.
  - set/get/delete round-trip via mocked `execFile` invoking `security {find,add,delete}-generic-password`.
  - `get` returns `null` and `delete` returns `false` when stderr matches `/could not be found/i` (mirrors keytar's null-on-missing / false-on-already-gone semantics).
  - Other stderr propagates as `SecretStoreError` code `security_cli_failed` for find/add/delete error paths.
  - `findAll` returns `[]` in fallback mode (security CLI has no clean enumerate-by-service; bridge runtime path never calls findAll, only CLI `list-sites` does and that runs in system Node).
  - Password containing shell metacharacters (`p$wd "with" \`dangerous\` chars; rm -rf /`) round-trips through `execFile` argv verbatim — pins the no-shell-injection property.
  - Darwin keytar-success path: when keytar IS available, fallback is NOT engaged; security CLI is never called.
- [x] **Non-darwin (linux + win32)**: keytar load failure still throws `keytar_unavailable`. No fallback engaged. Existing contract preserved.
- [x] **Real-world smoke against the macOS `security` CLI** (non-mocked, on the host darwin-arm64):
  ```
  isAvailable: true
  get (before set): null
  set: OK
  get (after set): MATCHES
  delete (existing): true
  get (after delete): null
  delete (already gone): false
  findAll (fallback): []
  SMOKE PASS
  ```
  Confirms my implementation matches the actual macOS `security` CLI's contract (not just my fake), with the same null/true/false return semantics keytar provides.

## Research — Linux + Windows behavior inside Claude Desktop's `.mcpb` runtime

Both platforms are **unverified — require operator-side or follow-up validation** before any non-darwin fallback ships.

### Linux

- I do not have access to a Linux Claude Desktop install on this dev machine, so the empirical test of "does keytar's libsecret native binding load cleanly inside Linux Claude Desktop's `.mcpb` runtime?" is not runnable from here.
- **What's knowable:** Linux apps don't have macOS-style hardened runtime / Team ID matching. The libsecret-backed `.node` binding loads via standard `dlopen`. The most likely failure mode is **not** the same as macOS — it would be either (a) keytar prebuild absent for the operator's libc/glibc (we ship `linux-x64`, broadly compatible), or (b) `libsecret-1.so.0` missing on the host (keytar links to libsecret at runtime; on systems without `libsecret-1` installed via the package manager, operations would fail at the underlying call rather than at `require`).
- **What's unverified:** whether Claude Desktop on Linux is packaged in a way that sandboxes the bridge subprocess (snap/AppImage confinement, flatpak portals) and whether such confinement could block `dlopen` of the bundled binary in a way analogous to macOS hardened runtime. Plausible but unconfirmed.
- **Suggested operator test:** install the upcoming `.mcpb` from a clean Linux Claude Desktop, follow the documented `add-site` progression, observe whether OAuth-required calls succeed or surface `keytar_unavailable`. If they fail, file a follow-up issue with the platform and stderr — the fallback shape for Linux would likely shell out to `secret-tool` (libsecret CLI) on systems that have it, with a documented "install `libsecret-tools`" step otherwise.

### Windows

- Likewise, no Windows Claude Desktop access on this dev machine.
- **What's knowable:** Windows doesn't have macOS-style hardened runtime. Claude Desktop on Windows is (per public docs) a regular desktop process, not UWP/AppContainer-isolated, so native module loading is generally permitted. keytar's `win32-x64` prebuild talks to Windows Credential Manager via the `wincred` API (standard NAPI addon).
- **What's unverified:** whether Claude Desktop's process on Windows imposes any additional code-signing or AppLocker restrictions that would block `dlopen` analogous to macOS Team ID matching. No public evidence either way; my prior is "probably loads cleanly" based on Windows's looser-by-default native-module policy, but this is not empirical.
- **Why I'm not implementing a Windows fallback in this PR**: per dispatch (`Do not implement a Windows fallback in this PR if it requires a fix shape we haven't validated`). If keytar fails to load on Windows Claude Desktop, the fix shape needs research first — Windows Credential Manager has no clean CLI for arbitrary secret storage that's analogous to macOS `security`. Options would be:
  1. PowerShell `New-StoredCredential` / `Get-StoredCredential` from the `CredentialManager` PowerShell module — but that module is not built into Windows; requires `Install-Module CredentialManager`, which most users won't have done.
  2. PowerShell DPAPI for file-encrypted secrets — but that's a different store (file-based DPAPI), not Windows Credential Manager, and would diverge the bridge's storage location across platforms.
  3. Bundle a different native library — same hardened-runtime / code-signing concern as keytar would have hit.
  4. Limit Windows operators to Path B (manual MCP server entry pointing at a CLI install via `abilities-mcp --register`) or Path C (pure CLI/IDE/Docker), as documented in the operator-facing install paths section J recently added to the Knowledge Layer docs.
- **Suggested operator test:** install the upcoming `.mcpb` from a clean Windows Claude Desktop, follow the documented `add-site` progression, observe outcome. If `keytar_unavailable` surfaces, file a follow-up with the platform/stderr/exit context and we research the Windows fallback shape with empirical evidence in hand.

## Deviations

1. **Test seams added to the constructor.** `opts.requireKeytar` (override the `require` call), `opts.platform` (override `process.platform`), `opts.exec` (override `child_process.execFile`). All three default to production behavior; required for unit-testing the fallback path without breaking the test runtime's real `require('keytar')`. Issue body didn't prescribe test seams; this is the standard NAPI-binding test pattern.

2. **`_isNotFound` matches stderr substring case-insensitively.** Issue body said `"Could not be found" stderr maps to keytar's null/false return semantics`. The actual macOS stderr capitalization is `could not be found` (lowercase) per the `SecKeychainSearchCopyNext` error. Used `/could not be found/i` to match either casing — defensive.

3. **`_execSecurity` is defensive about which side of the cb the stderr lives on.** Real `child_process.execFile` populates `err.stderr` AND passes stderr as the third cb arg. Some test doubles only attach to `err`; some only pass via cb args. Code preserves whichever the caller set. Nine extra lines, no behavior change for production callers.

4. **`opts.exec` defaults to the imported `execFile` rather than `require('child_process').execFile` at call time.** Module-load-time import; minor but makes the seam observable to debuggers and avoids re-importing on every call.

5. **No test changes to `test/auth/secret-store.test.js`.** The existing `KeychainSecretStore (with stub)` block uses `opts.keytar` injection, which is unchanged. Existing tests still pass without modification — verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)