### PR TITLE
fix(add-site): request abilities:multisite:read/write in DCR

### DIFF
--- a/lib/auth/oauth-client.js
+++ b/lib/auth/oauth-client.js
@@ -46,7 +46,17 @@ const {
  * @license GPL-2.0-or-later
  */
 
-const DEFAULT_SCOPE = 'abilities:read abilities:write';
+// `abilities:multisite:read` / `abilities:multisite:write` are SENSITIVE_SCOPES
+// in the adapter's ScopeRegistry (Auth/OAuth/ScopeRegistry.php) — never implied
+// by the `abilities:read` / `abilities:write` umbrella expansion. Requesting
+// them explicitly during DCR is the only way the consent screen can surface
+// them for super-admin operators on a Multisite Network root, which in turn
+// is the only way `add-site`'s post-OAuth multisite/list-sites probe (#43)
+// can fire end-to-end. Single-site WP installs accept the request — the
+// adapter simply won't grant scopes the OAuth user lacks WP capability for,
+// so single-site UX is preserved.
+const DEFAULT_SCOPE =
+  'abilities:read abilities:write abilities:multisite:read abilities:multisite:write';
 const DEFAULT_LOOPBACK_TIMEOUT_MS = 5 * 60_000;
 
 class OAuthClient extends EventEmitter {

--- a/lib/cli/commands/add-site.js
+++ b/lib/cli/commands/add-site.js
@@ -250,10 +250,14 @@ function _appendProbeAdvisory(probeErr, siteId, errLines) {
 
   if (code === 'permission_denied' || code === 'unauthorized') {
     errLines.push(
-      `Multisite discovery skipped for "${siteId}": insufficient capability ` +
-      `(multisite/list-sites requires manage_network_options on the OAuth user). ` +
+      `Multisite discovery skipped for "${siteId}": multisite/list-sites was rejected ` +
+      `by the adapter. Two possible causes — verify both before manually adding the block: ` +
+      `(1) the OAuth user lacks the manage_network_options WP capability (super-admin ` +
+      `required on a Multisite Network root), or (2) the OAuth token lacks the ` +
+      `abilities:multisite:read scope (it must be granted on the consent screen — ` +
+      `re-run add-site and confirm the multisite scope checkbox if it was unchecked). ` +
       `Site entry written without multisite block — dot-notation subsite routing ` +
-      `will not be available until the block is added manually.`
+      `will not be available until the block is added manually or add-site is re-run.`
     );
     return;
   }

--- a/test/cli/add-site.test.js
+++ b/test/cli/add-site.test.js
@@ -11,6 +11,7 @@ const {
   deriveSubsiteSlug,
 } = require('../../lib/cli/multisite-probe');
 const { SCHEMA_VERSION } = require('../../lib/auth/schema-v2');
+const { DEFAULT_SCOPE } = require('../../lib/auth/oauth-client');
 
 describe('CLI add-site', () => {
   describe('site-id derivation', () => {
@@ -247,7 +248,11 @@ describe('CLI add-site', () => {
 
       const advisory = r.errLines.join('\n');
       assert.match(advisory, /Multisite discovery skipped/);
+      // Advisory must surface BOTH possible causes (#45) — capability gate
+      // AND OAuth-scope gate — so operators don't chase the wrong one.
       assert.match(advisory, /manage_network_options/);
+      assert.match(advisory, /abilities:multisite:read/);
+      assert.match(advisory, /consent screen/);
       assert.match(advisory, /permd/);
     });
 
@@ -270,6 +275,131 @@ describe('CLI add-site', () => {
       assert.match(advisory, /Multisite discovery failed/);
       assert.match(advisory, /ETIMEDOUT/);
       assert.match(advisory, /neterr/);
+    });
+  });
+
+  describe('DCR multisite scope request (Issue #45)', () => {
+    let server;
+    let h;
+    before(async () => { server = await new MockAuthServer().start(); });
+    after(async () => { await server.stop(); });
+    afterEach(() => { if (h) h.cleanup(); });
+
+    it('DEFAULT_SCOPE includes the multisite scopes the probe needs', () => {
+      // Naming verified against adapter ScopeRegistry SENSITIVE_SCOPES
+      // (src/Auth/OAuth/ScopeRegistry.php:43-44). These scopes are excluded
+      // from the abilities:read / abilities:write umbrella expansion by
+      // design, so they must be requested explicitly during DCR.
+      assert.match(DEFAULT_SCOPE, /\babilities:read\b/);
+      assert.match(DEFAULT_SCOPE, /\babilities:write\b/);
+      assert.match(DEFAULT_SCOPE, /\babilities:multisite:read\b/);
+      assert.match(DEFAULT_SCOPE, /\babilities:multisite:write\b/);
+    });
+
+    it('add-site DCR registration includes the multisite scopes', async () => {
+      h = makeHarness({
+        deps: {
+          oauthClientDeps: autoConsentDeps(),
+          // Stub probe — we only care about DCR body for this test.
+          probeMultisite: async () => ({ block: null, reason: 'single-site' }),
+        },
+      });
+
+      const r = await h.runCli('add-site', [server.siteUrl, '--site-id=dcrscope']);
+      assert.equal(r.exitCode, 0, r.errLines.join('\n'));
+
+      // The mock records the DCR body keyed by issued client_id. The most
+      // recently issued client is this run's registration.
+      const issued = Array.from(server._issuedClients.values());
+      const dcrBody = issued[issued.length - 1].body;
+      assert.ok(dcrBody, 'DCR body should be recorded by mock');
+      assert.match(dcrBody.scope, /\babilities:multisite:read\b/,
+        'DCR scope must include abilities:multisite:read so consent can grant it');
+      assert.match(dcrBody.scope, /\babilities:multisite:write\b/,
+        'DCR scope must include abilities:multisite:write for symmetry');
+      // Existing umbrella scopes still requested.
+      assert.match(dcrBody.scope, /\babilities:read\b/);
+      assert.match(dcrBody.scope, /\babilities:write\b/);
+    });
+
+    it('granted multisite scope ends up in wp-sites.json after super-admin consent', async () => {
+      // Simulate a super-admin operator on a Multisite Network root: the
+      // adapter's consent screen surfaces the multisite scope and the
+      // operator grants it. The token endpoint reflects the grant in the
+      // `scope` field, which add-site persists to auth.scopes.
+      const grantedScope = 'abilities:read abilities:write abilities:multisite:read abilities:multisite:write';
+      const superAdminServer = await new MockAuthServer({
+        tokenJson: {
+          access_token: 'at-superadmin-test',
+          refresh_token: 'rt-superadmin-test',
+          token_type: 'Bearer',
+          expires_in: 3600,
+          scope: grantedScope,
+        },
+      }).start();
+      try {
+        h = makeHarness({
+          deps: {
+            oauthClientDeps: autoConsentDeps(),
+            // Stub probe — assertion is about persisted scopes, not the
+            // probe round-trip (which has its own dedicated tests).
+            probeMultisite: async () => ({
+              block: { main: superAdminServer.siteUrl },
+              reason: 'multisite-root',
+            }),
+          },
+        });
+
+        const r = await h.runCli('add-site', [
+          superAdminServer.siteUrl, '--site-id=superadmin',
+        ]);
+        assert.equal(r.exitCode, 0, r.errLines.join('\n'));
+
+        const cfg = h.readConfig();
+        const scopes = cfg.sites.superadmin.auth.scopes;
+        assert.ok(scopes.includes('abilities:multisite:read'),
+          `expected granted scopes to include abilities:multisite:read, got: ${scopes.join(', ')}`);
+        assert.ok(scopes.includes('abilities:multisite:write'),
+          `expected granted scopes to include abilities:multisite:write, got: ${scopes.join(', ')}`);
+      } finally {
+        await superAdminServer.stop();
+      }
+    });
+
+    it('single-site path: scopes requested but adapter grants only umbrella, no multisite block', async () => {
+      // Single-site WP: DCR includes the multisite scopes (we always
+      // request them now), but the adapter doesn't grant them because
+      // the OAuth user lacks WP capability — the mock token endpoint's
+      // default `scope` field does not include them. Site entry must
+      // still be written without a multisite block, exactly as before.
+      h = makeHarness({
+        deps: {
+          oauthClientDeps: autoConsentDeps(),
+          probeMultisite: async () => {
+            // Tool-not-registered mirrors what a non-multisite WP would
+            // return — multisite-abilities.php bails early when
+            // is_multisite() is false, so the ability isn't registered.
+            const e = new Error('Method not found');
+            e.code = 'tool_not_registered';
+            throw e;
+          },
+        },
+      });
+
+      const r = await h.runCli('add-site', [server.siteUrl, '--site-id=ss']);
+      assert.equal(r.exitCode, 0, r.errLines.join('\n'));
+      assert.equal(r.errLines.length, 0,
+        'single-site path must remain silent — no advisory expected');
+
+      const cfg = h.readConfig();
+      assert.equal(cfg.sites.ss.multisite, undefined,
+        'no multisite block on single-site install — graceful degrade preserved');
+      assert.equal(cfg.sites.ss.auth.method, 'oauth');
+
+      // DCR was still asked for the multisite scopes — the gate is server-side.
+      const issued = Array.from(server._issuedClients.values());
+      const dcrBody = issued[issued.length - 1].body;
+      assert.match(dcrBody.scope, /\babilities:multisite:read\b/);
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #45. Rides on top of #44 (already merged at bae5a8f) — both ship together as v1.5.4.

PR #44 added the post-OAuth `multisite/list-sites` probe that auto-populates the multisite block, but the probe was rejected on every multisite root in production. Diagnosed (per #45) to a scope gap: the adapter's `ScopeRegistry` classifies `abilities:multisite:read` / `abilities:multisite:write` as `SENSITIVE_SCOPES` ([ScopeRegistry.php:43-44](https://github.com/Wicked-Evolutions/abilities-mcp-adapter/blob/main/src/Auth/OAuth/ScopeRegistry.php#L43-L45)) and intentionally excludes them from `abilities:read` / `abilities:write` umbrella expansion. The bridge's `add-site` only requested the umbrellas during DCR, so OAuth tokens never carried the multisite scope — auto-populate never fired, even for super-admin operators.

Fix: extend the default DCR scope set to explicitly request the multisite scopes. The adapter's consent screen will now surface them for operators with the underlying WP capability (`manage_network_options`); single-site / non-super-admin operators are unaffected because the adapter declines to grant scopes the user can't back with capability.

Verified empirically against the adapter's `ScopeRegistry`: the scope strings `abilities:multisite:read` and `abilities:multisite:write` exist in `SENSITIVE_SCOPES` (lines 43-44) and are valid, expected scope identifiers. Naming convention `abilities:<module>:<op>` matches the rest of the registry (per `all_scopes()` builder, `$sensitive_modules` array, line 158).

## What changed

- **`lib/auth/oauth-client.js`** — `DEFAULT_SCOPE` now includes `abilities:multisite:read abilities:multisite:write` alongside the umbrella scopes. Single source of truth — `add-site`, `reauth`, `upgrade-auth` all pick it up. Comment explains why these are requested explicitly (sensitive-scope umbrella exclusion).
- **`lib/cli/commands/add-site.js`** — `_appendProbeAdvisory` permission-denied wording rewritten to name BOTH possible causes so operators don't chase the wrong layer:
  - `manage_network_options` WP-capability gate (the original anticipated cause)
  - `abilities:multisite:read` OAuth-scope gate at consent (the actual cause we hit)
- **`test/cli/add-site.test.js`** — strengthened the existing permission-denied test to assert both causes appear in the advisory; added four new tests in a `DCR multisite scope request (Issue #45)` block:
  1. `DEFAULT_SCOPE` includes the multisite scopes the probe needs
  2. add-site DCR registration body sent to the AS includes `abilities:multisite:read` + `abilities:multisite:write`
  3. Granted multisite scope (when adapter consent grants it) ends up in `wp-sites.json` `auth.scopes`
  4. Single-site path: scopes requested but adapter grants only umbrellas — site entry written without multisite block (graceful degrade preserved)

## Test plan

- [x] All 289 existing tests still pass (no scope assertions broke; mocks hardcode granted scopes, not requested scopes)
- [x] 4 new tests pass: DEFAULT_SCOPE shape, DCR body inclusion, granted-scope propagation to wp-sites.json, single-site graceful degrade preserved
- [x] Existing #43 permission-denied test extended — advisory wording asserts both causes
- [x] Total: 293 / 293 tests pass
- [ ] Operator validation: post-merge, orchestrator builds local bridge from main (PR #44 + this PR combined). Operator runs `add-site` against wickedevolutions multisite, consents to multisite scopes on consent screen, observes 4-subsite auto-populate, validates dot-notation routing in Claude Desktop end-to-end.

## Deviations

**Both `abilities:multisite:read` and `abilities:multisite:write` requested.** The probe only needs `:read`. The issue spec recommended `:write` "for symmetry with operator multisite admin needs," and the dispatch confirmed it after scope-name verification. Including both lets operators manage subsites via `multisite/*` abilities post-OAuth without a second consent round-trip — net UX win, no downside (the adapter still gates on WP capability). Verified the scope name against `SENSITIVE_SCOPES` line 44 before assuming.

**No client-side scope-presence guard before probing.** `add-site` does not check `result.scopes` for `abilities:multisite:read` before invoking the probe. Adding such a guard would skip a wasted round-trip for non-super-admin operators on multisite roots, but the existing graceful-degrade path already handles the rejection cleanly with the now-improved advisory. Not worth the added branch.

**No changes to `reauth` / `upgrade-auth` advisory or scope handling.** Both already pull from `DEFAULT_SCOPE` via the same module export, so the new scope set propagates automatically. The advisory in `add-site` is the only operator-facing surface that mentions the scope gate; `reauth` re-runs the same flow without any equivalent narration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)