### PR TITLE
chore(changelog): #70 migration note — pre-1.6.0 stale 'main' aliases in wp-sites.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to Abilities MCP are documented here.
 
 - **Full OAuth grant does not imply full execution. Abilities for AI module permissions remain an independent per-blog gate.** A granted OAuth scope is necessary but not sufficient to execute an ability. Abilities for AI's module permission settings (per-blog on multisite, configured at *Abilities for AI → Permissions* in wp-admin) gate execution independently — if a module's read/write/delete tier is disabled there, the OAuth-scope-bearing token will receive `[ability_disabled]` 403 errors with explicit operator remediation guidance, regardless of the granted scope set. The two gates apply together by design (Principle 5 — Permissions Stay Layered) to prevent AI sessions from escalating their own permissions via the OAuth surface.
 
+- **Pre-1.6.0 add-site runs may have written stale `main` aliases into multisite blocks of `wp-sites.json` (Issue [#70](https://github.com/Wicked-Evolutions/abilities-mcp/issues/70)).** v1.6.0 includes the fix that no longer generates `main` slugs, but existing `wp-sites.json` files written by earlier versions retain those keys and would silently route `<site>.main` to the source subsite instead of the network root. Operators upgrading from earlier versions: either re-run `add-site` against any affected subsite to regenerate its multisite block fresh under v1.6.0+ logic, or manually edit `~/.abilities-mcp/wp-sites.json` to remove the `"main": ...` entry from each affected `multisite` block. The `<site>.<network-root-domain-label>` slug (e.g., `wicked-community.wickedevolutions`) continues to route to the network root and remains the supported alias.
+
 
 ## [1.5.5] - 2026-05-05
 


### PR DESCRIPTION
## Summary

Phase C.4/C.5 follow-up to bridge #70 (merged 3f02353). Adds an operator-facing migration note to the existing `[1.6.0]` Known limitations block describing the stale-`main`-alias scenario for operators upgrading from pre-1.6.0 versions.

The #70 fix prevents NEW add-site runs from generating the bogus `main` slug, but existing `wp-sites.json` files written by earlier versions retain those keys and would silently route `<site>.main` to the source subsite instead of the network root. Two operator paths to clean up: re-run `add-site` (regenerates the multisite block under v1.6.0+ logic), or manually edit `wp-sites.json` to remove `"main": ...` keys from affected multisite blocks.

This wording must also land in the bridge GitHub Release notes for v1.6.0 since `.mcpbignore` excludes `CHANGELOG.md` from the .mcpb bundle.

## Official WordPress Compatibility Review

- Registry / source-of-truth impact: None.
- Adapter / product-layer impact: None. CHANGELOG-only docs change.

## Sprint linkage

- Doc A Phase C.4/C.5 — operator-facing migration note for #70
- Reviewer-locked wording 2026-05-07

## Deviations

Deviations: None.