### PR TITLE
fix(keychain): pass absolute /usr/bin/security path to execFile (#66)

### DIFF
--- a/lib/auth/keychain-secret-store.js
+++ b/lib/auth/keychain-secret-store.js
@@ -281,7 +281,12 @@ class KeychainSecretStore {
         timeout: this._securityTimeoutMs,
         killSignal: 'SIGTERM',
       };
-      this._exec('security', args, opts, (err, stdout, stderr) => {
+      // Issue #66: pass the absolute path explicitly so execFile bypasses
+      // PATH resolution. Bare `'security'` would resolve through the
+      // operator's PATH and could route the syscall through a shadowing
+      // binary (brew, nvm, ~/bin, etc.), breaking #61's "trusted caller
+      // binary at syscall time = /usr/bin/security" guarantee.
+      this._exec(SECURITY_CLI_PATH, args, opts, (err, stdout, stderr) => {
         const stdoutStr = typeof stdout === 'string'
           ? stdout
           : (stdout ? stdout.toString() : '');

--- a/test/auth/keychain-secret-store-darwin-default.test.js
+++ b/test/auth/keychain-secret-store-darwin-default.test.js
@@ -104,10 +104,43 @@ describe('KeychainSecretStore — darwin auto default = security-CLI (#61)', () 
     await store.delete('abilities-mcp', 'siteA/access');
 
     assert.equal(calls.length, 3, 'set/get/delete must each invoke security CLI');
-    assert.equal(calls[0].file, 'security');
     assert.equal(calls[0].args[0], 'add-generic-password');
     assert.equal(calls[1].args[0], 'find-generic-password');
     assert.equal(calls[2].args[0], 'delete-generic-password');
+  });
+
+  it('passes the absolute /usr/bin/security path to execFile (no PATH resolution) — #66 regression pin', async () => {
+    // Issue #66: the load-time probe pins SECURITY_CLI_PATH but a prior
+    // version of _execSecurity passed bare 'security' to execFile, which
+    // would resolve through PATH and could route the syscall through a
+    // shadowing binary (brew, nvm, ~/bin). Pin the absolute path explicitly
+    // so a future revert to bare-name fails this test loudly.
+    const calls = [];
+    function captureExec(file, args, opts, cb) {
+      calls.push({ file });
+      const sub = args[0];
+      const wIdx = args.indexOf('-w');
+      if (sub === 'add-generic-password') return cb(null, '', '');
+      if (sub === 'find-generic-password') return cb(null, `${args[wIdx + 1] || 'pw'}\n`, '');
+      if (sub === 'delete-generic-password') return cb(null, '', '');
+      return cb(Object.assign(new Error('unknown'), { stderr: 'unknown' }));
+    }
+
+    const store = new KeychainSecretStore({
+      platform: 'darwin',
+      fsExistsSync: PROBE_TRUE,
+      exec: captureExec,
+    });
+
+    await store.set('abilities-mcp', 'siteA/access', 'AT');
+    await store.get('abilities-mcp', 'siteA/access');
+    await store.delete('abilities-mcp', 'siteA/access');
+
+    assert.equal(calls.length, 3);
+    for (const call of calls) {
+      assert.equal(call.file, '/usr/bin/security',
+        'execFile must be called with the absolute /usr/bin/security path to bypass PATH resolution (#66)');
+    }
   });
 });
 

--- a/test/auth/keychain-secret-store-darwin-fallback.test.js
+++ b/test/auth/keychain-secret-store-darwin-fallback.test.js
@@ -54,10 +54,14 @@ function fakeSecurityExec(seed = {}) {
   function exec(file, args, opts, cb) {
     calls.push({ file, args: args.slice(), opts });
 
-    if (file !== 'security') {
-      return cb(Object.assign(new Error('unexpected exec'), {
+    // Issue #66: production code must call execFile with the absolute
+    // /usr/bin/security path (no PATH resolution). Reject bare 'security'
+    // here so a regression to bare-name resolves to "unexpected exec" and
+    // every dispatch test fails loudly instead of silently passing.
+    if (file !== '/usr/bin/security') {
+      return cb(Object.assign(new Error(`unexpected exec file: ${file}`), {
         code: 1,
-        stderr: 'unexpected exec',
+        stderr: `unexpected exec file: ${file}`,
       }));
     }
 
@@ -231,7 +235,7 @@ describe('KeychainSecretStore — darwin security-CLI dispatch (#39 + #61)', () 
 
   it('maps a stuck security CLI prompt to SecretStoreError code=security_cli_timeout', async () => {
     function timedOutExec(file, args, opts, cb) {
-      assert.equal(file, 'security');
+      assert.equal(file, '/usr/bin/security');
       assert.equal(args[0], 'find-generic-password');
       assert.equal(opts.timeout, 5);
       cb(Object.assign(new Error('operation timed out'), {


### PR DESCRIPTION
## Summary

PR #63 added the `SECURITY_CLI_PATH = '/usr/bin/security'` constant and used it in the load-time probe at [lib/auth/keychain-secret-store.js:198](lib/auth/keychain-secret-store.js#L198), but `_execSecurity()` at line 284 still passed bare `'security'` to `execFile`, which resolves through `PATH`. A shadowing binary earlier in `PATH` (`brew`, `nvm`, `~/bin`, etc.) would route the `SecKeychainItem*` syscall through that binary instead of `/usr/bin/security`, breaking #61's "trusted caller binary at syscall time = `/usr/bin/security`" guarantee.

One-identifier swap in production code, plus test updates that pin the absolute path so a future revert to bare-name fails loudly.

## Issue / Project / Phase

- Closes #66.
- Doc A Phase B.2 follow-up — gates Phase C.1 RC artifact build (per reviewer verdict)
- Project: [Abilities Suite Alpha & Roadmap](https://github.com/orgs/Wicked-Evolutions/projects/8)
- Source: GPT 5.5 reviewer source-check on merged PR #63 (2026-05-07)

## Sprint Plan Gate

```
Official WordPress Compatibility Review:
- Registry / source-of-truth impact: None. No ability registration, schema, callback, or permission semantics changed.
- Adapter / product-layer impact: Bridge keychain syscall now bypasses PATH resolution; preserves #61's caller-identity guarantee. No operator-facing behavior change, no CHANGELOG entry needed (security model fix internal to the bridge).
```

## Production change

```diff
- this._exec('security', args, opts, (err, stdout, stderr) => {
+ // Issue #66: pass the absolute path explicitly so execFile bypasses
+ // PATH resolution. Bare `'security'` would resolve through the
+ // operator's PATH and could route the syscall through a shadowing
+ // binary (brew, nvm, ~/bin, etc.), breaking #61's "trusted caller
+ // binary at syscall time = /usr/bin/security" guarantee.
+ this._exec(SECURITY_CLI_PATH, args, opts, (err, stdout, stderr) => {
```

The constant and the load-time probe both already pinned the absolute path; this aligns the runtime exec with that pin.

## Test changes

- **`keychain-secret-store-darwin-default.test.js`** — new dedicated regression test "passes the absolute /usr/bin/security path to execFile (no PATH resolution) — #66 regression pin" asserts the absolute path on every `set`/`get`/`delete` invocation. The pre-existing test "uses the security-CLI execFile path" had the file assertion absorbed into the new dedicated pin.
- **`keychain-secret-store-darwin-fallback.test.js`** — `fakeSecurityExec()` helper now rejects any `file !== '/usr/bin/security'` so a future revert to bare-name resolves to "unexpected exec file: security" and every dispatch test through the helper fails loudly. The timeout test's `assert.equal(file, 'security')` updated to `'/usr/bin/security'`.

## Tests run

```
node --test test/auth/keychain-secret-store-darwin-default.test.js \
            test/auth/keychain-secret-store-darwin-fallback.test.js \
            test/auth/secret-store.test.js
→ tests 36  pass 36  fail 0  duration_ms 56.3

npm test
→ tests 368  pass 368  fail 0  duration_ms 30370.9
   (+1 from 367 — the new regression pin)
```

## Negative-control verification

Temporarily reverted the production fix (sed `SECURITY_CLI_PATH` back to `'security'`) and re-ran the focused tests:

```
✖ passes the absolute /usr/bin/security path to execFile (no PATH resolution) — #66 regression pin
  AssertionError: execFile must be called with the absolute /usr/bin/security path to bypass PATH resolution (#66)
```

Pin fires loudly with the issue-named message. Production code restored before commit.

## Deviations

None.

## Out of scope

- Linux / Windows secret store paths (same scope as #61).
- Any refactoring of the `_exec` / probe relationship beyond pinning the constant.
- CHANGELOG entry: this is an internal security-model fix to the bridge code with no operator-facing behavior change or surface-shape change. The existing `[Unreleased]` entry from #63 already covers the keychain default change; this PR strengthens the implementation to match the documented model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)