### PR TITLE
fix(multisite): drop synthetic 'main' slug to prevent silent wrong-context routing (#70)

### DIFF
--- a/lib/cli/multisite-probe.js
+++ b/lib/cli/multisite-probe.js
@@ -177,15 +177,28 @@ function buildMultisiteBlock(parentSiteUrl, items) {
 /**
  * Map a `multisite/list-sites` item to a slug usable for dot-notation
  * routing. Subdomain mode → first label of the subdomain. Path mode →
- * first segment of the path. Network root → 'main'. Mapped-domain
- * subsites → first label of the domain.
+ * first segment of the path. Mapped-domain subsites → first label of
+ * the domain.
+ *
+ * Issue #70: returns null when `itemDomain === parentHost && itemPath
+ * is empty`. That case used to synthesize a `'main'` slug intended to
+ * point at the network root, but in subdomain-style multisite the only
+ * blog matching parent host is the parent subsite itself — so the
+ * resulting `<site>.main` URL was the source subsite, not the root,
+ * silently routing dot-notation calls to the wrong context. Skipping
+ * the slug means: in subdomain-style the network root is reachable via
+ * its domain-label slug from the fall-through (`<site>.<root-label>`);
+ * in path-style the network root is the parent itself and reachable as
+ * `<site>` (no dot). A first-class `'main' → blog_id 1` alias is
+ * post-alpha work.
  */
 function deriveSubsiteSlug(parentHost, item) {
   const itemDomain = String(item.domain || '').toLowerCase().replace(/^www\./, '');
   const itemPath = String(item.path || '/').replace(/^\/+|\/+$/g, '');
 
   if (itemDomain === parentHost) {
-    return itemPath === '' ? 'main' : itemPath.split('/')[0];
+    if (itemPath === '') return null;
+    return itemPath.split('/')[0];
   }
   if (itemDomain.endsWith('.' + parentHost)) {
     const prefix = itemDomain.slice(0, itemDomain.length - parentHost.length - 1);

--- a/test/cli/add-site.test.js
+++ b/test/cli/add-site.test.js
@@ -408,7 +408,12 @@ describe('CLI add-site', () => {
     // site.multisite[slug] as a URL string) and lib/connection-pool.js
     // (treats it identically). buildMultisiteBlock must produce that shape.
 
-    it('maps subdomain-mode subsites to first-label slugs', () => {
+    it('maps subdomain-mode subsites to first-label slugs (no synthetic main)', () => {
+      // Issue #70: the network-root item (blog_id 1, parent host) used to
+      // produce a `main` slug. That synthetic alias is gone — the network
+      // root is reachable as the parent site_id itself when add-site runs
+      // against the root, so the dot-notation block contains only the
+      // siblings.
       const items = [
         { blog_id: 1, domain: 'wickedevolutions.com', path: '/', url: 'https://wickedevolutions.com' },
         { blog_id: 2, domain: 'community.wickedevolutions.com', path: '/', url: 'https://community.wickedevolutions.com' },
@@ -417,14 +422,17 @@ describe('CLI add-site', () => {
       ];
       const block = buildMultisiteBlock('https://wickedevolutions.com', items);
       assert.deepEqual(block, {
-        main: 'https://wickedevolutions.com',
         community: 'https://community.wickedevolutions.com',
         knowledge: 'https://knowledge.wickedevolutions.com',
         test1: 'https://test1.wickedevolutions.com',
       });
+      assert.ok(!('main' in block), 'no synthetic `main` slug (#70)');
     });
 
-    it('maps path-mode subsites to first-segment slugs', () => {
+    it('maps path-mode subsites to first-segment slugs (no synthetic main)', () => {
+      // Issue #70: in path-style multisite the network-root item also
+      // used to synthesize `main`. Now it is skipped; the network root is
+      // the parent site itself (reachable as `<site>` without dot).
       const items = [
         { blog_id: 1, domain: 'example.com', path: '/', url: 'https://example.com' },
         { blog_id: 2, domain: 'example.com', path: '/blog2/', url: 'https://example.com/blog2' },
@@ -432,25 +440,26 @@ describe('CLI add-site', () => {
       ];
       const block = buildMultisiteBlock('https://example.com', items);
       assert.deepEqual(block, {
-        main: 'https://example.com',
         blog2: 'https://example.com/blog2',
         store: 'https://example.com/store',
       });
+      assert.ok(!('main' in block), 'no synthetic `main` slug (#70)');
     });
 
     it('disambiguates colliding slugs by blog_id', () => {
       // Pathological case: subdomain + path mode mixed where two sites
       // would resolve to the same first-label slug. Block must preserve
-      // both entries by appending blog_id.
+      // both entries by appending blog_id. The network-root item
+      // (blog_id 1) is skipped per #70.
       const items = [
         { blog_id: 1, domain: 'example.com', path: '/', url: 'https://example.com' },
         { blog_id: 2, domain: 'shop.example.com', path: '/', url: 'https://shop.example.com' },
         { blog_id: 3, domain: 'shop.example.com', path: '/', url: 'https://shop.example.com/alt' },
       ];
       const block = buildMultisiteBlock('https://example.com', items);
-      assert.equal(block.main, 'https://example.com');
       assert.equal(block.shop, 'https://shop.example.com');
       assert.equal(block['shop-3'], 'https://shop.example.com/alt');
+      assert.ok(!('main' in block), 'no synthetic `main` slug (#70)');
     });
 
     it('strips www. from parent host before deriving slugs', () => {
@@ -459,25 +468,56 @@ describe('CLI add-site', () => {
         { blog_id: 2, domain: 'community.example.com', path: '/', url: 'https://community.example.com' },
       ];
       const block = buildMultisiteBlock('https://www.example.com', items);
-      assert.equal(block.main, 'https://example.com');
       assert.equal(block.community, 'https://community.example.com');
+      assert.ok(!('main' in block), 'no synthetic `main` slug (#70)');
     });
 
     it('skips items missing a URL', () => {
       const items = [
-        { blog_id: 1, domain: 'example.com', path: '/', url: 'https://example.com' },
-        { blog_id: 2, domain: 'community.example.com', path: '/' },
+        { blog_id: 2, domain: 'community.example.com', path: '/', url: 'https://community.example.com' },
+        { blog_id: 3, domain: 'shop.example.com', path: '/' },
       ];
       const block = buildMultisiteBlock('https://example.com', items);
-      assert.equal(Object.keys(block).length, 1);
-      assert.equal(block.main, 'https://example.com');
+      assert.deepEqual(block, { community: 'https://community.example.com' });
     });
 
-    it('deriveSubsiteSlug returns "main" for the network root', () => {
+    it('subdomain-style multisite with subsite parent: no `main` key in block (#70 cold-AI scenario)', () => {
+      // Phase C.3 cold-AI scenario: operator runs add-site against a
+      // subdomain-style subsite (community.wickedevolutions.com), not
+      // against the network root. The bridge probes multisite/list-sites
+      // and builds the dot-notation block. Pre-fix, the parent-host item
+      // (the subsite itself, with path '/') synthesized a `main` slug
+      // whose URL was the SOURCE SUBSITE — agents calling
+      // `<site>.main` silently acted on community.* instead of the
+      // network root. Post-fix the synthetic alias is gone; the network
+      // root is reachable as `<site>.<root-domain-label>`
+      // (`<site>.wickedevolutions`) via the fall-through branch.
+      const items = [
+        { blog_id: 1, domain: 'wickedevolutions.com', path: '/', url: 'https://wickedevolutions.com' },
+        { blog_id: 2, domain: 'community.wickedevolutions.com', path: '/', url: 'https://community.wickedevolutions.com' },
+        { blog_id: 3, domain: 'knowledge.wickedevolutions.com', path: '/', url: 'https://knowledge.wickedevolutions.com' },
+        { blog_id: 4, domain: 'test1.wickedevolutions.com', path: '/', url: 'https://test1.wickedevolutions.com' },
+      ];
+      const block = buildMultisiteBlock('https://community.wickedevolutions.com', items);
+
+      assert.ok(!('main' in block),
+        '`main` slug must not appear when add-site parent is a subdomain subsite (#70)');
+      assert.equal(block.wickedevolutions, 'https://wickedevolutions.com',
+        'network root reachable via its domain-label slug (fall-through branch)');
+      assert.equal(block.knowledge, 'https://knowledge.wickedevolutions.com');
+      assert.equal(block.test1, 'https://test1.wickedevolutions.com');
+      // The source subsite (community.wickedevolutions.com — itemDomain
+      // === parentHost && itemPath === '') is skipped: it is the parent
+      // site_id itself, addressable without a dot.
+      assert.ok(!('community' in block),
+        'source subsite is the parent site_id itself, not a dot-notation entry');
+    });
+
+    it('deriveSubsiteSlug returns null when item is the parent root (#70 — was "main")', () => {
       assert.equal(
         deriveSubsiteSlug('example.com',
           { domain: 'example.com', path: '/' }),
-        'main');
+        null);
     });
 
     it('deriveSubsiteSlug returns first label for subdomain subsites', () => {

--- a/test/cli/multisite-probe.test.js
+++ b/test/cli/multisite-probe.test.js
@@ -29,7 +29,9 @@ const ENDPOINT = 'https://network.example.com/wp-json/mcp/mcp-adapter-default-se
 const ACCESS_TOKEN = 'AT-test';
 
 function makeSubsite(i) {
-  // i = 1 → main (network root). i > 1 → subdomain subsite.
+  // i = 1 → network root. i > 1 → subdomain subsite. Per #70, the network
+  // root item is skipped by buildMultisiteBlock (no synthetic `main`
+  // slug), so block size in these pagination tests is N - 1 not N.
   if (i === 1) {
     return { blog_id: 1, domain: 'network.example.com', path: '/', url: 'https://network.example.com' };
   }
@@ -105,7 +107,8 @@ describe('probeMultisite — pagination (Issue #49)', () => {
       deps: { request },
     });
     assert.equal(r.reason, 'multisite-root');
-    assert.equal(Object.keys(r.block).length, 100);
+    // 100 fixture items - 1 (network root, skipped per #70) = 99 in block.
+    assert.equal(Object.keys(r.block).length, 99);
     // The page param is REQUIRED — pinned via call sequence so a future
     // regression where page defaults to 1 silently fails here, not in
     // the data assertion above.
@@ -130,7 +133,8 @@ describe('probeMultisite — pagination (Issue #49)', () => {
       deps: { request },
     });
     assert.equal(r.reason, 'multisite-root');
-    assert.equal(Object.keys(r.block).length, 101,
+    // 101 fixture items - 1 (network root, skipped per #70) = 100 in block.
+    assert.equal(Object.keys(r.block).length, 100,
       'partial page on page 2 (1 item) must NOT be dropped — termination ordering pins this');
     assert.deepEqual(calls, [
       { page: 1, per_page: 100 },
@@ -147,7 +151,8 @@ describe('probeMultisite — pagination (Issue #49)', () => {
       deps: { request },
     });
     assert.equal(r.reason, 'multisite-root');
-    assert.equal(Object.keys(r.block).length, 250);
+    // 250 fixture items - 1 (network root, skipped per #70) = 249 in block.
+    assert.equal(Object.keys(r.block).length, 249);
     assert.deepEqual(calls, [
       { page: 1, per_page: 100 },
       { page: 2, per_page: 100 },
@@ -167,7 +172,8 @@ describe('probeMultisite — pagination (Issue #49)', () => {
       deps: { request },
     });
     assert.equal(r.reason, 'multisite-root');
-    assert.equal(Object.keys(r.block).length, 100);
+    // 100 fixture items - 1 (network root, skipped per #70) = 99 in block.
+    assert.equal(Object.keys(r.block).length, 99);
     assert.deepEqual(calls, [{ page: 1, per_page: 100 }]);
   });
 
@@ -180,7 +186,8 @@ describe('probeMultisite — pagination (Issue #49)', () => {
       deps: { request },
     });
     assert.equal(r.reason, 'multisite-root');
-    assert.equal(Object.keys(r.block).length, 250);
+    // 250 fixture items - 1 (network root, skipped per #70) = 249 in block.
+    assert.equal(Object.keys(r.block).length, 249);
     assert.deepEqual(calls, [
       { page: 1, per_page: 100 },
       { page: 2, per_page: 100 },


### PR DESCRIPTION
## Summary

`deriveSubsiteSlug()` previously synthesized a `'main'` slug whenever a `multisite/list-sites` item's `domain` matched `parentHost` AND its `path` was empty. The intent (per the comment block at `multisite-probe.js:178-181`) was *"network root → main"*, but the check is *"item domain matches parent host."* In **subdomain-style** multisite the parent IS a subsite, not the network root; the only blog matching parent host is the source subsite itself. So `'main'` got generated as a slug whose URL was the source subsite URL — agents calling `<site>.main` with intent to act on the network root silently acted on the source subsite instead. No error, no warning.

Fix shape 1 (smallest viable, per #70 reviewer-ratified direction): the branch returns `null` instead of `'main'` when `itemPath === ''`. The path-style sibling case (`itemPath.split('/')[0]`) is preserved. Network root is reachable via:
- subdomain-style with subsite parent → `<site>.<network-root-domain-label>` from the fall-through branch
- path-style with root parent → `<site>` (no dot) — the parent site_id itself

A first-class `'main' → blog_id 1` alias is explicitly post-alpha work.

## Issue / Project / Phase

- Closes #70.
- Doc A Phase C.3 follow-up — gates Phase C.6 release authorization
- Project: [Abilities Suite Alpha & Roadmap](https://github.com/orgs/Wicked-Evolutions/projects/8)
- Source: Phase C.3 cold-AI smoke 2026-05-07 (External Reviewer + cold AI agreed)

## Sprint Plan Gate

```
Official WordPress Compatibility Review:
- Registry / source-of-truth impact: None.
- Adapter / product-layer impact: Bridge multisite-block slug-derivation correction — operator-trust surface, no ability registration / schema / permission semantics changed.
```

## Production change

```diff
 function deriveSubsiteSlug(parentHost, item) {
   const itemDomain = String(item.domain || '').toLowerCase().replace(/^www\./, '');
   const itemPath = String(item.path || '/').replace(/^\/+|\/+$/g, '');

   if (itemDomain === parentHost) {
-    return itemPath === '' ? 'main' : itemPath.split('/')[0];
+    if (itemPath === '') return null;
+    return itemPath.split('/')[0];
   }
   ...
 }
```

The comment block above the function is rewritten to document the new semantics and reference #70.

## Live verification — exact failure shape (binding evidence per dispatch)

Same fixture as the cold-AI scenario in #70 (`add-site` against `community.wickedevolutions.com`, four sites returned by `multisite/list-sites`):

**BEFORE this PR (current main, bug present):**
```json
{
  "wickedevolutions": "https://wickedevolutions.com",
  "main": "https://community.wickedevolutions.com",
  "knowledge": "https://knowledge.wickedevolutions.com",
  "test1": "https://test1.wickedevolutions.com"
}
```

`<site>.main` → `https://community.wickedevolutions.com` (source subsite — silent wrong context).

**AFTER this PR:**
```json
{
  "wickedevolutions": "https://wickedevolutions.com",
  "knowledge": "https://knowledge.wickedevolutions.com",
  "test1": "https://test1.wickedevolutions.com"
}
```

`<site>.main` → key not present in block. Network root reachable as `<site>.wickedevolutions`. The source subsite is the parent site_id itself.

Captured by stashing and un-stashing the production change against the same `buildMultisiteBlock` fixture.

## 4-phase verification matrix

**Phase 1 — positive:** new pin "subdomain-style multisite with subsite parent: no \`main\` key in block (#70 cold-AI scenario)" in [test/cli/add-site.test.js](test/cli/add-site.test.js) asserts the block omits `'main'` and exposes the network root via its domain-label slug. `node --test test/cli/add-site.test.js` → 31/31 pass.

**Phase 2 — negative control / preserved behavior:** existing path-mode and subdomain-mode tests still pass with `main` removed from expected output. Network root reachable via `<site>` (parent, no dot) in path-style; via `<site>.<root-domain-label>` in subdomain-style with subsite parent. Existing non-`main` slugs (`<site>.<subdomain>` / `<site>.<path-segment>`) unchanged.

**Phase 3 — behavior-rollback:** sed-reverted `if (itemPath === '') return null;` back to `if (itemPath === '') return 'main';`, re-ran focused tests:

```
✖ subdomain-style multisite with subsite parent: no `main` key in block (#70 cold-AI scenario)
  AssertionError: `main` slug must not appear when add-site parent is a subdomain subsite (#70)
✖ deriveSubsiteSlug returns null when item is the parent root (#70 — was "main")
  AssertionError [ERR_ASSERTION]
+ 4 existing schema-mapping tests fired with "no synthetic `main` slug (#70)"
ℹ fail 6
```

6 tests failed loudly with `#70`-named messages. Production restored.

## Out of scope (per #70)

- Path-style multisite `'main' = network root` semantics redesign — post-alpha with blog_id-based detection.
- Any alternative `'main' → network root` alias system.
- Tests for behavior beyond unit pin on `buildMultisiteBlock` / `deriveSubsiteSlug`.
- Routing-layer `.main` paths in `lib/config.js` / `lib/connection-pool.js` — operators with manually-edited `wp-sites.json` may still keep a `'main'` entry; this PR only stops the bridge from auto-generating one.
- CHANGELOG entry: this is the C.3 follow-up to v1.6.0; orchestrator/J coordinate the changelog wording for the next release across the parallel C.4 work.

## Tests run

```
node --test test/cli/add-site.test.js
→ tests 31  pass 31  fail 0

npm test
→ tests 369  pass 369  fail 0  duration_ms 4967
   (+1 from 368 — the new #70 cold-AI scenario pin)
```

## Deviations

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)