### PR TITLE
feat(add-site): auto-populate multisite block on Multisite Network root

### DIFF
--- a/lib/cli/commands/add-site.js
+++ b/lib/cli/commands/add-site.js
@@ -12,6 +12,7 @@ const { makeRef } = require('../../auth/secret-store');
 const { CliError, EXIT_USAGE, EXIT_CONFIG, fromAuthError } = require('../errors');
 const { subscribeProgress } = require('../output');
 const { readConfig, writeConfig, freshConfig } = require('../config-store');
+const { probeMultisite: defaultProbeMultisite } = require('../multisite-probe');
 
 /**
  * `add-site <url>` — register a new site with the bridge using OAuth (default)
@@ -108,6 +109,7 @@ async function run(args, ctx) {
   }
 
   const out = [];
+  const errLines = [];
   let exitCode = 0;
 
   if (args.apppassword) {
@@ -139,7 +141,7 @@ async function run(args, ctx) {
     await writeConfig(ctx.configPath, config);
     out.push(`✓ Site "${siteId}" configured with App Password authentication.`);
     out.push(`  Config: ${ctx.configPath}`);
-    return { exitCode, lines: out };
+    return { exitCode, lines: out, errLines };
   }
 
   // OAuth path — full authorization-code + PKCE flow via OAuthClient.
@@ -199,12 +201,69 @@ async function run(args, ctx) {
   if (result.prMetadata && result.prMetadata.resource) {
     config.sites[siteId].mcp_resource = result.prMetadata.resource;
   }
+
+  // Multisite Network root probe. If the freshly authenticated bridge can
+  // resolve `multisite/list-sites`, populate the multisite block so dot-
+  // notation routing works without operator JSON editing. Single-site,
+  // permission-denied, and network errors all degrade gracefully — the
+  // site entry is still written without a multisite block.
+  const probeEndpoint = result.prMetadata && result.prMetadata.resource;
+  if (probeEndpoint && result.tokens && result.tokens.access_token) {
+    const probe = (ctx.deps && ctx.deps.probeMultisite) || defaultProbeMultisite;
+    try {
+      const probeResult = await probe({
+        endpoint: probeEndpoint,
+        accessToken: result.tokens.access_token,
+        siteUrl: parsedUrl.origin,
+        log: typeof ctx.log === 'function' ? ctx.log : null,
+        deps: ctx.deps && ctx.deps.probeMultisiteDeps,
+      });
+      if (probeResult && probeResult.block && Object.keys(probeResult.block).length > 0) {
+        config.sites[siteId].multisite = probeResult.block;
+        const slugs = Object.keys(probeResult.block).join(', ');
+        out.push(`  Multisite: discovered ${Object.keys(probeResult.block).length} subsite(s) → ${slugs}`);
+      }
+    } catch (probeErr) {
+      _appendProbeAdvisory(probeErr, siteId, errLines);
+    }
+  }
+
   if (!config.defaultSite) config.defaultSite = siteId;
   await writeConfig(ctx.configPath, config);
 
   out.push(`✓ Site "${siteId}" configured. Granted scopes: ${result.scopes.join(', ')}.`);
   out.push(`  Config: ${ctx.configPath}`);
-  return { exitCode, lines: out };
+  return { exitCode, lines: out, errLines };
+}
+
+/**
+ * Append a stderr advisory naming the multisite-probe failure so operators
+ * who expected dot-notation routing know why it isn't wired and can either
+ * fix the underlying issue or hand-add the block per existing docs.
+ *
+ * Silent for `tool_not_registered` (single-site is the expected case for
+ * the vast majority of `add-site` invocations).
+ */
+function _appendProbeAdvisory(probeErr, siteId, errLines) {
+  const code = probeErr && probeErr.code;
+  if (code === 'tool_not_registered') return;
+
+  if (code === 'permission_denied' || code === 'unauthorized') {
+    errLines.push(
+      `Multisite discovery skipped for "${siteId}": insufficient capability ` +
+      `(multisite/list-sites requires manage_network_options on the OAuth user). ` +
+      `Site entry written without multisite block — dot-notation subsite routing ` +
+      `will not be available until the block is added manually.`
+    );
+    return;
+  }
+
+  const detail = (probeErr && probeErr.message) || String(probeErr);
+  errLines.push(
+    `Multisite discovery failed for "${siteId}": ${detail}. ` +
+    `Site entry written without multisite block — dot-notation subsite routing ` +
+    `will not be available until the block is added manually or add-site is re-run.`
+  );
 }
 
 /**

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -100,7 +100,12 @@ async function runCommand(opts) {
     const lines = preLines.length
       ? preLines.concat(r.lines || [])
       : (r.lines || []);
-    return { exitCode: r.exitCode || EXIT_OK, lines, errLines: [] };
+    // Commands may return non-fatal advisories alongside a success exit
+    // code (e.g. add-site emits one when the multisite-discovery probe
+    // degrades gracefully). Surface them on stderr without changing
+    // exit semantics.
+    const errLines = Array.isArray(r.errLines) ? r.errLines : [];
+    return { exitCode: r.exitCode || EXIT_OK, lines, errLines };
   } catch (err) {
     const cliErr = err instanceof CliError ? err : fromAuthError(err);
     const errLines = renderNextAction(cliErr);

--- a/lib/cli/multisite-probe.js
+++ b/lib/cli/multisite-probe.js
@@ -1,0 +1,392 @@
+'use strict';
+
+const https = require('node:https');
+const http = require('node:http');
+const { URL } = require('node:url');
+
+/**
+ * Multisite Network root probe for `abilities-mcp add-site`.
+ *
+ * After OAuth completes, call `multisite/list-sites` against the freshly
+ * authenticated bridge connection. If the URL points to a Multisite Network
+ * root, build the `multisite` block (slug → subsite-URL map) the bridge's
+ * dot-notation routing already expects (see `lib/config.js:resolveSiteKey`,
+ * `lib/connection-pool.js:_findExistingHttpTransport`). If the URL is a
+ * single-site install, the OAuth user lacks `manage_network_options`, or the
+ * call fails for any other reason, the probe returns null / a structured
+ * error so `add-site` can degrade gracefully without writing the block.
+ *
+ * Schema (verified against routing read paths):
+ *   site.multisite = { [slug]: subsiteUrlString }
+ *
+ * Copyright (C) 2026 Influencentricity | Wicked Evolutions
+ * @license GPL-2.0-or-later
+ */
+
+const PROBE_PROTOCOL_VERSION = '2025-06-18';
+const PROBE_PER_PAGE = 100;
+const PROBE_TIMEOUT_MS = 30000;
+
+/**
+ * @typedef {object} ProbeResult
+ * @property {object|null} block      Multisite block, or null when no block
+ *                                    should be written (single-site / empty).
+ * @property {string} reason          One of: 'multisite-root', 'single-site',
+ *                                    'tool-not-registered', 'empty-list'.
+ */
+
+/**
+ * @param {object} opts
+ * @param {string} opts.endpoint      MCP resource URL (from prMetadata.resource).
+ * @param {string} opts.accessToken   Freshly minted OAuth access token.
+ * @param {string} opts.siteUrl       Parent network-root URL (parsedUrl.origin).
+ * @param {function} [opts.log]       Logger.
+ * @param {object} [opts.deps]
+ * @param {function} [opts.deps.request]  Inject for tests; replaces the inline
+ *                                        bearer JSON-RPC client. Receives the
+ *                                        full message and resolves the parsed
+ *                                        JSON-RPC response (or rejects with a
+ *                                        structured error).
+ * @returns {Promise<ProbeResult>}
+ */
+async function probeMultisite(opts) {
+  const { endpoint, accessToken, siteUrl, log } = opts;
+  const logger = typeof log === 'function' ? log : function noop() {};
+
+  if (!endpoint) {
+    const e = new Error('multisite probe: no MCP endpoint available');
+    e.code = 'no_endpoint';
+    throw e;
+  }
+  if (!accessToken) {
+    const e = new Error('multisite probe: no access token available');
+    e.code = 'no_access_token';
+    throw e;
+  }
+
+  const client = (opts.deps && opts.deps.request)
+    ? new InjectedClient(opts.deps.request)
+    : new BearerJsonRpcClient(endpoint, accessToken, logger);
+
+  await client.initialize();
+  const toolResp = await client.callTool('multisite/list-sites', { per_page: PROBE_PER_PAGE });
+  const payload = parseToolResponse(toolResp);
+  const items = extractSites(payload);
+
+  if (items === null) {
+    return { block: null, reason: 'empty-list' };
+  }
+  if (items.length === 0) {
+    return { block: null, reason: 'empty-list' };
+  }
+  if (items.length === 1) {
+    // Only the network root came back — treat as single-site for routing
+    // purposes. Operators can still call `multisite/*` abilities at the
+    // network level; dot-notation routing isn't useful with no subsites.
+    return { block: null, reason: 'single-site' };
+  }
+
+  const block = buildMultisiteBlock(siteUrl, items);
+  if (!block || Object.keys(block).length === 0) {
+    return { block: null, reason: 'empty-list' };
+  }
+  return { block, reason: 'multisite-root' };
+}
+
+/**
+ * Build the multisite block (slug → subsite URL) from a `multisite/list-sites`
+ * response. Pure function — no I/O, no logging. Exported so `add-site.js`
+ * tests can verify the schema-mapping logic in isolation.
+ */
+function buildMultisiteBlock(parentSiteUrl, items) {
+  let parentHost;
+  try { parentHost = new URL(parentSiteUrl).hostname.toLowerCase().replace(/^www\./, ''); }
+  catch { return null; }
+
+  const block = {};
+  const used = new Set();
+  for (const item of items) {
+    if (!item || typeof item.url !== 'string' || item.url.length === 0) continue;
+    const baseSlug = deriveSubsiteSlug(parentHost, item);
+    if (!baseSlug) continue;
+    const slug = uniqueSlug(baseSlug, used, item);
+    used.add(slug);
+    block[slug] = item.url;
+  }
+  return block;
+}
+
+/**
+ * Map a `multisite/list-sites` item to a slug usable for dot-notation
+ * routing. Subdomain mode → first label of the subdomain. Path mode →
+ * first segment of the path. Network root → 'main'. Mapped-domain
+ * subsites → first label of the domain.
+ */
+function deriveSubsiteSlug(parentHost, item) {
+  const itemDomain = String(item.domain || '').toLowerCase().replace(/^www\./, '');
+  const itemPath = String(item.path || '/').replace(/^\/+|\/+$/g, '');
+
+  if (itemDomain === parentHost) {
+    return itemPath === '' ? 'main' : itemPath.split('/')[0];
+  }
+  if (itemDomain.endsWith('.' + parentHost)) {
+    const prefix = itemDomain.slice(0, itemDomain.length - parentHost.length - 1);
+    const first = prefix.split('.')[0];
+    return first || null;
+  }
+  // Mapped / different domain — fall back to first label
+  const first = itemDomain.split('.')[0];
+  return first || null;
+}
+
+function uniqueSlug(base, used, item) {
+  if (!used.has(base)) return base;
+  // Disambiguate with blog_id when slugs collide (e.g. two subsites whose
+  // first path segments match). Never silently overwrite a previously
+  // mapped subsite.
+  const blogId = item && item.blog_id;
+  if (blogId !== undefined && blogId !== null) {
+    const candidate = `${base}-${blogId}`;
+    if (!used.has(candidate)) return candidate;
+  }
+  let n = 2;
+  while (used.has(`${base}-${n}`)) n += 1;
+  return `${base}-${n}`;
+}
+
+function parseToolResponse(resp) {
+  if (resp && resp.error) {
+    const e = new Error(resp.error.message || 'JSON-RPC error');
+    e.code = mapJsonRpcErrorCode(resp.error.code, resp.error.message);
+    e.jsonrpcCode = resp.error.code;
+    throw e;
+  }
+  const result = resp && resp.result;
+  if (!result) {
+    const e = new Error('multisite/list-sites: empty result');
+    e.code = 'empty_result';
+    throw e;
+  }
+  const content = Array.isArray(result.content) ? result.content : [];
+  const first = content[0];
+  let payload = null;
+  if (first && first.type === 'text' && typeof first.text === 'string') {
+    try { payload = JSON.parse(first.text); }
+    catch { payload = { _raw: first.text }; }
+  }
+
+  if (result.isError) {
+    const errMsg = (payload && (payload.error || payload._raw))
+      || (first && first.text)
+      || 'tool error';
+    const errCode = (payload && payload.error_code) || 'tool_error';
+    const e = new Error(errMsg);
+    e.code = mapAbilityErrorCode(errCode, errMsg);
+    e.abilityCode = errCode;
+    e.data = payload && payload.error_data;
+    throw e;
+  }
+
+  return payload || result;
+}
+
+function extractSites(payload) {
+  if (!payload || typeof payload !== 'object') return null;
+  if (Array.isArray(payload.sites)) return payload.sites;
+  if (payload.data && Array.isArray(payload.data.sites)) return payload.data.sites;
+  return null;
+}
+
+function mapJsonRpcErrorCode(code, message) {
+  // -32601 = Method not found → tool not registered (single-site install)
+  if (code === -32601) return 'tool_not_registered';
+  if (typeof message === 'string' && /unknown\s+tool/i.test(message)) return 'tool_not_registered';
+  return 'jsonrpc_error';
+}
+
+function mapAbilityErrorCode(abilityCode, message) {
+  const code = String(abilityCode || '').toLowerCase();
+  if (code === 'rest_forbidden_context'
+      || code === 'rest_forbidden'
+      || code === 'permission_denied'
+      || code === 'forbidden_context'
+      || code.indexOf('forbidden') !== -1) {
+    return 'permission_denied';
+  }
+  if (code === 'rest_no_route' || code === 'not_multisite') {
+    return 'tool_not_registered';
+  }
+  if (typeof message === 'string' && /manage_network_options|insufficient.*capabilit|forbidden/i.test(message)) {
+    return 'permission_denied';
+  }
+  return 'tool_error';
+}
+
+// ---------------------------------------------------------------------------
+// Bearer JSON-RPC client — minimal MCP handshake + tools/call over HTTP.
+// Distinct from OAuthHttpTransport: this runs once during add-site with a
+// fresh in-memory access token, so it skips TokenManager + queue/batch.
+// ---------------------------------------------------------------------------
+
+class BearerJsonRpcClient {
+  constructor(endpoint, accessToken, log) {
+    this.url = new URL(endpoint);
+    this.accessToken = accessToken;
+    this.log = log;
+    this.module = this.url.protocol === 'https:' ? https : http;
+    this.sessionId = null;
+    this.cookies = new Map();
+    this._idCounter = 1;
+  }
+
+  async initialize() {
+    const initResp = await this._post({
+      jsonrpc: '2.0',
+      id: this._idCounter++,
+      method: 'initialize',
+      params: {
+        protocolVersion: PROBE_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: 'abilities-mcp-add-site', version: '1.5.4' },
+      },
+    });
+    if (initResp && initResp.error) {
+      const e = new Error(initResp.error.message || 'initialize failed');
+      e.code = 'initialize_failed';
+      e.jsonrpcCode = initResp.error.code;
+      throw e;
+    }
+    await this._post({
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+    });
+  }
+
+  callTool(name, args) {
+    return this._post({
+      jsonrpc: '2.0',
+      id: this._idCounter++,
+      method: 'tools/call',
+      params: { name, arguments: args || {} },
+    });
+  }
+
+  _post(message) {
+    return new Promise((resolve, reject) => {
+      const body = JSON.stringify(message);
+      const headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+        'Authorization': `Bearer ${this.accessToken}`,
+        'Content-Length': Buffer.byteLength(body),
+      };
+      if (this.sessionId) headers['Mcp-Session-Id'] = this.sessionId;
+      if (this.cookies.size > 0) {
+        headers['Cookie'] = Array.from(this.cookies.entries())
+          .map(([k, v]) => `${k}=${v}`).join('; ');
+      }
+
+      const req = this.module.request({
+        hostname: this.url.hostname,
+        port: this.url.port || (this.url.protocol === 'https:' ? 443 : 80),
+        path: this.url.pathname + this.url.search,
+        method: 'POST',
+        headers,
+      }, (res) => {
+        const chunks = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => {
+          const newSession = res.headers['mcp-session-id'];
+          if (newSession) this.sessionId = newSession;
+          const setCookie = res.headers['set-cookie'];
+          if (setCookie) {
+            const list = Array.isArray(setCookie) ? setCookie : [setCookie];
+            for (const raw of list) {
+              const nv = raw.split(';')[0].trim();
+              const eq = nv.indexOf('=');
+              if (eq > 0) this.cookies.set(nv.slice(0, eq), nv.slice(eq + 1));
+            }
+          }
+          if (res.statusCode === 401) {
+            const e = new Error('multisite probe: HTTP 401 (token rejected)');
+            e.code = 'unauthorized';
+            return reject(e);
+          }
+          if (res.statusCode === 403) {
+            const e = new Error('multisite probe: HTTP 403 (forbidden)');
+            e.code = 'permission_denied';
+            return reject(e);
+          }
+          const text = Buffer.concat(chunks).toString('utf8');
+          if (!text.trim()) return resolve(null);
+          let parsed;
+          try { parsed = JSON.parse(text); }
+          catch (err) {
+            const e = new Error(`multisite probe: response parse error: ${err.message}`);
+            e.code = 'parse_error';
+            return reject(e);
+          }
+          // Tolerate single-element JSON-RPC batch responses (some servers
+          // wrap a single response in an array).
+          if (Array.isArray(parsed) && parsed.length === 1) parsed = parsed[0];
+          resolve(parsed);
+        });
+      });
+
+      req.setTimeout(PROBE_TIMEOUT_MS, () => {
+        req.destroy(new Error('multisite probe: request timeout'));
+      });
+      req.on('error', (err) => {
+        const e = new Error(`multisite probe: ${err.message}`);
+        e.code = 'network_error';
+        e.cause = err;
+        reject(e);
+      });
+      req.write(body);
+      req.end();
+    });
+  }
+}
+
+/**
+ * Test injection seam — wraps a function `(message) => Promise<jsonrpcResp>`
+ * and presents the same surface (`initialize`, `callTool`) the inline client
+ * does so the probe code path is identical.
+ */
+class InjectedClient {
+  constructor(requestFn) {
+    this._request = requestFn;
+    this._idCounter = 1;
+  }
+  async initialize() {
+    const resp = await this._request({
+      jsonrpc: '2.0',
+      id: this._idCounter++,
+      method: 'initialize',
+      params: { protocolVersion: PROBE_PROTOCOL_VERSION, capabilities: {} },
+    });
+    if (resp && resp.error) {
+      const e = new Error(resp.error.message || 'initialize failed');
+      e.code = 'initialize_failed';
+      e.jsonrpcCode = resp.error.code;
+      throw e;
+    }
+    await this._request({ jsonrpc: '2.0', method: 'notifications/initialized' });
+  }
+  callTool(name, args) {
+    return this._request({
+      jsonrpc: '2.0',
+      id: this._idCounter++,
+      method: 'tools/call',
+      params: { name, arguments: args || {} },
+    });
+  }
+}
+
+module.exports = {
+  probeMultisite,
+  buildMultisiteBlock,
+  deriveSubsiteSlug,
+  parseToolResponse,
+  PROBE_PROTOCOL_VERSION,
+};

