### PR TITLE
fix(keychain): darwin auto defaults to security-CLI for cross-runtime ACL identity (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Abilities MCP are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- **macOS keychain backend defaults to security-CLI for cross-runtime ACL identity (Issue [#61](https://github.com/Wicked-Evolutions/abilities-mcp/issues/61), Alpha Release Gate Phase B.2).** v1.5.5's [#58](https://github.com/Wicked-Evolutions/abilities-mcp/issues/58) shipped `ABILITIES_MCP_KEYCHAIN_BACKEND=security-cli` as an opt-in alignment, but the default `auto` backend still picked keytar in terminal / Claude Code contexts and security-CLI only in Claude Desktop's `.mcpb` runtime. Multi-client operator setups (Claude Desktop + Claude Code + Codex on the same workstation — the standard alpha install reality) saw a fresh macOS Keychain ACL prompt on every cross-runtime read, because each runtime's keychain syscall caller binary was a different ACL identity (system `node`, Codex's bundled `node`, `/usr/bin/security`). On darwin under the default `auto` backend, `KeychainSecretStore` now engages `/usr/bin/security` directly without attempting to load keytar. Every bridge spawn — Claude Desktop, Claude Code, Codex, terminal CLI — issues `SecKeychainItem*` calls through the same caller binary, so macOS's per-binary ACL trusted-application list contains exactly one entry. After the operator's first "Always Allow" the entry is silently readable from every runtime. The fix preserves least-privilege ACL semantics: no `-A` all-apps flag, no `-T` consumer-path additions, no broadening of the trusted-application set; the trusted set is *narrower* than today (one binary instead of N). Linux / win32 behavior unchanged (keytar via libsecret / Credential Manager — no analogous identity-split bug on those platforms).
+  - **Security CLI existence probe.** `_load()` now probes `/usr/bin/security` on first use and surfaces a typed `SecretStoreError` (`code: 'security_cli_unavailable'`) if absent, so corporate-locked or non-standard macOS hosts get a clear early diagnostic instead of an opaque execFile spawn failure on the first ability call.
+  - **`findAll()` darwin behavior:** `findAll()` is unavailable on the Darwin security-cli backend; current bridge flows do not rely on it. Linux / Windows (keytar) continue to enumerate normally.
+  - **Operator opt-out:** operators who need keytar on darwin (uncommon — debugging, custom build) can opt back in with `ABILITIES_MCP_KEYCHAIN_BACKEND=keytar`. Behavior matches v1.5.5: keytar is attempted, throws `SecretStoreError` (`code: 'keytar_unavailable'`) if it can't load.
+
+### Known limitations
+
+- **Existing macOS keychain entries written under v1.5.5 keytar may prompt once on first read under the new default (Issue [#61](https://github.com/Wicked-Evolutions/abilities-mcp/issues/61)).** v1.5.5 wrote OAuth and App Password entries via keytar in terminal / Claude Code contexts, so the entry's macOS Keychain ACL trusted-application list contains the system `node` binary, not `/usr/bin/security`. After upgrading, the first read by `/usr/bin/security` against an existing entry triggers a one-time ACL prompt — operators have **two recovery paths** (same shape as the v1.5.5 [#58](https://github.com/Wicked-Evolutions/abilities-mcp/issues/58) opt-in note): (1) click **Always Allow** at the prompt — the ACL is updated to add `/usr/bin/security` and no further prompts appear from any runtime, OR (2) re-run `abilities-mcp add-site --force <site>` / `abilities-mcp reauth <site>` to write a fresh entry under the new default backend. New entries written from this release forward never carry the legacy ACL state. The remaining one-time prompt is UX, not security: existing keychain ACLs continue to protect secrets correctly throughout.
+
+
 ## [1.5.5] - 2026-05-05
 
 ### Fixed

--- a/lib/auth/keychain-secret-store.js
+++ b/lib/auth/keychain-secret-store.js
@@ -1,12 +1,14 @@
 'use strict';
 
 const { execFile } = require('node:child_process');
+const { existsSync } = require('node:fs');
 
 const { SecretStoreError } = require('./errors');
 
 const DEFAULT_SECURITY_TIMEOUT_MS = 30_000;
 const DEFAULT_KEYCHAIN_BACKEND = 'auto';
 const KEYCHAIN_BACKENDS = new Set(['auto', 'keytar', 'security-cli']);
+const SECURITY_CLI_PATH = '/usr/bin/security';
 
 /**
  * KeychainSecretStore — keytar-backed SecretStore with a darwin-only
@@ -17,25 +19,32 @@ const KEYCHAIN_BACKENDS = new Set(['auto', 'keytar', 'security-cli']);
  * `optionalDependency` so a failed native build does not break `npm install`
  * for env-var-only operators.
  *
- * **The darwin fallback (issue #39).** When the bundled keytar binary fails
- * to dlopen inside Claude Desktop's hardened-runtime process — the macOS
- * code-signing rejects native binaries with mismatched Team IDs, Anthropic-
- * signed Claude Desktop refuses to load npm-distribution-signed keytar.node —
- * we fall back to shelling out to the macOS `security` CLI via
- * `child_process.execFile`. `security` is always installed on macOS, doesn't
- * require dynamic native loading, operates against the same macOS Keychain,
- * and runs as a child process out from under Claude Desktop's hardened-
- * runtime restrictions. The fallback fires only on darwin; on linux/win32 a
- * keytar load failure still throws `keytar_unavailable` (current behavior).
+ * **Darwin default: security-CLI (issue #61).** On darwin under the default
+ * `auto` backend, the store engages the `/usr/bin/security` CLI directly
+ * without attempting to load keytar. This is the alpha-gate fix for the
+ * multi-client macOS keychain ACL identity split: every runtime that spawns
+ * the bridge — Claude Desktop's `.mcpb`, Claude Code via npm/node, Codex,
+ * terminal CLI, etc. — issues `SecKeychainItem*` calls through the same
+ * caller binary (`/usr/bin/security`), so macOS's per-binary ACL trusted-
+ * application list contains exactly one entry. After the operator's first
+ * "Always Allow" the entry is silently readable from every runtime.
  *
- * Outside the .mcpb path — system Node, CLI install, npx, source clone —
- * keytar loads normally and the fallback never engages.
+ * Issue #58's `ABILITIES_MCP_KEYCHAIN_BACKEND=security-cli` env var was the
+ * opt-in shape of this fix; #61 promotes it to the default. Operators who
+ * need keytar on darwin (uncommon — debugging, custom build) can opt back in
+ * with `ABILITIES_MCP_KEYCHAIN_BACKEND=keytar`.
  *
- * **Backend alignment escape hatch (issue #58).** On macOS, operators can set
- * `ABILITIES_MCP_KEYCHAIN_BACKEND=security-cli` so terminal `add-site` /
- * `reauth` writes entries through the same `/usr/bin/security` backend that
- * Claude Desktop's `.mcpb` runtime uses after keytar is rejected. This is
- * opt-in and darwin-only; it does not broaden keychain ACLs or use `-A`.
+ * **The original darwin fallback (issue #39).** When the bundled keytar
+ * binary failed to dlopen inside Claude Desktop's hardened-runtime process,
+ * the store fell back to `/usr/bin/security` automatically. With the #61
+ * default in place, darwin auto never attempts keytar in the first place, so
+ * the dlopen-rejection branch is no longer reachable from `auto`. The
+ * security-CLI implementation itself is the same code path that's been
+ * shipping inside the .mcpb runtime since v1.5.3.
+ *
+ * Linux / win32 behavior unchanged: keytar via libsecret / Credential
+ * Manager. There is no `/usr/bin/security` equivalent and no analogous ACL
+ * prompt, so the per-platform identity-split bug doesn't apply.
  *
  * If keytar is unavailable at runtime AND the darwin fallback also can't run,
  * every method throws `SecretStoreError` with code `keytar_unavailable` —
@@ -70,6 +79,9 @@ class KeychainSecretStore {
    *                                       or security-cli. When omitted, reads
    *                                       ABILITIES_MCP_KEYCHAIN_BACKEND.
    * @param {object} [opts.env]            Env object for backend selection tests.
+   * @param {Function} [opts.fsExistsSync] Override `fs.existsSync` for the
+   *                                       `/usr/bin/security` existence probe.
+   *                                       Test seam.
    */
   constructor(opts = {}) {
     this._injected = opts.keytar || null;
@@ -82,6 +94,7 @@ class KeychainSecretStore {
     this._requireKeytar = opts.requireKeytar || ((id) => require(id));
     this._platform = opts.platform || process.platform;
     this._exec = opts.exec || execFile;
+    this._fsExistsSync = opts.fsExistsSync || existsSync;
     const env = opts.env || process.env;
     this._backend = _normalizeBackend(opts.backend || env.ABILITIES_MCP_KEYCHAIN_BACKEND);
     this._securityTimeoutMs = Number.isFinite(opts.securityTimeoutMs) && opts.securityTimeoutMs > 0
@@ -91,9 +104,13 @@ class KeychainSecretStore {
 
   /**
    * Lazy load. Sets one of three terminal states:
-   *  - `this._keytar` populated (keytar loaded normally; primary path)
-   *  - `this._fallbackMode === 'security-cli'` (darwin fallback engaged)
-   *  - `this._loadError` set + throws (non-darwin keytar failure)
+   *  - `this._fallbackMode === 'security-cli'` (darwin auto default + explicit
+   *    security-cli backend)
+   *  - `this._keytar` populated (keytar loaded normally; non-darwin auto, or
+   *    explicit `backend: 'keytar'` anywhere)
+   *  - `this._loadError` set + throws (security-cli engagement on a host
+   *    without `/usr/bin/security`, keytar load failure when keytar is the
+   *    selected backend, invalid backend value)
    */
   _load() {
     if (this._keytar || this._fallbackMode) {
@@ -122,19 +139,29 @@ class KeychainSecretStore {
     }
 
     if (this._backend === 'security-cli') {
-      if (this._platform === 'darwin') {
-        this._fallbackMode = 'security-cli';
-        return;
+      if (this._platform !== 'darwin') {
+        const err = new Error(
+          `ABILITIES_MCP_KEYCHAIN_BACKEND=security-cli is only supported on macOS.`
+        );
+        this._loadError = err;
+        this._loadErrorCode = 'security_cli_unavailable';
+        throw new SecretStoreError(
+          `OS keychain unavailable: ${err.message}`,
+          { code: this._loadErrorCode, cause: err }
+        );
       }
-      const err = new Error(
-        `ABILITIES_MCP_KEYCHAIN_BACKEND=security-cli is only supported on macOS.`
-      );
-      this._loadError = err;
-      this._loadErrorCode = 'security_cli_unavailable';
-      throw new SecretStoreError(
-        `OS keychain unavailable: ${err.message}`,
-        { code: this._loadErrorCode, cause: err }
-      );
+      this._engageSecurityCliMode();
+      return;
+    }
+
+    // Issue #61: darwin default = security-CLI for cross-runtime ACL identity.
+    // All bridge spawn paths (Claude Desktop .mcpb, Claude Code, Codex,
+    // terminal CLI) issue keychain syscalls through the same `/usr/bin/security`
+    // caller binary, so macOS sees one ACL identity instead of N. Operators
+    // who want keytar on darwin can opt back in with backend=keytar.
+    if (this._backend === 'auto' && this._platform === 'darwin') {
+      this._engageSecurityCliMode();
+      return;
     }
 
     if (this._injected) {
@@ -146,22 +173,9 @@ class KeychainSecretStore {
       this._keytar = this._requireKeytar('keytar');
       return;
     } catch (err) {
-      if (this._backend === 'keytar') {
-        this._loadError = err;
-        this._loadErrorCode = 'keytar_unavailable';
-        throw new SecretStoreError(
-          `OS keychain unavailable: ${err.message}`,
-          { code: this._loadErrorCode, cause: err }
-        );
-      }
-      // darwin: Claude Desktop's hardened-runtime rejects bundled keytar.node
-      // with a Team ID mismatch (issue #39). Fall back to the `security` CLI
-      // rather than throwing — the bridge keeps working against the same
-      // macOS Keychain, just via shell-out.
-      if (this._platform === 'darwin') {
-        this._fallbackMode = 'security-cli';
-        return;
-      }
+      // backend === 'keytar' (any platform), or backend === 'auto' on
+      // linux/win32. No fallback: the security-CLI is darwin-only, and the
+      // darwin auto path above already engaged it before we got here.
       this._loadError = err;
       this._loadErrorCode = 'keytar_unavailable';
       throw new SecretStoreError(
@@ -169,6 +183,32 @@ class KeychainSecretStore {
         { code: this._loadErrorCode, cause: err }
       );
     }
+  }
+
+  /**
+   * Probe `/usr/bin/security` and engage security-CLI mode. Surfaces a typed
+   * error early (at first `_load()`) on hosts where the binary is missing —
+   * the corporate-locked-macOS edge case — instead of waiting for the first
+   * keychain operation to fail at execFile spawn time.
+   *
+   * Sets `_fallbackMode = 'security-cli'` on success; throws
+   * SecretStoreError code `security_cli_unavailable` on failure.
+   */
+  _engageSecurityCliMode() {
+    if (!this._fsExistsSync(SECURITY_CLI_PATH)) {
+      const err = new Error(
+        `${SECURITY_CLI_PATH} not found. macOS Keychain access requires the ` +
+        `security CLI (standard at ${SECURITY_CLI_PATH} on a normal macOS ` +
+        `install). This may indicate a corporate-locked or non-standard host.`
+      );
+      this._loadError = err;
+      this._loadErrorCode = 'security_cli_unavailable';
+      throw new SecretStoreError(
+        `OS keychain unavailable: ${err.message}`,
+        { code: this._loadErrorCode, cause: err }
+      );
+    }
+    this._fallbackMode = 'security-cli';
   }
 
   /**
@@ -211,14 +251,14 @@ class KeychainSecretStore {
     return this._keytar.deletePassword(service, account);
   }
 
+  // findAll() is unavailable on the Darwin security-cli backend; current
+  // bridge flows do not rely on it. The macOS `security` CLI has no clean
+  // enumerate-by-service mode, and with #61 making security-cli the darwin
+  // default this method returns [] for every darwin caller. Linux/Windows
+  // (keytar) continue to enumerate normally.
   async findAll(service) {
     this._load();
     if (this._fallbackMode === 'security-cli') {
-      // The macOS `security` CLI has no clean enumerate-by-service mode.
-      // Returning [] here is safe because the bridge runtime path never
-      // calls findAll — only the CLI subcommand `list-sites` does, and that
-      // runs in system Node where keytar loads normally and this branch
-      // is never taken. Documented in the issue body's "findAll" note.
       return [];
     }
     return this._keytar.findCredentials(service);

--- a/test/auth/keychain-secret-store-darwin-default.test.js
+++ b/test/auth/keychain-secret-store-darwin-default.test.js
@@ -1,0 +1,178 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { KeychainSecretStore } = require('../../lib/auth/keychain-secret-store');
+
+/**
+ * Issue #61 — darwin default = security-CLI for cross-runtime ACL identity.
+ *
+ * Pins the new alpha-gate behavior promoted from the v1.5.5 #58 opt-in:
+ *
+ *  - On darwin under the default `auto` backend, `_load()` engages
+ *    `/usr/bin/security` directly without ever calling `requireKeytar`.
+ *    This is the structural fix for the multi-client keychain ACL identity
+ *    split — every runtime that spawns the bridge issues `SecKeychainItem*`
+ *    calls through the same `/usr/bin/security` caller binary.
+ *  - The `_engageSecurityCliMode()` probe surfaces a typed
+ *    `SecretStoreError(code: 'security_cli_unavailable')` if `/usr/bin/security`
+ *    is missing on the host (corporate-locked / non-standard macOS), so
+ *    operators get a clear early diagnostic rather than an opaque execFile
+ *    spawn failure on the first ability call.
+ *
+ * Shared security-CLI dispatch coverage (round-trip, error mapping, timeout,
+ * etc.) lives in `keychain-secret-store-darwin-fallback.test.js`.
+ */
+
+function noopExec(file, args, opts, cb) {
+  cb(null, '', '');
+}
+
+describe('KeychainSecretStore — darwin auto default = security-CLI (#61)', () => {
+  it('does NOT invoke requireKeytar on darwin under default auto backend', async () => {
+    let requireCalls = 0;
+    const requireKeytar = () => {
+      requireCalls += 1;
+      throw new Error('requireKeytar must not be called under #61 darwin auto');
+    };
+
+    const store = new KeychainSecretStore({
+      requireKeytar,
+      platform: 'darwin',
+      // exec stub never reached because we only call isAvailable().
+      exec: noopExec,
+    });
+
+    assert.equal(await store.isAvailable(), true);
+    assert.equal(requireCalls, 0, 'darwin + auto must engage security-CLI without trying keytar');
+  });
+
+  it('does NOT invoke requireKeytar even when keytar is injected on darwin auto', async () => {
+    // Belt-and-braces: a stale callsite that still passes opts.keytar should
+    // also not pull keytar into the load path on darwin auto. The injected
+    // keytar is simply ignored in favor of the security-CLI default.
+    let injectedTouched = 0;
+    const fakeKeytar = {
+      get getPassword() { injectedTouched += 1; return async () => null; },
+      get setPassword() { injectedTouched += 1; return async () => undefined; },
+      get deletePassword() { injectedTouched += 1; return async () => true; },
+      get findCredentials() { injectedTouched += 1; return async () => []; },
+    };
+
+    const store = new KeychainSecretStore({
+      keytar: fakeKeytar,
+      platform: 'darwin',
+      exec: noopExec,
+    });
+
+    assert.equal(await store.isAvailable(), true);
+    assert.equal(injectedTouched, 0, 'injected keytar must not be touched under #61 darwin auto');
+  });
+
+  it('uses the security-CLI execFile path for set/get/delete under darwin auto default', async () => {
+    const calls = [];
+    function captureExec(file, args, opts, cb) {
+      calls.push({ file, args: args.slice() });
+      const sub = args[0];
+      const sIdx = args.indexOf('-s');
+      const aIdx = args.indexOf('-a');
+      const wIdx = args.indexOf('-w');
+      if (sub === 'add-generic-password') return cb(null, '', '');
+      if (sub === 'find-generic-password') return cb(null, `${args[wIdx + 1] || 'pw-stub'}\n`, '');
+      if (sub === 'delete-generic-password') return cb(null, '', '');
+      return cb(Object.assign(new Error('unknown'), { stderr: 'unknown' }));
+    }
+
+    const store = new KeychainSecretStore({
+      platform: 'darwin',
+      exec: captureExec,
+      // No requireKeytar override needed — auto darwin never calls it.
+    });
+
+    await store.set('abilities-mcp', 'siteA/access', 'AT-DEFAULT');
+    await store.get('abilities-mcp', 'siteA/access');
+    await store.delete('abilities-mcp', 'siteA/access');
+
+    assert.equal(calls.length, 3, 'set/get/delete must each invoke security CLI');
+    assert.equal(calls[0].file, 'security');
+    assert.equal(calls[0].args[0], 'add-generic-password');
+    assert.equal(calls[1].args[0], 'find-generic-password');
+    assert.equal(calls[2].args[0], 'delete-generic-password');
+  });
+});
+
+describe('KeychainSecretStore — /usr/bin/security existence probe (#61)', () => {
+  it('surfaces security_cli_unavailable when /usr/bin/security is missing under darwin auto', async () => {
+    const store = new KeychainSecretStore({
+      platform: 'darwin',
+      fsExistsSync: (p) => {
+        assert.equal(p, '/usr/bin/security');
+        return false;
+      },
+      exec: () => { throw new Error('exec must not be called when probe fails'); },
+    });
+
+    assert.equal(await store.isAvailable(), false);
+    await assert.rejects(
+      store.get('abilities-mcp', 'siteA/access'),
+      (err) => err
+        && err.code === 'security_cli_unavailable'
+        && /\/usr\/bin\/security not found/.test(err.message)
+        && /corporate-locked or non-standard host/.test(err.message),
+    );
+  });
+
+  it('surfaces security_cli_unavailable when /usr/bin/security is missing under explicit backend=security-cli', async () => {
+    const store = new KeychainSecretStore({
+      backend: 'security-cli',
+      platform: 'darwin',
+      fsExistsSync: () => false,
+      exec: () => { throw new Error('exec must not be called when probe fails'); },
+    });
+
+    assert.equal(await store.isAvailable(), false);
+    await assert.rejects(
+      store.set('abilities-mcp', 'siteA/access', 'pw'),
+      (err) => err && err.code === 'security_cli_unavailable',
+    );
+  });
+
+  it('passes the probe and engages security-CLI when /usr/bin/security exists', async () => {
+    let probeCalls = 0;
+    const store = new KeychainSecretStore({
+      platform: 'darwin',
+      fsExistsSync: (p) => {
+        probeCalls += 1;
+        assert.equal(p, '/usr/bin/security');
+        return true;
+      },
+      exec: noopExec,
+    });
+
+    assert.equal(await store.isAvailable(), true);
+    assert.equal(probeCalls, 1, 'probe runs exactly once at first _load()');
+
+    // Second call should NOT re-probe — _load is memoized.
+    assert.equal(await store.isAvailable(), true);
+    assert.equal(probeCalls, 1, 'probe must not re-run on subsequent _load() calls');
+  });
+
+  it('caches the probe failure across subsequent calls (no repeated fs.existsSync)', async () => {
+    let probeCalls = 0;
+    const store = new KeychainSecretStore({
+      platform: 'darwin',
+      fsExistsSync: () => { probeCalls += 1; return false; },
+      exec: noopExec,
+    });
+
+    await assert.rejects(store.get('abilities-mcp', 'siteA/access'),
+      (err) => err && err.code === 'security_cli_unavailable');
+    await assert.rejects(store.set('abilities-mcp', 'siteA/access', 'pw'),
+      (err) => err && err.code === 'security_cli_unavailable');
+    await assert.rejects(store.delete('abilities-mcp', 'siteA/access'),
+      (err) => err && err.code === 'security_cli_unavailable');
+
+    assert.equal(probeCalls, 1, 'probe must not re-run after first cached failure');
+  });
+});

--- a/test/auth/keychain-secret-store-darwin-default.test.js
+++ b/test/auth/keychain-secret-store-darwin-default.test.js
@@ -30,6 +30,14 @@ function noopExec(file, args, opts, cb) {
 }
 
 describe('KeychainSecretStore — darwin auto default = security-CLI (#61)', () => {
+  // Tests in this describe simulate `platform: 'darwin'` while running on
+  // Ubuntu CI. The new #61 probe synchronously checks `/usr/bin/security`
+  // existence, which is absent on linux CI runners; injecting
+  // `fsExistsSync: () => true` makes the probe succeed so the rest of the
+  // dispatch behavior is what's actually being asserted. The probe-failure
+  // path is exercised explicitly in the second describe block below.
+  const PROBE_TRUE = () => true;
+
   it('does NOT invoke requireKeytar on darwin under default auto backend', async () => {
     let requireCalls = 0;
     const requireKeytar = () => {
@@ -40,6 +48,7 @@ describe('KeychainSecretStore — darwin auto default = security-CLI (#61)', () 
     const store = new KeychainSecretStore({
       requireKeytar,
       platform: 'darwin',
+      fsExistsSync: PROBE_TRUE,
       // exec stub never reached because we only call isAvailable().
       exec: noopExec,
     });
@@ -63,6 +72,7 @@ describe('KeychainSecretStore — darwin auto default = security-CLI (#61)', () 
     const store = new KeychainSecretStore({
       keytar: fakeKeytar,
       platform: 'darwin',
+      fsExistsSync: PROBE_TRUE,
       exec: noopExec,
     });
 
@@ -75,8 +85,6 @@ describe('KeychainSecretStore — darwin auto default = security-CLI (#61)', () 
     function captureExec(file, args, opts, cb) {
       calls.push({ file, args: args.slice() });
       const sub = args[0];
-      const sIdx = args.indexOf('-s');
-      const aIdx = args.indexOf('-a');
       const wIdx = args.indexOf('-w');
       if (sub === 'add-generic-password') return cb(null, '', '');
       if (sub === 'find-generic-password') return cb(null, `${args[wIdx + 1] || 'pw-stub'}\n`, '');
@@ -86,6 +94,7 @@ describe('KeychainSecretStore — darwin auto default = security-CLI (#61)', () 
 
     const store = new KeychainSecretStore({
       platform: 'darwin',
+      fsExistsSync: PROBE_TRUE,
       exec: captureExec,
       // No requireKeytar override needed — auto darwin never calls it.
     });

--- a/test/auth/keychain-secret-store-darwin-fallback.test.js
+++ b/test/auth/keychain-secret-store-darwin-fallback.test.js
@@ -3,29 +3,44 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { KeychainSecretStore } = require('../../lib/auth/keychain-secret-store');
+const { KeychainSecretStore: _KeychainSecretStore } = require('../../lib/auth/keychain-secret-store');
+
+// All constructor calls in this file simulate a darwin host. Default the
+// `/usr/bin/security` existence probe (#61) to true so the security-CLI
+// dispatch tests run on linux / win32 CI hosts where the real path doesn't
+// exist. Tests that exercise the probe failure path live in
+// `keychain-secret-store-darwin-default.test.js` and inject explicitly.
+function KeychainSecretStore(opts = {}) {
+  return new _KeychainSecretStore({ fsExistsSync: () => true, ...opts });
+}
 
 /**
- * Issue #39 — darwin security-CLI fallback.
+ * Issues #39 + #61 — darwin security-CLI behavior.
  *
- * macOS's hardened-runtime rejects bundled keytar.node inside Claude Desktop
- * with a Team ID mismatch. The store detects this at `_load()` time and falls
- * back to the macOS `security` CLI via `child_process.execFile`. Tests cover:
+ * #39 introduced a darwin-only security-CLI shell-out for the case where
+ * macOS's hardened-runtime rejected bundled keytar.node inside Claude Desktop.
+ * #61 promoted that path to the default on darwin (alpha-gate fix for the
+ * multi-client ACL identity split). On darwin under the default `auto`
+ * backend, the store engages `/usr/bin/security` directly without attempting
+ * keytar at all.
+ *
+ * The new-default-on-darwin pin lives in
+ * `keychain-secret-store-darwin-default.test.js`; this file covers the
+ * shared security-CLI dispatch behavior plus the explicit-backend opt-outs.
  *
  *  - Keytar-success path is preserved on every platform (existing tests in
- *    `secret-store.test.js` cover the basic round-trip; this file adds
- *    fallback-specific coverage).
- *  - On darwin, when `require('keytar')` throws (simulated via the
- *    `requireKeytar` injection seam), the store enters fallback mode and
+ *    `secret-store.test.js` cover the basic round-trip; this file covers
+ *    security-CLI-specific dispatch).
+ *  - On darwin under default `auto`, the store engages security-CLI mode and
  *    dispatches get/set/delete to a mocked `execFile`.
  *  - The "could not be found" stderr from `security` maps to keytar's
  *    null (get) / false (delete) return semantics.
  *  - Other stderr propagates as `SecretStoreError` with code
  *    `security_cli_failed`.
- *  - `isAvailable()` returns true in both keytar and fallback modes.
+ *  - `isAvailable()` returns true in both keytar and security-CLI modes.
  *  - On linux/win32, a keytar load failure still throws `keytar_unavailable`
- *    (no fallback engaged — the security CLI is darwin-only).
- *  - `findAll` returns [] in fallback mode.
+ *    (no security-CLI engagement — it's darwin-only).
+ *  - `findAll` returns [] in security-CLI mode.
  */
 
 /**
@@ -98,8 +113,8 @@ const REJECT_KEYTAR = () => {
   throw new Error("dlopen(keytar.node, 0x0001): code signature in mapping process and mapped file (non-platform) have different Team IDs");
 };
 
-describe('KeychainSecretStore — darwin security-CLI fallback (#39)', () => {
-  it('falls back to security-CLI on darwin when keytar require fails', async () => {
+describe('KeychainSecretStore — darwin security-CLI dispatch (#39 + #61)', () => {
+  it('engages security-CLI mode on darwin under default auto backend', async () => {
     const harness = fakeSecurityExec();
     const store = new KeychainSecretStore({
       requireKeytar: REJECT_KEYTAR,
@@ -109,7 +124,7 @@ describe('KeychainSecretStore — darwin security-CLI fallback (#39)', () => {
     assert.equal(await store.isAvailable(), true);
   });
 
-  it('round-trips set/get/delete via security CLI in fallback mode', async () => {
+  it('round-trips set/get/delete via security CLI on darwin', async () => {
     const harness = fakeSecurityExec();
     const store = new KeychainSecretStore({
       requireKeytar: REJECT_KEYTAR,
@@ -240,7 +255,7 @@ describe('KeychainSecretStore — darwin security-CLI fallback (#39)', () => {
     );
   });
 
-  it('findAll returns [] in fallback mode (security CLI has no enumerate-by-service)', async () => {
+  it('findAll returns [] in security-CLI mode (security CLI has no enumerate-by-service)', async () => {
     const harness = fakeSecurityExec({
       'abilities-mcp|siteA/access': 'AT',
       'abilities-mcp|siteA/refresh': 'RT',
@@ -272,7 +287,7 @@ describe('KeychainSecretStore — darwin security-CLI fallback (#39)', () => {
     assert.equal(setCall.args[wIdx + 1], trickyPassword);
   });
 
-  it('on darwin, when keytar IS available, fallback is NOT engaged', async () => {
+  it('on darwin with explicit backend=keytar, security-CLI is NOT engaged (#61 opt-out)', async () => {
     function fakeKeytar() {
       const map = new Map();
       return {
@@ -286,6 +301,7 @@ describe('KeychainSecretStore — darwin security-CLI fallback (#39)', () => {
     const trapExec = () => { execCalls += 1; };
     const store = new KeychainSecretStore({
       keytar: fakeKeytar(),
+      backend: 'keytar',
       platform: 'darwin',
       exec: trapExec,
     });
@@ -293,7 +309,7 @@ describe('KeychainSecretStore — darwin security-CLI fallback (#39)', () => {
     assert.equal(await store.get('abilities-mcp', 'siteA/access'), 'AT');
     const found = await store.findAll('abilities-mcp');
     assert.deepEqual(found, [{ account: 'sentinel', password: 'x' }]);
-    assert.equal(execCalls, 0, 'security CLI must not be called when keytar loads normally');
+    assert.equal(execCalls, 0, 'security CLI must not be called when keytar is explicitly opted into');
   });
 
   it('backend=keytar disables the darwin security-CLI fallback', async () => {

--- a/test/auth/secret-store.test.js
+++ b/test/auth/secret-store.test.js
@@ -84,7 +84,9 @@ describe('KeychainSecretStore (with stub)', () => {
   }
 
   it('round-trips through an injected keytar-shaped object', async () => {
-    const store = new KeychainSecretStore({ keytar: stubKeytar() });
+    // backend: 'keytar' opts out of the #61 darwin-default security-CLI path
+    // so the injected keytar is actually exercised on every CI platform.
+    const store = new KeychainSecretStore({ keytar: stubKeytar(), backend: 'keytar' });
     await store.set('abilities-mcp', 'siteA/access', 'AT');
     assert.equal(await store.get('abilities-mcp', 'siteA/access'), 'AT');
     await store.delete('abilities-mcp', 'siteA/access');
@@ -92,7 +94,7 @@ describe('KeychainSecretStore (with stub)', () => {
   });
 
   it('isAvailable() is true with injected keytar', async () => {
-    const store = new KeychainSecretStore({ keytar: stubKeytar() });
+    const store = new KeychainSecretStore({ keytar: stubKeytar(), backend: 'keytar' });
     assert.equal(await store.isAvailable(), true);
   });
 });


### PR DESCRIPTION
## Summary

Promote the v1.5.5 [#58](https://github.com/Wicked-Evolutions/abilities-mcp/issues/58) opt-in (`ABILITIES_MCP_KEYCHAIN_BACKEND=security-cli`) to the **default** on darwin. Under the default `auto` backend on macOS, `KeychainSecretStore` now engages `/usr/bin/security` directly without ever attempting to load keytar. Every bridge spawn — Claude Desktop's `.mcpb`, Claude Code via npm/node, Codex, terminal CLI — issues `SecKeychainItem*` calls through the same caller binary (`/usr/bin/security`), so macOS's per-binary ACL trusted-application list contains exactly one entry. After the operator's first "Always Allow" the entry is silently readable from every runtime.

Linux / win32 behavior unchanged (keytar via libsecret / Credential Manager — no analogous identity-split bug on those platforms).

Operator opt-out: `ABILITIES_MCP_KEYCHAIN_BACKEND=keytar`.

## Issue / Project / Phase

- Closes #61.
- Doc A Phase B.2 — abilities-mcp#61
- Project: [Abilities Suite Alpha & Roadmap](https://github.com/orgs/Wicked-Evolutions/projects/8)
- Sprint plan: `Plans/Alpha Release Gate/Alpha Release Gate + Issue Reconciliation 2026-05-07.md` (Influencentricity OS vault) — Phase B.2

## Sprint Plan Gate

```
Official WordPress Compatibility Review:
- Registry / source-of-truth impact: None. No ability registration, schema, callback, or permission semantics changed.
- Adapter / product-layer impact: Bridge auth backend default change on darwin only; no ability registration / schema / permission semantics changed; one-time operator-facing migration prompt documented in CHANGELOG.
```

## Architecture review (per #61 body — directions considered)

`#61` explicitly required architecture review before coding. Surfaced to orchestrator/J pre-implementation; recommended direction approved.

| Direction | Status | Reason |
|---|---|---|
| **A. Same backend across all runtimes by default (security-CLI on darwin)** | **Selected** | Single `/usr/bin/security` ACL identity across every runtime. Strictly *narrower* trusted-app set than today (1 binary vs. N). No `-A`, no `-T`, no weakening of macOS Keychain ACL semantics. |
| B. Explicit `-T` consumer-path list at write-time | Rejected | Trusted-app list grows linearly with installed clients. Unbounded across operator setups (system node, nvm node, Claude Desktop helper, Claude Code helper, Codex helper, Cursor's, etc.). Fragile across version updates. **Weaker** security than the selected path. |
| C. Canonical helper-identity binary the bridge ships | Rejected (alpha) | Requires shipping a signed helper, code-signing infra, install ceremony, update flow. Big surface for an alpha gate. `/usr/bin/security` already plays the canonical-helper role for free. |
| D. Storage outside macOS Keychain | Rejected (alpha) | Loses operator's Keychain-Access.app revoke affordance and OS-managed crypto. #61 body explicitly names "last resort." |
| E. Make Claude Desktop's `.mcpb` load keytar via signed-bundle workaround | Rejected | Addresses #39, not #61. Still leaves `node`-vs-`security` split for terminal CLI. Requires Anthropic Team-ID signing of our `keytar.node` which we don't control. |

## Keychain access model (per AGENT spec)

- **Service / account identity:** unchanged — `service = "abilities-mcp"`, `account = "<siteId>/<credKind>"`.
- **Trusted-app list (ACL):** exactly `/usr/bin/security`. No `-T` additions. No `-A`.
- **Caller binary at syscall time:** always `/usr/bin/security`, regardless of which runtime spawned the bridge.
- **Coverage:**
  - Claude Desktop `.mcpb` → bridge → `/usr/bin/security` ✅ (already shipping under #39 fallback; now also the default)
  - Claude Code (system node) → bridge → `/usr/bin/security` ✅ (changed; was keytar)
  - Codex (bundled node) → bridge → `/usr/bin/security` ✅ (changed; was sometimes keytar, sometimes security)
  - Terminal CLI → `/usr/bin/security` ✅ (changed; was keytar)
- **Unrelated local processes:** still need their own ACL approval to read; the change does NOT add them to the trusted list.

## Security constraints (per #61 — non-negotiable)

| Constraint | Compliance |
|---|---|
| No trust-all keychain setting | ✅ |
| No broad `-A` access flag | ✅ ([lib/auth/keychain-secret-store.js](lib/auth/keychain-secret-store.js) `_securitySet` invocation unchanged from v1.5.5) |
| No fix that makes secrets easier for unrelated local processes to read | ✅ Trusted-app set is *narrower* than today (one binary instead of N) |
| No weakening of macOS Keychain ACL semantics | ✅ Identical ACL semantics; only the caller binary identity is unified |
| Operator UX vs secret hygiene tradeoff | ✅ Strictly stronger hygiene than today |

## /usr/bin/security existence probe

`_load()` now probes `/usr/bin/security` on first use (synchronous `fs.existsSync`) and surfaces a typed `SecretStoreError` (`code: 'security_cli_unavailable'`) if absent — surfaces the corporate-locked / non-standard macOS edge case at first `isAvailable()` call rather than at first execFile spawn failure.

## findAll() darwin behavior

Per J's exact wording: `findAll()` is unavailable on the Darwin security-cli backend; current bridge flows do not rely on it. Wired into both the source comment ([lib/auth/keychain-secret-store.js](lib/auth/keychain-secret-store.js) above the method) and the CHANGELOG entry. Linux/Windows (keytar) continue to enumerate normally.

## Tests run

```
node --test test/auth/keychain-secret-store-darwin-default.test.js \
            test/auth/keychain-secret-store-darwin-fallback.test.js \
            test/auth/secret-store.test.js
→ tests 35  pass 35  fail 0  duration_ms 57.4

npm test
→ tests 367  pass 367  fail 0  duration_ms 30402.7
```

Test changes:
- **New:** `test/auth/keychain-secret-store-darwin-default.test.js` (7 tests) — pins #61 default behavior. Key pin: `requireKeytar` is never invoked on darwin under default `auto` backend. Probe failure path (typed `security_cli_unavailable` when `/usr/bin/security` is missing) covered for both auto and explicit `security-cli` backends. Probe-call-counted to confirm load-once memoization.
- **Updated:** `test/auth/keychain-secret-store-darwin-fallback.test.js` — the existing "on darwin when keytar IS available, fallback is NOT engaged" test re-pinned to `backend: 'keytar'` explicit (the new opt-out path). Test file's KeychainSecretStore wrapper auto-injects `fsExistsSync: () => true` so darwin-platform tests run on Ubuntu CI without hitting the new probe.
- **Updated:** `test/auth/secret-store.test.js` — `KeychainSecretStore (with stub)` tests now pass `backend: 'keytar'` so injected keytar is exercised on every CI platform (otherwise darwin auto would ignore the injection and engage security-CLI mode).

## Live verification evidence

Real macOS workstation: `Darwin 25.3.0 arm64` / `macOS 26.3.1` / `node v24.10.0` / `/usr/bin/security` = `662480 bytes -rwxr-xr-x root:wheel`.

Synthetic-service harness (`abilities-mcp-issue61-verify` — never touched real OAuth/AppPwd entries) ran 5 phases:

| Phase | Pin | Result |
|---|---|---|
| A | Fresh write under darwin auto default round-trips through real `/usr/bin/security` | ✅ wrote + read MATCH, no prompt observed (writer = reader = `/usr/bin/security` in this same process) |
| B | Entry findable by SERVICE+ACCOUNT through `/usr/bin/security` | ✅ exit 0; class `genp`; svce/acct attributes set; cdat/mdat populated |
| C | `requireKeytar` is NEVER invoked under darwin auto | ✅ `requireKeytarCalls === 0` after `_load + set + get` |
| D | Negative control — `backend=keytar` still loads keytar | ✅ `keytarCalls === 1` after `isAvailable()`; opt-out routing works |
| E | Cleanup — synthetic entry removed | ✅ `delete` returned true; post-delete `get` returns null; `security find-generic-password -s abilities-mcp-issue61-verify` returns "could not be found" |

**Operator-side GUI verification (out of scope for programmatic harness):**

The end-to-end "exact prompt count" portion of the #61 acceptance gate requires GUI interaction (Always Allow click in macOS keychain modal), which the programmatic harness can't drive. **Hand-off reproducer for J:**

1. **Baseline:** check out `main` at `8a243aa`. From a fresh shell where the bridge has never been used, run `abilities-mcp list-sites`. Note the prompt(s).
2. **Apply branch:** `git switch fix/61-darwin-keychain-default-security-cli`. Either click "Always Allow" once on the next prompt for an existing entry, OR `abilities-mcp add-site --force <site>` to write a fresh entry under the new default.
3. **Cross-runtime exercise:** open Claude Desktop with the bridge configured. Open Claude Code with the bridge MCP. Open Codex with the bridge MCP. Run one ability call from each. Expected: 0 prompts after the initial Always Allow / fresh add.
4. **Negative control:** `ABILITIES_MCP_KEYCHAIN_BACKEND=keytar abilities-mcp list-sites` from terminal. Expected: prompts return (proves the fix is in the default path, not a side-effect).
5. **Visual ACL confirmation:** Keychain Access.app → search `abilities-mcp` → Cmd-I on a fresh entry → "Access Control" tab. Expected: only `/usr/bin/security` listed under "Always allow access by these applications."

The synthetic-service harness file (`test/__verify_issue61_live.js`) was created during verification and removed before commit; it is not part of the diff.

## Deviations

None.

## Out of scope

- #60 multisite OAuth dot-notation routing (known-limitation, post-alpha).
- Linux / Windows secret store paths.
- Long-term migration off macOS Keychain.
- Migration helper (J directed: belongs post-alpha if live verification surfaces a worse upgrade path than CHANGELOG describes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)