### PR TITLE
fix(sanitizer): normalize broken inputSchema to {type:'object'} (#78)

### DIFF
--- a/lib/sanitizer.js
+++ b/lib/sanitizer.js
@@ -65,8 +65,14 @@ function sanitizeToolsList(msg, log) {
     delete tool.type;
     delete tool.outputSchema;
 
-    // Validate schema and log warnings
-    if (tool.inputSchema) {
+    // Normalize broken or non-object inputSchema (defensive — broken upstream
+    // schemas would otherwise 400 the API and break the entire tool list).
+    if (!tool.inputSchema || typeof tool.inputSchema !== 'object' || Array.isArray(tool.inputSchema)) {
+      if (tool.inputSchema !== undefined) {
+        _log(`SCHEMA NORMALIZE [${tool.name || '(unnamed)'}]: inputSchema not a valid object — defaulted to {type:'object'}`);
+      }
+      tool.inputSchema = { type: 'object' };
+    } else {
       validateToolSchema(tool.name || '(unnamed)', tool.inputSchema, _log);
     }
 

--- a/test/sanitizer.test.js
+++ b/test/sanitizer.test.js
@@ -235,6 +235,45 @@ describe('sanitizeToolsList — [DISABLED] injection', () => {
   });
 });
 
+describe('sanitizeToolsList — inputSchema normalization (#78)', () => {
+  it('normalizes inputSchema: [] (PHP array() default) to {type:"object"}', () => {
+    const msg = makeToolsListMsg([makeTool({ inputSchema: [] })]);
+    sanitizeToolsList(msg);
+    assert.deepEqual(msg.result.tools[0].inputSchema, { type: 'object' });
+  });
+
+  it('normalizes inputSchema: null to {type:"object"}', () => {
+    const msg = makeToolsListMsg([makeTool({ inputSchema: null })]);
+    sanitizeToolsList(msg);
+    assert.deepEqual(msg.result.tools[0].inputSchema, { type: 'object' });
+  });
+
+  it('normalizes inputSchema: undefined to {type:"object"}', () => {
+    const msg = makeToolsListMsg([makeTool({ inputSchema: undefined })]);
+    sanitizeToolsList(msg);
+    assert.deepEqual(msg.result.tools[0].inputSchema, { type: 'object' });
+  });
+
+  it('normalizes inputSchema: "invalid string" (primitive) to {type:"object"}', () => {
+    const msg = makeToolsListMsg([makeTool({ inputSchema: 'invalid string' })]);
+    sanitizeToolsList(msg);
+    assert.deepEqual(msg.result.tools[0].inputSchema, { type: 'object' });
+  });
+
+  it('regression: valid inputSchema passes through byte-identical (no normalization, no mutation)', () => {
+    const validSchema = { type: 'object', properties: { foo: { type: 'string' } } };
+    const before = JSON.stringify(validSchema);
+    const msg = makeToolsListMsg([makeTool({ inputSchema: validSchema })]);
+
+    sanitizeToolsList(msg);
+
+    const after = msg.result.tools[0].inputSchema;
+    assert.equal(after, validSchema, 'inputSchema reference must be unchanged');
+    assert.equal(JSON.stringify(after), before, 'inputSchema must be byte-identical post-sanitize');
+    assert.deepEqual(after, { type: 'object', properties: { foo: { type: 'string' } } });
+  });
+});
+
 describe('sanitizeToolsList — multiple tools', () => {
   it('processes each tool independently', () => {
     const msg = makeToolsListMsg([


### PR DESCRIPTION
## What changed

Extends `sanitizeToolsList` in [`lib/sanitizer.js`](lib/sanitizer.js) so that when a tool's `inputSchema` is missing, not an object, or an array, it is normalized to `{ type: 'object' }`. When `inputSchema` is a valid object, the existing `validateToolSchema()` warn-only validation runs unchanged.

This extends the same defensive-projection pattern already in `sanitizeToolsList` (strips `type`, `outputSchema`; filters `annotations`) to a third class of broken input the upstream registry can ship — a PHP `array()` default that JSON-encodes to `[]` (this morning's incident: 8 zero-arg Fluent abilities in `abilities-for-fluent-plugins` v1.1.2).

## How it satisfies the acceptance gate

| Gate | Evidence |
|---|---|
| (a) `lib/sanitizer.js:64-71` extended per #78 fix shape, with `_log()` message naming the normalization | [lib/sanitizer.js#L64-L78](lib/sanitizer.js#L64-L78) — `_log()` line: `SCHEMA NORMALIZE [<name>]: inputSchema not a valid object — defaulted to {type:'object'}`. Valid-object branch still runs `validateToolSchema()` unchanged. |
| (b) `test/sanitizer.test.js` covers `inputSchema: []`, `null`, `undefined`, `'invalid string'`; each asserts `{ type: 'object' }` post-sanitize | New describe block `sanitizeToolsList — inputSchema normalization (#78)` in [test/sanitizer.test.js](test/sanitizer.test.js) — 4 test cases, one per broken-input shape. |
| (c) `npm test` green (full bridge suite, not subsetted) | `tests 374  pass 374  fail 0  duration_ms 30410` — full `npm test` run before commit; re-confirmed post-restore. |
| (d) Regression guard: a tool with valid `{ type: 'object', properties: { foo: { type: 'string' } } }` passes through byte-identical | Test `regression: valid inputSchema passes through byte-identical (no normalization, no mutation)` — asserts reference equality (no replacement) **and** `JSON.stringify` byte-equality before/after. |
| (e) PR body references the sprint's Sprint Plan Gate block + Deviations line | See Sprint Plan Gate + Deviations sections below. |

## Tests run

```
$ npm test
ℹ tests 374
ℹ suites 91
ℹ pass 374
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ duration_ms 30410
```

### Negative-control verification (per `feedback_negative_control_per_test_pin`)

Reverted `lib/sanitizer.js` to `origin/main`, ran `node --test test/sanitizer.test.js`, then restored from MD5-pinned backup. Confirms the four normalization tests would have failed before the fix:

```
▶ sanitizeToolsList — inputSchema normalization (#78)
  ✖ normalizes inputSchema: [] (PHP array() default) to {type:"object"}
  ✖ normalizes inputSchema: null to {type:"object"}
  ✖ normalizes inputSchema: undefined to {type:"object"}
  ✖ normalizes inputSchema: "invalid string" (primitive) to {type:"object"}
  ✔ regression: valid inputSchema passes through byte-identical (no normalization, no mutation)
ℹ tests 23  ℹ pass 19  ℹ fail 4
```

Regression test passes either way (correct — it pins behavior that was already correct on `main`). Restore MD5-verified identical to fixed file before `npm test` re-confirmed 374/374.

## Sprint Plan Gate

Per Schema Validity Polish Sprint 2026-05-10 (Obsidian: `Plans/Alpha Release Gate/Schema Validity Polish Sprint 2026-05-10.md`), and reflecting this PR's actual touch:

```
Official WordPress Compatibility Review:
- Registry / source-of-truth impact: None. No ability registration, schema declaration, callback,
  or permission semantics change. The bridge sanitizer is a projection-edge defense; it does not
  alter what the registry exposes.
- Adapter / product-layer impact: Bridge layer only. Extends an existing defensive normalization
  pattern in sanitizeToolsList (already strips type + outputSchema, filters annotations) to a
  third case (non-object inputSchema → {type:'object'}). Tools that already ship valid schemas
  pass through byte-identical (regression-guarded). No protocol semantics change.
```

## Issue / Project / phase linkage

- Closes #78
- Sprint plan: `Plans/Alpha Release Gate/Schema Validity Polish Sprint 2026-05-10.md` — Phase B Bridge dev row
- Companion to source-of-truth work: [abilities-for-fluent-plugins#41](https://github.com/Wicked-Evolutions/abilities-for-fluent-plugins/issues/41) (separate Phase B dev row)
- Defense-in-depth: either fix alone closes the operator-side 400; both ship as a coordinated wave.

## Deviations

None.
