### PR TITLE
fix(connection-pool): OAuth subsite routes use resolved subsite endpoint (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Abilities MCP are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- **OAuth subsite routing actually targets the subsite host (Issue [#48](https://github.com/Wicked-Evolutions/abilities-mcp/issues/48), Public Alpha Hardening Phase A.1).** v1.5.4 wrote the `multisite` block on add-site but the OAuth dispatch path ignored the resolved subsite endpoint — every `<network-id>.<subsite-slug>` ability call was POSTed to the network root, so WordPress booted blog 1 regardless of which subsite was named. Three connected fixes:
+  - `lib/config.js:resolveSiteKey` now derives `resolvedEndpoint` for OAuth subsites (was HTTP/App-Password only). OAuth sites carry their endpoint on `mcp_resource`, not `http.endpoint`, so the substitution branch never fired for the OAuth case.
+  - `lib/connection-pool.js:_createTransport` passes `{ resolvedEndpoint, subsiteUrl: finalSubsiteUrl }` through to the OAuth branch, mirroring the HTTP branch's pattern. `_createOAuthHttpTransport` uses `resolvedEndpoint || siteConfig.mcp_resource` and forwards `subsiteUrl` to the transport.
+  - `lib/connection-pool.js:_findExistingHttpTransport` dedupes OAuth subsites by `resolvedEndpoint || mcp_resource` (was always `mcp_resource`). Without this, the cached network-root transport was returned for every subsite key, making the endpoint fix functionally inert behind the cache lookup.
+  - `lib/transports/oauth-http-transport.js` accepts `subsiteUrl` and forwards it on every POST as `X-Abilities-MCP-Subsite-URL`. Subdomain-style multisite (the alpha-locked scope) routes by host in the endpoint URL and does not need the header; it's forward-looking infrastructure for path-style multisite (Phase B) so the adapter can `switch_to_blog()` per request without re-parsing the request URL.
+
 ## [1.5.4] - 2026-05-04
 
 This release lands the bridge-side foundations for the multisite UX promised in [#43](https://github.com/Wicked-Evolutions/abilities-mcp/issues/43). `add-site` now requests multisite OAuth scopes during DCR (so super-admin operators consent through the standard consent flow), runs a one-shot `multisite/list-sites` probe after OAuth completes, and on success writes a slug→subsite-URL `multisite` block to `wp-sites.json` so the bridge's existing dot-notation routing serves multi-site OAuth in any AI client without operator JSON editing. End-to-end dot-notation routing validated on darwin-arm64 against a 4-subsite multisite by manually populating the block from the verified `multisite/list-sites` response.

--- a/lib/config.js
+++ b/lib/config.js
@@ -356,12 +356,22 @@ function resolveSiteKey(config, compositeKey) {
       const subsiteUrl = site.multisite[subsiteKey];
       let resolvedEndpoint = null;
 
-      // For HTTP transport: build subsite endpoint from subsite URL + parent endpoint path.
-      // This makes WordPress boot natively into the correct blog context —
-      // community.wickedevolutions.com/wp-json/mcp/... boots into blog 2,
-      // not wickedevolutions.com/wp-json/mcp/... which boots into blog 1.
-      if (site.transport === 'http' && site.http && site.http.endpoint) {
-        const parentUrl = new URL(site.http.endpoint);
+      // Build subsite endpoint from subsite URL + parent endpoint path.
+      // WordPress multisite (subdomain-style) routes by URL host, so posting
+      // to community.wickedevolutions.com/wp-json/mcp/... boots into the
+      // community blog, not the network root. Without this substitution the
+      // request lands on blog 1 regardless of which subsite was targeted.
+      //
+      // Source endpoint differs by auth method:
+      //   - HTTP / App Password sites carry it on `http.endpoint`.
+      //   - OAuth sites carry it on `mcp_resource` (set during OAuth
+      //     discovery; there's no `http.endpoint` for OAuth sites).
+      const parentEndpoint =
+        (site.http && site.http.endpoint)
+        || (site.auth && site.auth.method === 'oauth' && site.mcp_resource)
+        || null;
+      if (parentEndpoint) {
+        const parentUrl = new URL(parentEndpoint);
         const subsiteOrigin = new URL(subsiteUrl).origin;
         resolvedEndpoint = subsiteOrigin + parentUrl.pathname;
       }

--- a/lib/connection-pool.js
+++ b/lib/connection-pool.js
@@ -293,8 +293,16 @@ class ConnectionPool {
     // Sites with auth.method === 'oauth' use the OAuth-aware HTTP transport;
     // every other site (App Password, SSH carrier-only) keeps the existing
     // legacy code paths untouched.
+    //
+    // Pass the resolved subsite endpoint and URL through. For multisite OAuth
+    // (Issue #48) the OAuth branch must POST to the subsite host, not the
+    // network root — mirroring the HTTP branch's `resolvedEndpoint || ...`
+    // pattern below.
     if (siteConfig.auth && siteConfig.auth.method === 'oauth') {
-      return this._createOAuthHttpTransport(compositeKey, siteConfig);
+      return this._createOAuthHttpTransport(compositeKey, siteConfig, {
+        resolvedEndpoint,
+        subsiteUrl: finalSubsiteUrl,
+      });
     }
 
     if (siteConfig.transport === 'ssh') {
@@ -342,7 +350,7 @@ class ConnectionPool {
    * we let propagate so the bridge fails loud rather than silently
    * downgrading to App Password).
    */
-  async _createOAuthHttpTransport(compositeKey, siteConfig) {
+  async _createOAuthHttpTransport(compositeKey, siteConfig, { resolvedEndpoint, subsiteUrl } = {}) {
     const { OAuthHttpTransport } = require('./transports/oauth-http-transport');
     const { TokenManager } = require('./auth/token-manager');
     const { discover } = require('./auth/discovery-client');
@@ -393,7 +401,8 @@ class ConnectionPool {
     const siteAuth = _siteAuthFromConfig(compositeKey, siteConfig, asMetadata);
 
     return new OAuthHttpTransport({
-      endpoint: siteConfig.mcp_resource,
+      endpoint: resolvedEndpoint || siteConfig.mcp_resource,
+      subsiteUrl: subsiteUrl || null,
       tokenManager: this._tokenManager,
       siteAuth,
       onAuthStatusChange: (newStatus, info) => {
@@ -455,9 +464,16 @@ class ConnectionPool {
   _findExistingHttpTransport(compositeKey) {
     const { siteConfig, resolvedEndpoint } = resolveSiteKey(this.config, compositeKey);
 
+    // The dedupe target must be the *subsite* endpoint when one is resolved,
+    // otherwise different subsite keys collapse onto whichever transport
+    // happens to be cached first — which was the v1.5.4 multisite-OAuth
+    // failure mode (Issue #48): every wickedevolutions.<subsite> reused the
+    // network-root transport built for `wickedevolutions`. Single-site keys
+    // (resolvedEndpoint=null) still fall back to siteConfig.mcp_resource /
+    // http.endpoint, which is what dedupes parent + same-host subsites.
     let targetEndpoint = null;
     if (siteConfig.auth && siteConfig.auth.method === 'oauth') {
-      targetEndpoint = siteConfig.mcp_resource;
+      targetEndpoint = resolvedEndpoint || siteConfig.mcp_resource;
     } else if (siteConfig.transport === 'http') {
       targetEndpoint = resolvedEndpoint || (siteConfig.http && siteConfig.http.endpoint);
     }

--- a/lib/transports/oauth-http-transport.js
+++ b/lib/transports/oauth-http-transport.js
@@ -44,7 +44,28 @@ const MAX_QUEUE = 100;
  *     it is NOT a runtime "if OAuth fails, try Basic" branch.
  *
  * @param {object} opts
- * @param {string} opts.endpoint              MCP resource URL (https)
+ * @param {string} opts.endpoint              MCP resource URL (https). For
+ *                                            multisite OAuth (Issue #48) the
+ *                                            caller derives the subsite-host
+ *                                            endpoint via resolveSiteKey and
+ *                                            passes it here; the transport
+ *                                            posts to whatever it's given.
+ * @param {string} [opts.subsiteUrl]          Optional. When the resolved
+ *                                            site key targets a multisite
+ *                                            subsite, the subsite home URL
+ *                                            is forwarded on every request
+ *                                            via X-Abilities-MCP-Subsite-URL
+ *                                            so server-side adapters that
+ *                                            honour it (Phase B / future)
+ *                                            can route per-request without
+ *                                            re-parsing the endpoint URL.
+ *                                            Subdomain-style multisite does
+ *                                            not need this header — the host
+ *                                            in the endpoint URL is
+ *                                            sufficient — but the header is
+ *                                            unconditional so path-style
+ *                                            multisite works once the
+ *                                            adapter consumes it.
  * @param {object} opts.tokenManager          TokenManager instance
  * @param {object} opts.siteAuth              SiteAuthState (see TokenManager)
  * @param {function} opts.onAuthStatusChange  Optional. Called with
@@ -70,6 +91,7 @@ class OAuthHttpTransport {
     }
 
     this.endpoint = opts.endpoint;
+    this.subsiteUrl = opts.subsiteUrl || null;
     this._tokenManager = opts.tokenManager;
     this._siteAuth = opts.siteAuth;
     this._onAuthStatusChange = opts.onAuthStatusChange || null;
@@ -496,6 +518,12 @@ class OAuthHttpTransport {
 
       if (this.sessionId) headers['Mcp-Session-Id'] = this.sessionId;
       if (this.sessionToken) headers['Mcp-Session-Token'] = this.sessionToken;
+      // Forward subsite context for multisite OAuth (Issue #48). Subdomain-
+      // style multisite already routes by host in the endpoint URL; the
+      // header is forward-looking infrastructure for path-style multisite
+      // (Phase B), so the server can switch_to_blog() without re-parsing
+      // the request URL.
+      if (this.subsiteUrl) headers['X-Abilities-MCP-Subsite-URL'] = this.subsiteUrl;
 
       const hostCookies = this._cookies.get(this.parsedUrl.hostname);
       if (hostCookies && hostCookies.size > 0) {

--- a/test/config-v2-oauth.test.js
+++ b/test/config-v2-oauth.test.js
@@ -6,7 +6,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const { loadConfig } = require('../lib/config');
+const { loadConfig, resolveSiteKey } = require('../lib/config');
 
 /**
  * The runtime config loader must accept v2 OAuth sites (which carry no
@@ -111,5 +111,94 @@ describe('loadConfig — v2 OAuth site acceptance (Issue #17 gating change)', ()
     });
     const cfg = await loadConfig({ config: file });
     assert.equal(cfg.sites.siteA.http.username, 'wp_user');
+  });
+});
+
+/**
+ * resolveSiteKey — multisite endpoint derivation (Issue #48).
+ *
+ * Subdomain-style multisite routes by URL host. The pool relies on
+ * resolveSiteKey to substitute the subsite's origin into the parent
+ * endpoint path so the OAuth and HTTP branches can post to the correct
+ * blog. Before the fix, OAuth subsite keys returned resolvedEndpoint=null
+ * because the substitution branch only fired for site.transport === 'http'
+ * — and OAuth sites carry no `transport` block.
+ */
+describe('resolveSiteKey — multisite endpoint derivation (Issue #48)', () => {
+  function makeOAuthMultisiteConfig() {
+    return {
+      sites: {
+        wickedevolutions: {
+          url: 'https://wickedevolutions.com',
+          mcp_resource: 'https://wickedevolutions.com/wp-json/mcp/mcp-adapter-default-server',
+          auth: {
+            method: 'oauth',
+            client_id: 'client-x',
+            access_token_ref: 'keychain://abilities-mcp/we/access',
+            refresh_token_ref: 'keychain://abilities-mcp/we/refresh',
+          },
+          auth_status: 'active',
+          multisite: {
+            main: 'https://wickedevolutions.com',
+            community: 'https://community.wickedevolutions.com',
+            test1: 'https://test1.wickedevolutions.com',
+            knowledge: 'https://knowledge.wickedevolutions.com',
+          },
+        },
+      },
+    };
+  }
+
+  it('OAuth subsite resolves to subsite-host endpoint (was null before #48)', () => {
+    const config = makeOAuthMultisiteConfig();
+    const r = resolveSiteKey(config, 'wickedevolutions.community');
+    assert.equal(r.subsiteUrl, 'https://community.wickedevolutions.com');
+    assert.equal(
+      r.resolvedEndpoint,
+      'https://community.wickedevolutions.com/wp-json/mcp/mcp-adapter-default-server',
+      'subsite endpoint must use the subsite host so multisite routes by URL'
+    );
+  });
+
+  it('every OAuth subsite resolves to its own host (no shared-network-root regression)', () => {
+    const config = makeOAuthMultisiteConfig();
+    const subsites = ['main', 'community', 'test1', 'knowledge'];
+    const endpoints = subsites.map((s) => resolveSiteKey(config, `wickedevolutions.${s}`).resolvedEndpoint);
+    // Every endpoint distinct (sanity — bug had them all equal to the network root).
+    const uniq = new Set(endpoints);
+    assert.equal(uniq.size, subsites.length, `expected 4 distinct subsite endpoints, got ${[...uniq].join(' | ')}`);
+    // Each endpoint's host matches its subsite's host.
+    for (let i = 0; i < subsites.length; i++) {
+      const expectedHost = new URL(config.sites.wickedevolutions.multisite[subsites[i]]).hostname;
+      const actualHost = new URL(endpoints[i]).hostname;
+      assert.equal(actualHost, expectedHost, `subsite "${subsites[i]}" endpoint host mismatch`);
+    }
+  });
+
+  it('OAuth single-site (no dot suffix) returns null resolvedEndpoint', () => {
+    // Single-site keys return the raw siteConfig with no subsite resolution;
+    // the pool then falls back to siteConfig.mcp_resource as the endpoint.
+    const config = makeOAuthMultisiteConfig();
+    const r = resolveSiteKey(config, 'wickedevolutions');
+    assert.equal(r.subsiteUrl, null);
+    assert.equal(r.resolvedEndpoint, null);
+  });
+
+  it('HTTP App-Password subsite resolution still works (no regression)', () => {
+    const config = {
+      sites: {
+        wp: {
+          url: 'https://example.com',
+          transport: 'http',
+          http: { endpoint: 'https://example.com/wp-json/mcp/mcp-adapter-default-server' },
+          multisite: { sub: 'https://sub.example.com' },
+        },
+      },
+    };
+    const r = resolveSiteKey(config, 'wp.sub');
+    assert.equal(
+      r.resolvedEndpoint,
+      'https://sub.example.com/wp-json/mcp/mcp-adapter-default-server'
+    );
   });
 });

--- a/test/connection-pool.test.js
+++ b/test/connection-pool.test.js
@@ -248,6 +248,51 @@ describe('ConnectionPool — _findExistingHttpTransport handles both transport v
     assert.equal(found.key, 'siteA');
   });
 
+  it('OAuth multisite subsite dedupes by subsite endpoint, NOT by network root (Issue #48)', async () => {
+    // Pre-fix bug: targetEndpoint = siteConfig.mcp_resource always, so
+    // wickedevolutions.community looking for an existing transport found
+    // the cached `wickedevolutions` (network root) transport and reused it.
+    // Outcome: every subsite call landed on blog 1.
+    //
+    // Post-fix: targetEndpoint = resolvedEndpoint || siteConfig.mcp_resource,
+    // so subsite keys dedupe against subsite-host transports only.
+    const config = {
+      defaultSite: 'wicked',
+      sites: {
+        wicked: {
+          url: 'https://wickedevolutions.com',
+          mcp_resource: 'https://wickedevolutions.com/wp-json/mcp/mcp-adapter-default-server',
+          auth: { method: 'oauth', client_id: 'x',
+            access_token_ref: 'keychain://abilities-mcp/w/access',
+            refresh_token_ref: 'keychain://abilities-mcp/w/refresh' },
+          auth_status: 'active',
+          multisite: {
+            main: 'https://wickedevolutions.com',
+            community: 'https://community.wickedevolutions.com',
+          },
+        },
+      },
+    };
+    const pool = new ConnectionPool(config, () => {});
+    // Seed cache with the network-root transport (parent / .main lookup path).
+    const networkRootTransport = { endpoint: 'https://wickedevolutions.com/wp-json/mcp/mcp-adapter-default-server' };
+    pool.transports.set('wicked', networkRootTransport);
+
+    // Before #48: this returned the network-root transport. After #48: returns null,
+    // so the pool builds a fresh subsite-host transport.
+    const community = pool._findExistingHttpTransport('wicked.community');
+    assert.equal(community, null,
+      'subsite key MUST NOT reuse the network-root transport (that was the v1.5.4 routing bug)');
+
+    // Same-host subsite (`.main`) still dedupes against the cached parent — the
+    // dedupe logic should fold them onto the same transport since they post
+    // to the same endpoint URL. Without this, the parent + .main get separate
+    // transports competing for the same WP session.
+    const main = pool._findExistingHttpTransport('wicked.main');
+    assert.ok(main, 'same-host subsite should still dedupe against the parent transport');
+    assert.equal(main.key, 'wicked');
+  });
+
   it('returns null for non-HTTP / non-OAuth sites with no endpoint', async () => {
     const config = {
       defaultSite: 'ssh1',
@@ -400,5 +445,102 @@ describe('ConnectionPool — multi-site v2 acceptance (Issue #26)', () => {
     } finally {
       try { fs.unlinkSync(file); } catch { /* ignore */ }
     }
+  });
+});
+
+/**
+ * OAuth subsite routing — Issue #48 acceptance.
+ *
+ * The OAuth branch of _createTransport must mirror the HTTP branch's use of
+ * resolvedEndpoint when a multisite subsite key (`<site>.<subsite>`) is
+ * dispatched, and must fall back to siteConfig.mcp_resource for single-site
+ * keys. The bug was that OAuth ignored both resolved values and always
+ * built the transport against the network root.
+ *
+ * Both directions are pinned so a future regression in either path fails
+ * loudly.
+ */
+describe('ConnectionPool — OAuth subsite routing (Issue #48)', () => {
+  function makeOAuthMultisitePool() {
+    const store = new MemorySecretStore();
+    return store.set(SECRET_SERVICE, 'wicked/access', 'AT')
+      .then(() => store.set(SECRET_SERVICE, 'wicked/refresh', 'RT'))
+      .then(() => {
+        const tm = new TokenManager({ secretStore: store, allowInsecure: true });
+        const config = {
+          defaultSite: 'wickedevolutions',
+          sites: {
+            wickedevolutions: {
+              url: 'https://wickedevolutions.com',
+              mcp_resource: 'https://wickedevolutions.com/wp-json/mcp/mcp-adapter-default-server',
+              auth: {
+                method: 'oauth',
+                client_id: 'client-x',
+                access_token_ref: makeRef(SECRET_SERVICE, 'wicked/access'),
+                refresh_token_ref: makeRef(SECRET_SERVICE, 'wicked/refresh'),
+                access_token_expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+                refresh_token_expires_at: new Date(Date.now() + 90 * 24 * 3600 * 1000).toISOString(),
+              },
+              auth_status: 'active',
+              multisite: {
+                main: 'https://wickedevolutions.com',
+                community: 'https://community.wickedevolutions.com',
+                test1: 'https://test1.wickedevolutions.com',
+                knowledge: 'https://knowledge.wickedevolutions.com',
+              },
+            },
+          },
+        };
+        const pool = new ConnectionPool(config, () => {}, {
+          secretStore: store,
+          tokenManager: tm,
+          discover: fakeDiscover(),
+          allowInsecure: true,
+        });
+        return pool;
+      });
+  }
+
+  it('subsite key routes to subsite-host endpoint, not network root', async () => {
+    const pool = await makeOAuthMultisitePool();
+    const transport = await pool._createTransport('wickedevolutions.community', null);
+    assert.ok(transport instanceof OAuthHttpTransport);
+    assert.equal(
+      transport.endpoint,
+      'https://community.wickedevolutions.com/wp-json/mcp/mcp-adapter-default-server',
+      'OAuth subsite must POST to the subsite host so multisite routes by URL — ' +
+      'this was the GPT 5.5 review finding (all subsites returned 106 main-site posts)'
+    );
+    assert.equal(transport.subsiteUrl, 'https://community.wickedevolutions.com',
+      'subsite URL should be forwarded to the transport for the X-Abilities-MCP-Subsite-URL header (Phase B)');
+  });
+
+  it('every subsite produces a distinct endpoint host', async () => {
+    const pool = await makeOAuthMultisitePool();
+    const subs = ['main', 'community', 'test1', 'knowledge'];
+    const endpoints = [];
+    for (const s of subs) {
+      const t = await pool._createTransport(`wickedevolutions.${s}`, null);
+      endpoints.push(t.endpoint);
+    }
+    const uniq = new Set(endpoints);
+    assert.equal(uniq.size, subs.length,
+      `expected 4 distinct subsite endpoints, got: ${[...uniq].join(' | ')}`);
+  });
+
+  it('single-site OAuth (no subsite suffix) still uses siteConfig.mcp_resource', async () => {
+    // Pin the no-subsite direction so a future refactor of resolveSiteKey
+    // doesn't accidentally null out the network-root fallback. This is the
+    // helenawillow / wickedevolutions-no-suffix case.
+    const pool = await makeOAuthMultisitePool();
+    const transport = await pool._createTransport('wickedevolutions', null);
+    assert.ok(transport instanceof OAuthHttpTransport);
+    assert.equal(
+      transport.endpoint,
+      'https://wickedevolutions.com/wp-json/mcp/mcp-adapter-default-server',
+      'no subsite suffix → siteConfig.mcp_resource (network root) is correct'
+    );
+    assert.equal(transport.subsiteUrl, null,
+      'no subsite suffix → no subsite URL header forwarded');
   });
 });

--- a/test/transports/oauth-http-transport.test.js
+++ b/test/transports/oauth-http-transport.test.js
@@ -283,3 +283,47 @@ describe('OAuthHttpTransport — surface compatibility with HttpTransport', () =
     assert.equal(t.isReady(), false);
   });
 });
+
+describe('OAuthHttpTransport — multisite subsite header (Issue #48)', () => {
+  it('forwards X-Abilities-MCP-Subsite-URL on every POST when subsiteUrl is set', async () => {
+    const { server, resource, tm, siteAuth } = await buildStack({ accessToken: 'AT-OK' });
+    try {
+      const t = new OAuthHttpTransport({
+        endpoint: resource.endpoint,
+        subsiteUrl: 'https://community.example.com',
+        tokenManager: tm, siteAuth, logger: () => {},
+      });
+      await t.connect();
+      const req = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+      await send(t, req);
+      const seen = resource.history[0];
+      assert.equal(
+        seen.headers['x-abilities-mcp-subsite-url'],
+        'https://community.example.com',
+        'subsite URL header is forward-looking infrastructure for path-style ' +
+        'multisite (Phase B); subdomain-style routing already works via the endpoint URL'
+      );
+      await t.shutdown();
+    } finally {
+      await server.stop(); await resource.stop();
+    }
+  });
+
+  it('omits the subsite header when subsiteUrl is not set (single-site OAuth)', async () => {
+    const { server, resource, tm, siteAuth } = await buildStack({ accessToken: 'AT-OK' });
+    try {
+      const t = new OAuthHttpTransport({
+        endpoint: resource.endpoint, tokenManager: tm, siteAuth, logger: () => {},
+      });
+      await t.connect();
+      const req = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+      await send(t, req);
+      const seen = resource.history[0];
+      assert.equal(seen.headers['x-abilities-mcp-subsite-url'], undefined,
+        'no subsite URL → no subsite header (single-site OAuth path unchanged)');
+      await t.shutdown();
+    } finally {
+      await server.stop(); await resource.stop();
+    }
+  });
+});


### PR DESCRIPTION
Closes #48 (Public Alpha Hardening Phase A.1).

## Root cause

v1.5.4 ships the `multisite` block on add-site so dot-notation routing accepts `<network-id>.<subsite-slug>` keys. But three independent code paths short-circuit the resolved subsite endpoint and fall back to `siteConfig.mcp_resource` (the network root):

1. `lib/config.js:resolveSiteKey` — substitution branch was gated on `site.transport === 'http'`. OAuth sites carry no `transport` field (they have `auth.method === 'oauth'` + `mcp_resource`), so `resolvedEndpoint` came back `null` for every OAuth subsite key.
2. `lib/connection-pool.js:_createTransport` — OAuth branch passed only `(compositeKey, siteConfig)` to `_createOAuthHttpTransport`, dropping both resolved values from `resolveSiteKey` even when they were set.
3. `lib/connection-pool.js:_findExistingHttpTransport` — dedup target for OAuth was hardcoded to `siteConfig.mcp_resource`, so the cached network-root transport was reused for every subsite key. Even with (1) and (2) fixed, the endpoint correction would be inert behind this lookup.

Net effect on wickedevolutions: every `wickedevolutions.<subsite>` ability call landed on blog 1, returning the same 106 main-site posts the GPT 5.5 reviewer observed.

## Fix shape (matches plan §4 A.1)

- `resolveSiteKey` derives `resolvedEndpoint` from `mcp_resource` for OAuth subsites (`lib/config.js`). Same origin-substitution shape as the existing HTTP branch.
- `_createTransport` passes `{ resolvedEndpoint, subsiteUrl: finalSubsiteUrl }` into the OAuth branch. `_createOAuthHttpTransport` signature takes the options bag and uses `resolvedEndpoint || siteConfig.mcp_resource` (`lib/connection-pool.js`).
- `_findExistingHttpTransport` dedupes OAuth by `resolvedEndpoint || mcp_resource` (`lib/connection-pool.js`). Single-site keys (`resolvedEndpoint=null`) still fall back to `mcp_resource`, so parent + same-host subsites still share a transport.
- `OAuthHttpTransport` accepts `subsiteUrl` and emits `X-Abilities-MCP-Subsite-URL: <subsiteUrl>` on every POST (`lib/transports/oauth-http-transport.js`). Subdomain-style multisite routes by URL host alone, so the header is **forward-looking infrastructure for Phase B** — path-style multisite needs server-side `switch_to_blog()` per request, and the header is the contract the adapter consumes. Single-site OAuth omits the header.

## Header for Phase B

`X-Abilities-MCP-Subsite-URL` is new — no prior site-context header convention existed in the OAuth/HTTP transports (SSH uses `--url=...` as a CLI flag; bridge dot-notation is bridge-internal otherwise). Phase B's adapter dev should consume this header on bearer-auth requests to drive `switch_to_blog()` for path-style multisite. Subdomain-style alpha scope ships green without server-side changes.

## Tests

`npm test`: 293 → 303 (+10 new).

- `test/config-v2-oauth.test.js` (+4): `resolveSiteKey` for OAuth multisite — subsite returns subsite-host endpoint; all four subsites distinct hosts; single-site returns null `resolvedEndpoint`; HTTP App-Password subsite still works (no regression).
- `test/connection-pool.test.js` (+4): OAuth subsite routes to subsite-host endpoint, not network root (the GPT 5.5 finding); each subsite key produces a distinct endpoint host; single-site OAuth still uses `siteConfig.mcp_resource` (pinning the no-subsite direction); `_findExistingHttpTransport` rejects subsite key reuse of network-root cached transport while still deduping same-host (`.main`) against the parent.
- `test/transports/oauth-http-transport.test.js` (+2): `X-Abilities-MCP-Subsite-URL` is forwarded on every POST when set; omitted when not set.

## Live verification

Drove the branch's `OAuthHttpTransport` directly against `wickedevolutions.com` via a local node harness (loads real `~/.abilities-mcp/wp-sites.json`, real keychain — same code path the runtime bridge uses):

| key | resolved endpoint | `X-Abilities-MCP-Subsite-URL` | result |
|---|---|---|---|
| `wickedevolutions` | `https://wickedevolutions.com/wp-json/mcp/...` | (none) | tools/list OK; `home_url=https://wickedevolutions.com` ✓ |
| `wickedevolutions.main` | `https://wickedevolutions.com/wp-json/mcp/...` | (none, same-host as parent) | tools/list OK; `home_url=https://wickedevolutions.com` ✓ |
| `wickedevolutions.community` | `https://community.wickedevolutions.com/wp-json/mcp/...` | `https://community.wickedevolutions.com` | **request reached community-side WP**; bearer 401 from the subsite (`Run: abilities-mcp reauth wickedevolutions.community`) — stale subsite OAuth token, **not a routing failure** ✓ |
| `wickedevolutions.test1` | `https://test1.wickedevolutions.com/wp-json/mcp/...` | `https://test1.wickedevolutions.com` | refresh token expired for `wickedevolutions.test1` (typed error names the subsite) — operator-side ✓ |
| `wickedevolutions.knowledge` | `https://knowledge.wickedevolutions.com/wp-json/mcp/...` | `https://knowledge.wickedevolutions.com` | refresh token expired for `wickedevolutions.knowledge` — operator-side ✓ |

Pre-fix, every endpoint was `https://wickedevolutions.com/wp-json/mcp/...` and the `.community` 401 would not occur (the parent token works against the network root). Post-fix, each subsite gets its own endpoint and the `.community` 401 from the subsite's own WP is direct evidence the routing fix landed.

**Primary signal gap:** plan §4 A.1 calls for `core/get-site-info` (or equivalent) to return the **subsite's** `home_url + blog_id` from a non-main subsite. That requires fresh OAuth tokens on at least one non-main subsite — currently blocked by stale subsite tokens, not by the routing fix. A `reauth wickedevolutions.community` on a machine where the operator can complete the consent flow unblocks the full primary signal. The routing-proof evidence above (subsite-side 401, distinct endpoints, correct header) is conclusive on its own; the orchestrator can ship as-is or run a reauth + re-verify before merge — your call.

**Sentinel pre-set step:** the plan's "secondary" signal (per-subsite sentinel options pre-set via `settings-update`) hits a circular dependency — pre-setting via the running v1.5.4 bridge would route every write to the network root (the bug under repair). After this PR ships and the operator pulls v1.5.5, sentinels become writable per-subsite and can be used as confirmation in future verifications.

## Workflow law compliance

- Single dev chat for the sprint, sequential PRs.
- One PR per issue — same-files rule justifies bundling the three fixes since all three trace to the same root cause ("OAuth subsites don't route") and live in the same two files (`lib/config.js`, `lib/connection-pool.js`) plus the transport surface that consumes the resolved values.
- CI green required before merge — orchestrator gates.
- Live multisite verification against wickedevolutions documented above.

## Deviations

None.