### PR TITLE
fix(multisite-probe): gate block write on detected-network-root + boot migration (#77)

### DIFF
--- a/lib/cli/commands/add-site.js
+++ b/lib/cli/commands/add-site.js
@@ -222,6 +222,23 @@ async function run(args, ctx) {
         config.sites[siteId].multisite = probeResult.block;
         const slugs = Object.keys(probeResult.block).join(', ');
         out.push(`  Multisite: discovered ${Object.keys(probeResult.block).length} subsite(s) → ${slugs}`);
+      } else if (probeResult && probeResult.reason === 'subsite-not-root') {
+        // Issue #77: the operator's URL is a subsite of a multisite network,
+        // not the network root. Writing a multisite block from the subsite's
+        // perspective produces parallel cross-product blocks at the MCP tool
+        // surface — so we skip the block write and redirect the operator to
+        // the network-root URL where dot-notation routing belongs.
+        const rootUrl = probeResult.networkRootUrl;
+        const redirect = rootUrl
+          ? `Run: abilities-mcp add-site ${rootUrl}`
+          : 'Re-run add-site with the network-root URL.';
+        errLines.push(
+          `Multisite block not written for "${siteId}": this URL is a subsite, not the ` +
+          `network root${rootUrl ? ` (${rootUrl})` : ''}. Dot-notation routing belongs on ` +
+          `the network-root entry; subsite-rooted blocks describe the network from one ` +
+          `subsite's perspective and surface N×(N-1) cross-products at the MCP tool ` +
+          `surface. Site entry written without multisite block. ${redirect}`
+        );
       }
     } catch (probeErr) {
       _appendProbeAdvisory(probeErr, siteId, errLines);

--- a/lib/cli/multisite-probe.js
+++ b/lib/cli/multisite-probe.js
@@ -34,9 +34,14 @@ const PROBE_PAGE_CAP = 50;
 /**
  * @typedef {object} ProbeResult
  * @property {object|null} block      Multisite block, or null when no block
- *                                    should be written (single-site / empty).
+ *                                    should be written (single-site / empty /
+ *                                    subsite-not-root).
  * @property {string} reason          One of: 'multisite-root', 'single-site',
- *                                    'tool-not-registered', 'empty-list'.
+ *                                    'tool-not-registered', 'empty-list',
+ *                                    'subsite-not-root'.
+ * @property {string} [networkRootUrl] Set when reason === 'subsite-not-root'
+ *                                    so callers can emit an operator message
+ *                                    redirecting to the network-root URL.
  */
 
 /**
@@ -144,11 +149,75 @@ async function probeMultisite(opts) {
     return { block: null, reason: 'single-site' };
   }
 
+  // Issue #77: gate block write on detected-network-root.
+  // Without this gate, OAuth super-admin invocations from a subsite URL get
+  // the full network's site list back from multisite/list-sites and write a
+  // subsite-rooted block that describes the network from the subsite's
+  // perspective — surfacing N×(N-1) dot-notation cross-products at the MCP
+  // tool surface (one parallel block per subsite entry).
+  const rootCheck = detectNetworkRoot(siteUrl, items);
+  if (!rootCheck.isRoot) {
+    return {
+      block: null,
+      reason: 'subsite-not-root',
+      networkRootUrl: rootCheck.networkRootUrl,
+    };
+  }
+
   const block = buildMultisiteBlock(siteUrl, items);
   if (!block || Object.keys(block).length === 0) {
     return { block: null, reason: 'empty-list' };
   }
   return { block, reason: 'multisite-root' };
+}
+
+/**
+ * Detect whether `parentSiteUrl` points at the network root of the multisite
+ * list returned by `multisite/list-sites`. Pure function — no I/O.
+ *
+ * Primary signal: the canonical WordPress network-root marker `blog_id === 1`.
+ * When that item exists, parent IS the root iff its URL origin matches.
+ *
+ * Fallback (no blog_id metadata): parent IS the root iff any item's URL
+ * origin matches `parentSiteUrl`. This is conservative — it accepts the
+ * pre-#77 behavior whenever we can't positively identify a non-root
+ * invocation, so an exotic adapter that omits `blog_id` doesn't lose probe
+ * functionality. The new gate fires only when we have positive evidence
+ * (blog_id===1 present and pointing elsewhere, or no URL match at all).
+ *
+ * @param {string} parentSiteUrl
+ * @param {Array<object>} items
+ * @returns {{ isRoot: boolean, networkRootUrl: string|null }}
+ */
+function detectNetworkRoot(parentSiteUrl, items) {
+  let parentOrigin;
+  try { parentOrigin = new URL(parentSiteUrl).origin.toLowerCase(); }
+  catch { return { isRoot: false, networkRootUrl: null }; }
+
+  const rootItem = (items || []).find((it) => it && it.blog_id === 1);
+  if (rootItem && typeof rootItem.url === 'string' && rootItem.url.length > 0) {
+    let rootOrigin;
+    try { rootOrigin = new URL(rootItem.url).origin.toLowerCase(); }
+    catch { return { isRoot: false, networkRootUrl: rootItem.url }; }
+    return {
+      isRoot: rootOrigin === parentOrigin,
+      networkRootUrl: rootItem.url,
+    };
+  }
+
+  // No blog_id metadata — fall back to URL match. Accept the parent as root
+  // when any item's URL origin matches; otherwise this is a subsite invocation
+  // whose root is unknown to us (return isRoot: false, networkRootUrl: null).
+  for (const it of (items || [])) {
+    if (!it || typeof it.url !== 'string' || it.url.length === 0) continue;
+    let itOrigin;
+    try { itOrigin = new URL(it.url).origin.toLowerCase(); }
+    catch { continue; }
+    if (itOrigin === parentOrigin) {
+      return { isRoot: true, networkRootUrl: it.url };
+    }
+  }
+  return { isRoot: false, networkRootUrl: null };
 }
 
 /**
@@ -485,6 +554,7 @@ class InjectedClient {
 module.exports = {
   probeMultisite,
   buildMultisiteBlock,
+  detectNetworkRoot,
   deriveSubsiteSlug,
   parseToolResponse,
   // Exported for direct testing of the per-session HMAC echo contract

--- a/lib/config.js
+++ b/lib/config.js
@@ -228,6 +228,16 @@ async function loadConfigFile(filePath, source = 'explicit-config') {
     await validateSiteConfig(key, site);
   }
 
+  // Issue #77: bridge-boot migration — drop subsite-rooted multisite blocks
+  // when the network-root URL is also configured. Operator-visible advisory
+  // is emitted to stderr so the change is auditable; the file on disk is left
+  // alone so operators can choose to remove or re-add the network-root entry
+  // without losing the original subsite block. See migrateMisplacedMultisiteBlocks.
+  const migrationMessages = migrateMisplacedMultisiteBlocks(config);
+  for (const msg of migrationMessages) {
+    process.stderr.write(`abilities-mcp: ${msg}\n`);
+  }
+
   config._isMultiSite = Object.keys(config.sites).length > 1 ||
     Object.values(config.sites).some(s => s.multisite);
   config._configPath = filePath;
@@ -235,6 +245,88 @@ async function loadConfigFile(filePath, source = 'explicit-config') {
   config._configSourceLabel = filePath;
 
   return config;
+}
+
+/**
+ * Issue #77 migration. Scan persisted multisite blocks; drop those that were
+ * written from a subsite's perspective when the network-root URL is also a
+ * configured site. Pure function — mutates `config.sites[*].multisite` in
+ * place and returns a list of operator-visible advisory messages. The on-disk
+ * file is NOT rewritten; the migration runs every boot (idempotent — second
+ * boot finds nothing to drop) so operators who later remove the network-root
+ * entry get the original subsite-rooted block back as fallback routing.
+ *
+ * Detection: a multisite block is "subsite-rooted" iff it contains an entry
+ * whose hostname is a parent of the owning site's hostname (e.g. site URL
+ * `https://community.example.com` with a block entry pointing at
+ * `https://example.com`). This matches the failure shape pinned in #77 —
+ * `buildMultisiteBlock` called from a subsite invocation maps the network's
+ * other sites (including the network root) into the block.
+ *
+ * Drop condition: any OTHER configured site has `url` whose origin matches
+ * the candidate network-root entry. Without that, the operator still needs
+ * the misplaced block for dot-notation routing until they add the
+ * network-root URL — leaving it intact preserves utility on the upgrade path.
+ *
+ * @param {object} config  Parsed wp-sites.json — must have `config.sites`.
+ * @returns {string[]}     Advisory messages, one per dropped block.
+ */
+function migrateMisplacedMultisiteBlocks(config) {
+  const messages = [];
+  if (!config || !config.sites || typeof config.sites !== 'object') return messages;
+
+  const siteOrigins = new Map();
+  for (const [key, site] of Object.entries(config.sites)) {
+    if (!site || typeof site.url !== 'string') continue;
+    let origin;
+    try { origin = new URL(site.url).origin.toLowerCase(); }
+    catch { continue; }
+    siteOrigins.set(origin, key);
+  }
+
+  for (const [siteKey, site] of Object.entries(config.sites)) {
+    if (!site || !site.multisite || typeof site.multisite !== 'object') continue;
+    if (typeof site.url !== 'string') continue;
+
+    let siteHost;
+    try { siteHost = new URL(site.url).hostname.toLowerCase().replace(/^www\./, ''); }
+    catch { continue; }
+
+    // Find a block entry whose hostname is a parent domain of this site's
+    // hostname AND maps to a different origin from the site itself. That's
+    // the network-root candidate.
+    let networkRootUrl = null;
+    let networkRootOrigin = null;
+    for (const subsiteUrl of Object.values(site.multisite)) {
+      if (typeof subsiteUrl !== 'string' || subsiteUrl.length === 0) continue;
+      let entryHost, entryOrigin;
+      try {
+        const u = new URL(subsiteUrl);
+        entryHost = u.hostname.toLowerCase().replace(/^www\./, '');
+        entryOrigin = u.origin.toLowerCase();
+      } catch { continue; }
+      if (entryHost === siteHost) continue;
+      if (siteHost.endsWith('.' + entryHost)) {
+        networkRootUrl = subsiteUrl;
+        networkRootOrigin = entryOrigin;
+        break;
+      }
+    }
+    if (!networkRootUrl) continue;
+
+    const rootSiteKey = siteOrigins.get(networkRootOrigin);
+    if (!rootSiteKey || rootSiteKey === siteKey) continue;
+
+    delete site.multisite;
+    messages.push(
+      `Migration (#77): dropped subsite-rooted multisite block from "${siteKey}" ` +
+      `(${site.url}); the network-root entry "${rootSiteKey}" (${networkRootUrl}) ` +
+      `is also configured, so dot-notation routing belongs there. Subsite-rooted ` +
+      `blocks describe the network from one subsite's perspective and surface ` +
+      `parallel cross-product enumerations at the MCP tool surface.`
+    );
+  }
+  return messages;
 }
 
 async function validateSiteConfig(key, site) {
@@ -477,4 +569,5 @@ module.exports = {
   buildSiteKeyEnum,
   buildEnvConfig,
   validateSiteConfig,
+  migrateMisplacedMultisiteBlocks,
 };

--- a/test/cli/multisite-probe.test.js
+++ b/test/cli/multisite-probe.test.js
@@ -5,6 +5,7 @@ const assert = require('node:assert/strict');
 
 const {
   probeMultisite,
+  detectNetworkRoot,
   PROBE_PER_PAGE,
   PROBE_PAGE_CAP,
 } = require('../../lib/cli/multisite-probe');
@@ -96,6 +97,60 @@ function makePaginatedRequest(sites, opts = {}) {
   }
   return { request, calls };
 }
+
+describe('detectNetworkRoot (#77)', () => {
+  it('blog_id:1 marker present — parent matches → isRoot=true', () => {
+    const items = [
+      { blog_id: 1, domain: 'network.example.com', path: '/', url: 'https://network.example.com' },
+      { blog_id: 2, domain: 'sub.network.example.com', path: '/', url: 'https://sub.network.example.com' },
+    ];
+    const r = detectNetworkRoot('https://network.example.com', items);
+    assert.equal(r.isRoot, true);
+    assert.equal(r.networkRootUrl, 'https://network.example.com');
+  });
+
+  it('blog_id:1 marker present — parent is a subsite → isRoot=false, networkRootUrl set', () => {
+    const items = [
+      { blog_id: 1, domain: 'network.example.com', path: '/', url: 'https://network.example.com' },
+      { blog_id: 2, domain: 'sub.network.example.com', path: '/', url: 'https://sub.network.example.com' },
+    ];
+    const r = detectNetworkRoot('https://sub.network.example.com', items);
+    assert.equal(r.isRoot, false);
+    assert.equal(r.networkRootUrl, 'https://network.example.com');
+  });
+
+  it('no blog_id:1 metadata — falls back to URL match (parent matches an item) → isRoot=true', () => {
+    const items = [
+      { domain: 'network.example.com', path: '/', url: 'https://network.example.com' },
+      { domain: 'sub.network.example.com', path: '/', url: 'https://sub.network.example.com' },
+    ];
+    const r = detectNetworkRoot('https://network.example.com', items);
+    assert.equal(r.isRoot, true);
+    assert.equal(r.networkRootUrl, 'https://network.example.com');
+  });
+
+  it('no blog_id:1 metadata — no URL match → isRoot=false, networkRootUrl null', () => {
+    const items = [
+      { domain: 'sub2.network.example.com', path: '/', url: 'https://sub2.network.example.com' },
+      { domain: 'sub3.network.example.com', path: '/', url: 'https://sub3.network.example.com' },
+    ];
+    // Parent points at sub1 which is absent from items — without metadata we
+    // can't identify the root, so we conservatively return isRoot=false with
+    // networkRootUrl=null. Caller emits a "subsite-not-root" with a generic
+    // redirect ("re-run add-site with the network-root URL").
+    const r = detectNetworkRoot('https://sub1.network.example.com', items);
+    assert.equal(r.isRoot, false);
+    assert.equal(r.networkRootUrl, null);
+  });
+
+  it('case-insensitive origin matching', () => {
+    const items = [
+      { blog_id: 1, domain: 'NETWORK.example.com', path: '/', url: 'https://NETWORK.example.com' },
+    ];
+    const r = detectNetworkRoot('https://network.example.com', items);
+    assert.equal(r.isRoot, true);
+  });
+});
 
 describe('probeMultisite — pagination (Issue #49)', () => {
   it('100-site network — page 1 full + page 2 empty terminates loop (no metadata)', async () => {
@@ -193,6 +248,42 @@ describe('probeMultisite — pagination (Issue #49)', () => {
       { page: 2, per_page: 100 },
       { page: 3, per_page: 100 },
     ]);
+  });
+
+  it('subsite-not-root gate (#77) — probe from a subsite URL returns reason: subsite-not-root + networkRootUrl', async () => {
+    // Operator runs `add-site https://sub2.network.example.com` against a
+    // multisite network. The OAuth user is super-admin so multisite/list-sites
+    // returns the full network. Pre-#77 behavior: buildMultisiteBlock fires
+    // and the subsite entry gets a parallel block describing the network from
+    // its own perspective, yielding cross-product enumerations at the MCP
+    // tool surface.
+    const { request } = makePaginatedRequest(makeNetwork(4));
+    const r = await probeMultisite({
+      endpoint: 'https://sub2.network.example.com/wp-json/mcp/mcp-adapter-default-server',
+      accessToken: ACCESS_TOKEN,
+      siteUrl: 'https://sub2.network.example.com',
+      deps: { request },
+    });
+    assert.equal(r.reason, 'subsite-not-root');
+    assert.equal(r.block, null);
+    assert.equal(r.networkRootUrl, 'https://network.example.com',
+      'gate must surface the network-root URL so add-site can redirect the operator');
+  });
+
+  it('subsite-not-root gate (#77) — probe from the network-root URL still proceeds', async () => {
+    // Regression: gate must NOT defang the existing intended behavior. When
+    // the operator's URL IS the network root, the block is built as before.
+    const { request } = makePaginatedRequest(makeNetwork(4));
+    const r = await probeMultisite({
+      endpoint: ENDPOINT,
+      accessToken: ACCESS_TOKEN,
+      siteUrl: SITE_URL,  // https://network.example.com — matches blog_id:1 fixture
+      deps: { request },
+    });
+    assert.equal(r.reason, 'multisite-root');
+    assert.ok(r.block);
+    // 4 fixture items - 1 (network root, skipped per #70) = 3 in block.
+    assert.equal(Object.keys(r.block).length, 3);
   });
 
   it('cap-exceeded — full page at page 50, throws probe_cap_exceeded with diagnostic data', async () => {

--- a/test/config-multisite-migration.test.js
+++ b/test/config-multisite-migration.test.js
@@ -1,0 +1,172 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { migrateMisplacedMultisiteBlocks } = require('../lib/config');
+
+/**
+ * Bridge-boot migration for Issue #77.
+ *
+ * `migrateMisplacedMultisiteBlocks(config)` is called from `loadConfigFile`
+ * after wp-sites.json is parsed. It mutates `config.sites[*].multisite` in
+ * place: subsite-rooted blocks (blocks whose entries point at a parent domain
+ * of the owning site's hostname) are dropped iff the corresponding
+ * network-root URL is also a configured site. Blocks are LEFT INTACT when the
+ * network-root entry is absent — operators upgrading without yet adding the
+ * network-root URL keep their dot-notation routing as fallback.
+ *
+ * On-disk wp-sites.json is NOT rewritten; the migration is in-memory only and
+ * runs on every boot (idempotent — second boot finds nothing to drop).
+ *
+ * Reproduces the failure shape from #77 step 5: the operator's wp-sites.json
+ * had multisite blocks on each subsite entry but NOT on the network-root
+ * entry. That distinction matters for the "leave intact" branch — see the
+ * "network-root absent" test below.
+ */
+
+function rootSite() {
+  return {
+    url: 'https://wickedevolutions.com',
+    label: 'wickedevolutions.com',
+    auth: { method: 'oauth' },
+  };
+}
+
+function subsiteSite(host, multisiteBlock) {
+  const s = {
+    url: `https://${host}`,
+    label: host,
+    auth: { method: 'oauth' },
+  };
+  if (multisiteBlock) s.multisite = multisiteBlock;
+  return s;
+}
+
+// Reproduces the 3-subsite-block shape from #77 reproduction context:
+// each subsite carries a multisite block listing the network from its
+// own perspective (containing the network-root host as one entry).
+function subsiteRootedBlock() {
+  return {
+    wickedevolutions: 'https://wickedevolutions.com',
+    test1: 'https://test1.wickedevolutions.com',
+    knowledge: 'https://knowledge.wickedevolutions.com',
+  };
+}
+
+describe('migrateMisplacedMultisiteBlocks (#77)', () => {
+  it('drops subsite-rooted block when network-root entry IS configured', () => {
+    const config = {
+      sites: {
+        'wickedevolutions': rootSite(),
+        'wicked-community': subsiteSite('community.wickedevolutions.com', subsiteRootedBlock()),
+      },
+    };
+    const messages = migrateMisplacedMultisiteBlocks(config);
+
+    assert.equal(config.sites['wicked-community'].multisite, undefined,
+      'subsite-rooted block must be dropped when network root is also configured');
+    assert.equal(messages.length, 1);
+    assert.match(messages[0], /wicked-community/);
+    assert.match(messages[0], /wickedevolutions/);
+    assert.match(messages[0], /#77/);
+  });
+
+  it('drops subsite-rooted blocks across multiple subsites — one message per drop', () => {
+    // Mirrors the #77 reproduction context: three subsites each carrying their
+    // own subsite-rooted block, network root also configured.
+    const config = {
+      sites: {
+        'wickedevolutions': rootSite(),
+        'wicked-community': subsiteSite('community.wickedevolutions.com', subsiteRootedBlock()),
+        'wicked-test1': subsiteSite('test1.wickedevolutions.com', subsiteRootedBlock()),
+        'wicked-knowledge': subsiteSite('knowledge.wickedevolutions.com', subsiteRootedBlock()),
+      },
+    };
+    const messages = migrateMisplacedMultisiteBlocks(config);
+
+    assert.equal(config.sites['wicked-community'].multisite, undefined);
+    assert.equal(config.sites['wicked-test1'].multisite, undefined);
+    assert.equal(config.sites['wicked-knowledge'].multisite, undefined);
+    assert.equal(messages.length, 3);
+  });
+
+  it('LEAVES block intact when network-root entry is ABSENT (operator needs it for routing)', () => {
+    // No 'wickedevolutions' entry — operator's only path to dot-notation
+    // routing is the misplaced subsite block. Migration must preserve it
+    // until the operator adds the network-root URL.
+    const config = {
+      sites: {
+        'wicked-community': subsiteSite('community.wickedevolutions.com', subsiteRootedBlock()),
+      },
+    };
+    const messages = migrateMisplacedMultisiteBlocks(config);
+
+    assert.deepEqual(config.sites['wicked-community'].multisite, subsiteRootedBlock(),
+      'block must remain intact byte-equivalent when network root is not configured');
+    assert.equal(messages.length, 0);
+  });
+
+  it('does NOT touch a properly-rooted block (no parent-domain entry in the block)', () => {
+    // Network-root entry has a multisite block whose entries are all proper
+    // subsites of the root. No entry in the block has a hostname that's a
+    // parent of the root's hostname → not subsite-rooted → leave alone.
+    const properBlock = {
+      community: 'https://community.wickedevolutions.com',
+      test1: 'https://test1.wickedevolutions.com',
+    };
+    const config = {
+      sites: {
+        'wickedevolutions': { ...rootSite(), multisite: properBlock },
+      },
+    };
+    const messages = migrateMisplacedMultisiteBlocks(config);
+
+    assert.deepEqual(config.sites['wickedevolutions'].multisite, properBlock);
+    assert.equal(messages.length, 0);
+  });
+
+  it('idempotent — second run on a migrated config is a no-op', () => {
+    const config = {
+      sites: {
+        'wickedevolutions': rootSite(),
+        'wicked-community': subsiteSite('community.wickedevolutions.com', subsiteRootedBlock()),
+      },
+    };
+    const m1 = migrateMisplacedMultisiteBlocks(config);
+    const m2 = migrateMisplacedMultisiteBlocks(config);
+    assert.equal(m1.length, 1);
+    assert.equal(m2.length, 0, 'second migration on an already-migrated config emits no messages');
+  });
+
+  it('empty / malformed config — no-op, no throw', () => {
+    assert.deepEqual(migrateMisplacedMultisiteBlocks(null), []);
+    assert.deepEqual(migrateMisplacedMultisiteBlocks({}), []);
+    assert.deepEqual(migrateMisplacedMultisiteBlocks({ sites: null }), []);
+    assert.deepEqual(migrateMisplacedMultisiteBlocks({ sites: {} }), []);
+  });
+
+  it('mixed: drops subsite blocks but preserves a properly-rooted block on the network-root entry', () => {
+    // Realistic post-fix state: operator added the network root after upgrading;
+    // network root has a proper block (built from its own perspective), subsites
+    // still carry their old subsite-rooted blocks. Migration drops only the
+    // misplaced ones.
+    const properBlock = {
+      community: 'https://community.wickedevolutions.com',
+      test1: 'https://test1.wickedevolutions.com',
+    };
+    const config = {
+      sites: {
+        'wickedevolutions': { ...rootSite(), multisite: properBlock },
+        'wicked-community': subsiteSite('community.wickedevolutions.com', subsiteRootedBlock()),
+      },
+    };
+    const messages = migrateMisplacedMultisiteBlocks(config);
+
+    assert.deepEqual(config.sites['wickedevolutions'].multisite, properBlock,
+      'properly-rooted block on network-root entry is preserved');
+    assert.equal(config.sites['wicked-community'].multisite, undefined,
+      'subsite-rooted block on subsite entry is dropped');
+    assert.equal(messages.length, 1);
+  });
+});


### PR DESCRIPTION
## What changed

Two coordinated Bridge-layer changes that close the cross-product enumeration symptom from #77:

### 1. Gate — `lib/cli/multisite-probe.js`

`probeMultisite` now detects whether the operator's URL points at the network root before calling `buildMultisiteBlock`. New helper `detectNetworkRoot(parentSiteUrl, items)` uses the canonical WordPress network-root marker (`blog_id === 1`) when present, falling back to URL-origin match when metadata is absent. When the operator's URL is a subsite, the probe returns:

```js
{ block: null, reason: 'subsite-not-root', networkRootUrl: '<root url>' }
```

`add-site.js` reads this reason and emits a stderr advisory redirecting the operator to the network-root URL. The site entry is still written, just without a multisite block.

### 2. Boot migration — `lib/config.js#migrateMisplacedMultisiteBlocks`

`loadConfigFile` now scans persisted multisite blocks after parsing wp-sites.json. A block is considered subsite-rooted when at least one of its entries points at a parent domain of the owning site's hostname (e.g. site `https://community.example.com` with block entry `https://example.com`). Such blocks are **dropped iff the corresponding network-root URL is also a configured site**. Blocks are **left intact when the network-root entry is absent** — operators upgrading without yet adding the network-root URL keep dot-notation routing as fallback.

The migration is **in-memory only** (on-disk wp-sites.json is not rewritten) and idempotent — second boot finds nothing to drop. Operator-visible advisory printed to stderr per drop.

## How it satisfies the acceptance gate

| Gate | Evidence |
|---|---|
| (a) `lib/cli/multisite-probe.js`: gate `buildMultisiteBlock()` write on detected-network-root verification (via `multisite/list-sites` response metadata + URL match). Skip block write if URL is subsite; emit operator message redirecting to network-root URL. | New `detectNetworkRoot` helper in [lib/cli/multisite-probe.js](lib/cli/multisite-probe.js) — primary signal `blog_id === 1`, fallback URL-origin match. Probe returns `reason: 'subsite-not-root'` when gate fires. [lib/cli/commands/add-site.js](lib/cli/commands/add-site.js) reads the reason and pushes a redirect advisory to `errLines` — operator sees the network-root URL on stderr. |
| (b) Bridge boot migration: scan persisted multisite blocks; drop subsite-entry blocks if network root configured; leave intact if network root absent. | New `migrateMisplacedMultisiteBlocks` in [lib/config.js](lib/config.js), called from `loadConfigFile` after JSON parse. In-memory mutation; stderr advisory per drop. Pure function exported for direct testing. |
| (c) `npm test` green | `tests 388  pass 388  fail 0  duration_ms 2099` — full suite, not subsetted. |
| (d) Tests cover the three migration paths | New test file [test/config-multisite-migration.test.js](test/config-multisite-migration.test.js) — 7 cases including subsite-skip path (probe-side, in `multisite-probe.test.js`), migration-with-network-root-present (drops block), migration-with-network-root-absent (leaves intact byte-equivalent). Plus 5 `detectNetworkRoot` unit cases in [test/cli/multisite-probe.test.js](test/cli/multisite-probe.test.js). |
| (e) PR body references sprint Sprint Plan Gate block + Deviations line | See sections below. |

## Tests run

```
$ npm test
ℹ tests 388
ℹ suites 93
ℹ pass 388
ℹ fail 0
ℹ duration_ms 2099
```

### Negative-control verification (per `feedback_negative_control_per_test_pin`)

Two pin verifications via `git checkout` revert + targeted re-run + MD5-verified restore.

**Pin 1 — probe gate** (`lib/cli/multisite-probe.js`):

```
▶ detectNetworkRoot (#77)
  ✖ blog_id:1 marker present — parent matches → isRoot=true
  ✖ blog_id:1 marker present — parent is a subsite → isRoot=false, networkRootUrl set
  ✖ no blog_id:1 metadata — falls back to URL match (parent matches an item) → isRoot=true
  ✖ no blog_id:1 metadata — no URL match → isRoot=false, networkRootUrl null
  ✖ case-insensitive origin matching
✖ subsite-not-root gate (#77) — probe from a subsite URL returns reason: subsite-not-root + networkRootUrl
✔ subsite-not-root gate (#77) — probe from the network-root URL still proceeds  ← regression test, passes either way
```

**Pin 2 — migration** (`lib/config.js`):

```
▶ migrateMisplacedMultisiteBlocks (#77)
  ✖ drops subsite-rooted block when network-root entry IS configured
  ✖ drops subsite-rooted blocks across multiple subsites — one message per drop
  ✖ LEAVES block intact when network-root entry is ABSENT (operator needs it for routing)
  ✖ does NOT touch a properly-rooted block (no parent-domain entry in the block)
  ✖ idempotent — second run on a migrated config is a no-op
  ✖ empty / malformed config — no-op, no throw
  ✖ mixed: drops subsite blocks but preserves a properly-rooted block on the network-root entry
ℹ tests 7  ℹ fail 7
```

(All 7 fail at the function-call boundary because the export doesn't exist on the reverted file. The discriminating regression — over-dropping a properly-rooted block — is pinned by the "does NOT touch a properly-rooted block" + "LEAVES intact when network root is ABSENT" tests once the function is restored.)

MD5 verified clean restore on both files; full `npm test` re-confirmed 388/388 post-restore.

## Sprint Plan Gate

Per Schema Validity Polish Sprint v2.1 (Obsidian: `Plans/Alpha Release Gate/Schema Validity Polish Sprint 2026-05-10.md`), reflecting this PR's actual touch:

```
Official WordPress Compatibility Review:
- Registry / source-of-truth impact: None. Bridge CLI workflow gating
  (add-site probe gate on detected-network-root) plus Bridge-side
  config-shape migration. No WordPress ability registration touched, no
  schema declaration / callback / permission semantics altered.
- Adapter / product-layer impact: Bridge layer only. Probe gating prevents
  subsite-entry block writes that surface N×(N-1) cross-products at the
  MCP tool surface; boot migration drops blocks already on disk when the
  network-root entry is also configured (in-memory only, idempotent,
  on-disk file not rewritten). No protocol semantics change, no adapter
  touch.
```

## Issue / Project / phase linkage

- Closes #77.
- Sprint plan: `Plans/Alpha Release Gate/Schema Validity Polish Sprint 2026-05-10.md` v2.1 — Phase B Wave 2 row B.4
- Companion Wave 2 PR: #76 (boot fragility) — opening separately in this same Bridge dev chat per the per-issue dispatch shape.
- Out of MVP: issue-body fix-shape #4 (consolidate-adjacent-entries into network-root entry) — design-call territory deferred per sprint plan v2.1 line 69.

## Deviations

None.