### PR TITLE
chore(release): 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Abilities MCP are documented here.
 
-## [Unreleased]
+## [1.6.0] - 2026-05-07
 
 ### Fixed
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.3",
   "name": "abilities-mcp",
   "display_name": "WordPress (Abilities MCP)",
-  "version": "1.5.5",
+  "version": "1.6.0",
   "description": "Connect AI clients to WordPress through the Abilities API. One-click bridge to your site's content, users, plugins, and Fluent ecosystem.",
   "long_description": "Abilities MCP is the open-source bridge that turns any WordPress site into a first-class MCP server. Install this bundle, type your site URL + WordPress username + application password, and your AI client gets typed access to content, users, media, plugins, themes, settings, FluentCRM/Forms/Community, and any other ability registered through the WordPress Abilities API.\n\nRequires the `abilities-mcp-adapter` and `abilities-for-ai` plugins on the WordPress site. The adapter exposes the MCP endpoint; this bundle is the client-side bridge running on your machine.",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wickedevolutions/abilities-mcp",
-  "version": "1.5.5",
+  "version": "1.6.0",
   "description": "Open-source MCP bridge connecting AI clients to WordPress through the Abilities API — multi-site routing, zero dependencies",
   "main": "abilities-mcp.js",
   "bin": {


### PR DESCRIPTION
## Summary

Phase C.1 release prep for v1.6.0 — bumps package.json + manifest.json + package-lock.json + finalizes CHANGELOG `[Unreleased]` → `[1.6.0] - 2026-05-07`.

Minor version (1.6.0, not 1.5.6) per reviewer + J ratified call: the Darwin default backend changed, upgrade UX changed (one-time prompt for existing operators with locked recovery wording), and the security model was tightened (PATH-pinned absolute /usr/bin/security path). Even though the code diff is small, the operator-facing behavior is not just a patch.

The release content is the merged Phase B.2 #63 fix (Darwin auto defaults to security-CLI; closed #61) plus the Phase B.2 follow-up #67 fix (PATH-pin /usr/bin/security; closed #66). No new code in this PR.

## Official WordPress Compatibility Review

- Registry / source-of-truth impact: None. Version-bump + CHANGELOG date.
- Adapter / product-layer impact: None. Release prep only.

## Sprint phase / linkage

- Doc A Phase C.1 — release artifact preparation
- Closes nothing; release tag follows at C.6 per J authorization

## Deviations

Deviations: None.