--- a/test/cli/add-site.test.js
+++ b/test/cli/add-site.test.js
@@ -6,6 +6,10 @@ const assert = require('node:assert/strict');
 const { MockAuthServer } = require('../auth/helpers/mock-auth-server');
 const { makeHarness, autoConsentDeps } = require('./helpers/cli-harness');
 const { deriveSiteId } = require('../../lib/cli/commands/add-site');
+const {
+  buildMultisiteBlock,
+  deriveSubsiteSlug,
+} = require('../../lib/cli/multisite-probe');
 const { SCHEMA_VERSION } = require('../../lib/auth/schema-v2');
 
 describe('CLI add-site', () => {
@@ -141,6 +145,230 @@ describe('CLI add-site', () => {
       const r = await h.runCli('add-site', []);
       assert.equal(r.exitCode, 2);
       assert.match(r.errLines.join('\n'), /requires a site URL/);
+    });
+  });
+
+  describe('multisite auto-populate (Issue #43)', () => {
+    let server;
+    let h;
+    before(async () => { server = await new MockAuthServer().start(); });
+    after(async () => { await server.stop(); });
+    afterEach(() => { if (h) h.cleanup(); });
+
+    function makeHarnessWithProbe(probeStub) {
+      return makeHarness({
+        deps: {
+          oauthClientDeps: autoConsentDeps(),
+          probeMultisite: probeStub,
+        },
+      });
+    }
+
+    it('writes multisite block when probe finds subsites (happy path)', async () => {
+      const block = {
+        main: 'https://network.example.com',
+        community: 'https://community.network.example.com',
+        knowledge: 'https://knowledge.network.example.com',
+        test1: 'https://test1.network.example.com',
+      };
+      let probeArgs = null;
+      h = makeHarnessWithProbe(async (args) => {
+        probeArgs = args;
+        return { block, reason: 'multisite-root' };
+      });
+
+      const r = await h.runCli('add-site', [server.siteUrl, '--site-id=ms']);
+      assert.equal(r.exitCode, 0, r.errLines.join('\n'));
+      assert.equal(r.errLines.length, 0,
+        `unexpected advisory: ${r.errLines.join('\n')}`);
+
+      const cfg = h.readConfig();
+      assert.deepEqual(cfg.sites.ms.multisite, block);
+      assert.match(r.lines.join('\n'), /Multisite: discovered 4 subsite/);
+
+      // Probe was called with the freshly-minted access token + MCP endpoint.
+      assert.ok(probeArgs, 'probe should have been invoked');
+      assert.ok(probeArgs.endpoint, 'probe should receive MCP endpoint');
+      assert.ok(probeArgs.accessToken, 'probe should receive access token');
+      assert.equal(probeArgs.siteUrl, server.siteUrl);
+    });
+
+    it('writes site without multisite block on single-site install', async () => {
+      h = makeHarnessWithProbe(async () => ({ block: null, reason: 'single-site' }));
+
+      const r = await h.runCli('add-site', [server.siteUrl, '--site-id=single']);
+      assert.equal(r.exitCode, 0, r.errLines.join('\n'));
+      assert.equal(r.errLines.length, 0,
+        'single-site path must degrade silently — no advisory expected');
+
+      const cfg = h.readConfig();
+      assert.equal(cfg.sites.single.multisite, undefined,
+        'no multisite block should be written for single-site installs');
+      // OAuth fields still written — single-site behavior is byte-identical
+      // to pre-probe behavior.
+      assert.equal(cfg.sites.single.auth.method, 'oauth');
+    });
+
+    it('writes site without multisite block on tool-not-registered (silent)', async () => {
+      // Same shape as single-site, but reaches add-site via a thrown
+      // tool_not_registered code (e.g. multisite-abilities.php returned
+      // before registering the ability because is_multisite() === false).
+      h = makeHarnessWithProbe(async () => {
+        const e = new Error('Method not found');
+        e.code = 'tool_not_registered';
+        throw e;
+      });
+
+      const r = await h.runCli('add-site', [server.siteUrl, '--site-id=notreg']);
+      assert.equal(r.exitCode, 0, r.errLines.join('\n'));
+      assert.equal(r.errLines.length, 0,
+        'tool_not_registered must degrade silently — no advisory expected');
+
+      const cfg = h.readConfig();
+      assert.equal(cfg.sites.notreg.multisite, undefined);
+    });
+
+    it('writes site without multisite block + advisory on permission-denied', async () => {
+      h = makeHarnessWithProbe(async () => {
+        const e = new Error('multisite probe: HTTP 403 (forbidden)');
+        e.code = 'permission_denied';
+        throw e;
+      });
+
+      const r = await h.runCli('add-site', [server.siteUrl, '--site-id=permd']);
+      assert.equal(r.exitCode, 0,
+        `expected success exit despite permission-denied probe: ${r.errLines.join('\n')}`);
+
+      const cfg = h.readConfig();
+      assert.equal(cfg.sites.permd.multisite, undefined,
+        'no multisite block should be written when capability is missing');
+      assert.equal(cfg.sites.permd.auth.method, 'oauth',
+        'OAuth site entry must still be written');
+
+      const advisory = r.errLines.join('\n');
+      assert.match(advisory, /Multisite discovery skipped/);
+      assert.match(advisory, /manage_network_options/);
+      assert.match(advisory, /permd/);
+    });
+
+    it('writes site without multisite block + advisory on probe error', async () => {
+      h = makeHarnessWithProbe(async () => {
+        const e = new Error('connect ETIMEDOUT 192.0.2.1:443');
+        e.code = 'network_error';
+        throw e;
+      });
+
+      const r = await h.runCli('add-site', [server.siteUrl, '--site-id=neterr']);
+      assert.equal(r.exitCode, 0,
+        `expected success exit despite probe network error: ${r.errLines.join('\n')}`);
+
+      const cfg = h.readConfig();
+      assert.equal(cfg.sites.neterr.multisite, undefined,
+        'no multisite block should be written on transient probe failure');
+
+      const advisory = r.errLines.join('\n');
+      assert.match(advisory, /Multisite discovery failed/);
+      assert.match(advisory, /ETIMEDOUT/);
+      assert.match(advisory, /neterr/);
+    });
+  });
+
+  describe('multisite block schema mapping', () => {
+    // Schema verified against lib/config.js:resolveSiteKey (reads
+    // site.multisite[slug] as a URL string) and lib/connection-pool.js
+    // (treats it identically). buildMultisiteBlock must produce that shape.
+
+    it('maps subdomain-mode subsites to first-label slugs', () => {
+      const items = [
+        { blog_id: 1, domain: 'wickedevolutions.com', path: '/', url: 'https://wickedevolutions.com' },
+        { blog_id: 2, domain: 'community.wickedevolutions.com', path: '/', url: 'https://community.wickedevolutions.com' },
+        { blog_id: 3, domain: 'knowledge.wickedevolutions.com', path: '/', url: 'https://knowledge.wickedevolutions.com' },
+        { blog_id: 4, domain: 'test1.wickedevolutions.com', path: '/', url: 'https://test1.wickedevolutions.com' },
+      ];
+      const block = buildMultisiteBlock('https://wickedevolutions.com', items);
+      assert.deepEqual(block, {
+        main: 'https://wickedevolutions.com',
+        community: 'https://community.wickedevolutions.com',
+        knowledge: 'https://knowledge.wickedevolutions.com',
+        test1: 'https://test1.wickedevolutions.com',
+      });
+    });
+
+    it('maps path-mode subsites to first-segment slugs', () => {
+      const items = [
+        { blog_id: 1, domain: 'example.com', path: '/', url: 'https://example.com' },
+        { blog_id: 2, domain: 'example.com', path: '/blog2/', url: 'https://example.com/blog2' },
+        { blog_id: 3, domain: 'example.com', path: '/store/', url: 'https://example.com/store' },
+      ];
+      const block = buildMultisiteBlock('https://example.com', items);
+      assert.deepEqual(block, {
+        main: 'https://example.com',
+        blog2: 'https://example.com/blog2',
+        store: 'https://example.com/store',
+      });
+    });
+
+    it('disambiguates colliding slugs by blog_id', () => {
+      // Pathological case: subdomain + path mode mixed where two sites
+      // would resolve to the same first-label slug. Block must preserve
+      // both entries by appending blog_id.
+      const items = [
+        { blog_id: 1, domain: 'example.com', path: '/', url: 'https://example.com' },
+        { blog_id: 2, domain: 'shop.example.com', path: '/', url: 'https://shop.example.com' },
+        { blog_id: 3, domain: 'shop.example.com', path: '/', url: 'https://shop.example.com/alt' },
+      ];
+      const block = buildMultisiteBlock('https://example.com', items);
+      assert.equal(block.main, 'https://example.com');
+      assert.equal(block.shop, 'https://shop.example.com');
+      assert.equal(block['shop-3'], 'https://shop.example.com/alt');
+    });
+
+    it('strips www. from parent host before deriving slugs', () => {
+      const items = [
+        { blog_id: 1, domain: 'example.com', path: '/', url: 'https://example.com' },
+        { blog_id: 2, domain: 'community.example.com', path: '/', url: 'https://community.example.com' },
+      ];
+      const block = buildMultisiteBlock('https://www.example.com', items);
+      assert.equal(block.main, 'https://example.com');
+      assert.equal(block.community, 'https://community.example.com');
+    });
+
+    it('skips items missing a URL', () => {
+      const items = [
+        { blog_id: 1, domain: 'example.com', path: '/', url: 'https://example.com' },
+        { blog_id: 2, domain: 'community.example.com', path: '/' },
+      ];
+      const block = buildMultisiteBlock('https://example.com', items);
+      assert.equal(Object.keys(block).length, 1);
+      assert.equal(block.main, 'https://example.com');
+    });
+
+    it('deriveSubsiteSlug returns "main" for the network root', () => {
+      assert.equal(
+        deriveSubsiteSlug('example.com',
+          { domain: 'example.com', path: '/' }),
+        'main');
+    });
+
+    it('deriveSubsiteSlug returns first label for subdomain subsites', () => {
+      assert.equal(
+        deriveSubsiteSlug('example.com',
+          { domain: 'community.example.com', path: '/' }),
+        'community');
+    });
+
+    it('deriveSubsiteSlug returns first segment for path subsites', () => {
+      assert.equal(
+        deriveSubsiteSlug('example.com',
+          { domain: 'example.com', path: '/blog2/' }),
+        'blog2');
+    });
+
+    it('deriveSubsiteSlug returns first label for mapped-domain subsites', () => {
+      assert.equal(
+        deriveSubsiteSlug('example.com',
+          { domain: 'mapped.test', path: '/' }),
+        'mapped');
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #43.

After OAuth completes in `abilities-mcp add-site`, probe `multisite/list-sites` against the freshly authenticated bridge connection. When the URL points to a Multisite Network root, build the existing `multisite` block schema (slug → subsite-URL map) and attach it to the new site entry before writing `wp-sites.json` — so dot-notation subsite routing (`content/list site=root.community`) works on first restart of any AI client without operator JSON editing.

Single-site / non-multisite / permission-denied / network-error paths all degrade gracefully: the site entry is written without a multisite block (today's behavior, byte-identical for single-site installs), and a stderr advisory names the failure where the operator can act on it. Single-site is the expected case for the vast majority of `add-site` invocations, so it degrades silently — no advisory.

## What changed

- **`lib/cli/multisite-probe.js`** (new) — minimal MCP-handshake-then-`tools/call` JSON-RPC client that runs once with the freshly minted in-memory access token. Skips `TokenManager` + queue/batch (one-shot probe). Pure helpers `buildMultisiteBlock` and `deriveSubsiteSlug` exported for unit-testing the schema-mapping logic in isolation.
- **`lib/cli/commands/add-site.js`** — after `mcp_resource` is set, run the probe with graceful-degrade. Multisite block written only when the probe yields ≥2 sites. Advisory accumulated into a new local `errLines` array.
- **`lib/cli/index.js`** — extended the command-`run()` return contract to forward `r.errLines` from successful subcommand returns. Previously success paths could only push to stdout `lines`; failures threw `CliError` to populate `errLines`. Needed so a successful `add-site` can surface a non-fatal stderr advisory without changing exit semantics. The bin entrypoint already writes `errLines` to stderr (`abilities-mcp.js:62`); no other call sites needed updates.
- **`test/cli/add-site.test.js`** — five integration tests covering all four acceptance paths (multisite root, single-site, permission-denied with advisory + `manage_network_options` text, network error with advisory) plus an explicit `tool_not_registered` silent-degrade case. Nine pure-function tests covering the schema-mapping logic for subdomain mode, path-based mode, slug collision disambiguation, `www.` parent stripping, and missing-URL skip.

## Schema verification (per issue ask)

The bridge's existing dot-notation routing reads the multisite block as a flat `{ [slug]: subsiteUrlString }` map (verified at `lib/config.js:355` and `:384-385`, also `lib/connection-pool.js:_findExistingHttpTransport`). The `multisite/list-sites` ability response carries `domain`, `path`, and `url` per site — sufficient to derive both the slug (subdomain first-label / path first-segment / `main` for the network root) and the URL value. **No schema migration required, no schema gap to flag.**

The auto-populated block matches the operator's existing wickedevolutions config shape (4 subsites: `main`, `community`, `knowledge`, `test1`).

## Test plan

- [x] Multisite root happy path: probe stub returns 4 subsites → block written + slug list logged
- [x] Single-site path: probe returns `{ block: null, reason: 'single-site' }` → no block, no advisory
- [x] `tool_not_registered` (non-multisite WP install): silent degrade, no advisory
- [x] Permission denied: no block + advisory naming `manage_network_options`
- [x] Network error: no block + advisory naming the underlying failure
- [x] Schema-mapping unit tests: subdomain mode, path mode, slug collision, `www.` stripping, missing-URL skip
- [x] Full suite: all 289 existing tests pass; 14 new tests pass; total 303 / 303
- [ ] Operator validation against wickedevolutions multisite (post-merge, orchestrator-built bridge artifact)

## Deviations

**Run-contract extension (`lib/cli/index.js`).** Adding the probe required a way for a successful subcommand to emit a non-fatal stderr advisory. The existing contract only allowed `errLines` via thrown `CliError`. I extended `runCommand` to forward `r.errLines` from successful returns. The change is internal to the CLI surface (no public API), backwards compatible (subcommands that don't set `errLines` get the previous behavior — empty array), and verified by the existing 12 add-site tests still passing. Mentioning it here because it touches a file outside the issue's listed critical files.

**Slug-collision disambiguation.** The issue did not specify behavior when two subsites would map to the same first-label slug (rare — shop + shop.example.com on a domain-mapped network, etc.). I append `-{blog_id}` to the second occurrence to preserve both entries. Verified by an explicit test. If this conflicts with operator expectations the test pins it down for easy adjustment.

**No changes to dot-notation routing implementation.** Read-only reference, as the issue specified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)