### PR TITLE
fix(boot): per-site auth-init isolation + degraded-mode router (#76)

### DIFF
--- a/abilities-mcp.js
+++ b/abilities-mcp.js
@@ -212,15 +212,42 @@ if (!isSubcommandInvocation) {
     // Startup — connect to default site
     // -----------------------------------------------------------------------
 
+    // Issue #76: per-site auth-init isolation. `pool.connectDefault` tries the
+    // configured default first and falls back to other configured sites on a
+    // per-site failure (typically RefreshError when refresh tokens expire).
+    // Returns the connected transport, or null when ALL sites failed — in
+    // that case the bridge enters degraded mode (router synthesizes a valid
+    // InitializeResult locally, returns bridge tools only on tools/list, and
+    // surfaces per-call errors on non-bridge tools/call) instead of dying
+    // with the malformed-InitializeResult / EOF symptom that motivated #76.
     try {
       const transport = await pool.connectDefault((parsedMsg, rawLine) => {
         router.handleTransportMessage(parsedMsg, rawLine);
       });
-      router.setDefaultTransport(transport);
-      log(`Default transport connected: ${config.defaultSite}`);
+      if (transport) {
+        router.setDefaultTransport(transport);
+        log(`Default transport connected: ${config.defaultSite}`);
+      } else {
+        const degradedSites = Object.entries(config.sites).map(([siteId, site]) => ({
+          siteId,
+          reason: (site && site._degraded_reason) || 'connect failed',
+        }));
+        process.stderr.write(
+          `abilities-mcp: all configured sites failed to connect at boot — ` +
+          `entering degraded mode. Operators can call wp_bridge_health to see ` +
+          `per-site status; reauth a site to recover.\n`
+        );
+        for (const ds of degradedSites) {
+          process.stderr.write(`  - ${ds.siteId}: ${ds.reason}\n`);
+        }
+        router.enterDegradedMode(degradedSites);
+      }
       router.drainEarlyQueue();
     } catch (err) {
-      process.stderr.write(`abilities-mcp: Failed to connect to default site: ${err.message}\n`);
+      // Reached only on non-per-site errors (bug in connectDefault itself,
+      // or a thrown synchronous error during bootstrap). Per-site failures
+      // are handled inside connectDefault and never surface here.
+      process.stderr.write(`abilities-mcp: bootstrap failed unexpectedly: ${err.message}\n`);
       process.exit(1);
     }
 

--- a/lib/connection-pool.js
+++ b/lib/connection-pool.js
@@ -2,6 +2,7 @@
 
 const { SshTransport } = require('./transports/ssh-transport');
 const { resolveSiteKey, resolveSitePassword } = require('./config');
+const { AUTH_STATUS } = require('./auth/events');
 
 // Incrementing counter for synthetic handshake IDs.
 // Avoids integer overflow from Date.now() (13-digit ms timestamps exceed
@@ -138,14 +139,69 @@ class ConnectionPool {
   /**
    * Create and connect transport for the default site (no handshake replay).
    * Called once at startup — the client handles the handshake directly.
+   *
+   * Issue #76: per-site auth-init isolation. The configured `defaultSite` is
+   * tried first; if its `_createTransport` / `transport.connect()` throws
+   * (typically a `RefreshError` when the refresh token is expired — confirmed
+   * via static trace from `lib/auth/token-manager.js:147-152`), the failure
+   * is captured against the site's in-memory `auth_status` and the next
+   * configured site is tried in `Object.keys(config.sites)` order. The first
+   * site that connects becomes the runtime default (`config.defaultSite` is
+   * reassigned in-memory only — wp-sites.json on disk is untouched).
+   *
+   * Returns `null` when ALL configured sites fail. The bootstrap caller pairs
+   * a `null` return with `router.enterDegradedMode(...)` so the bridge still
+   * answers `initialize` with a valid `InitializeResult` — the failure mode
+   * the gate explicitly forbids (init-time bridge death) cannot recur.
+   *
+   * @param {function} onMessage  Per-site message router callback.
+   * @returns {Promise<Transport|null>}
    */
   async connectDefault(onMessage) {
-    const key = this.config.defaultSite;
-    const transport = await this._createTransport(key, null);
-    transport.onMessage = onMessage;
-    await transport.connect();
-    this.transports.set(key, transport);
-    return transport;
+    const configuredDefault = this.config.defaultSite;
+    const otherKeys = Object.keys(this.config.sites).filter((k) => k !== configuredDefault);
+    const tryOrder = [configuredDefault, ...otherKeys];
+
+    for (const key of tryOrder) {
+      try {
+        const transport = await this._createTransport(key, null);
+        transport.onMessage = onMessage;
+        await transport.connect();
+        this.transports.set(key, transport);
+
+        if (key !== configuredDefault) {
+          this.log(
+            `Configured default "${configuredDefault}" failed to connect; ` +
+            `runtime default fell back to "${key}". The configured default ` +
+            `is marked degraded in-memory; reauth it to restore.`
+          );
+          this.config.defaultSite = key;
+        }
+        return transport;
+      } catch (err) {
+        this.log(`Site "${key}" failed to connect at boot: ${err.message}`);
+        this._markSiteDegraded(key, err);
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Mark a site degraded in the in-memory config so other lookups (tools/list,
+   * resources/read wp-abilities://sites, per-call routing) can surface it
+   * without re-attempting the failed connection. The on-disk wp-sites.json is
+   * NOT rewritten here — degraded state is recoverable (operator runs reauth)
+   * and the next bridge boot will re-attempt the connection from the existing
+   * persisted state.
+   *
+   * @private
+   */
+  _markSiteDegraded(siteId, err) {
+    const site = this.config.sites && this.config.sites[siteId];
+    if (!site) return;
+    site.auth_status = AUTH_STATUS.EXPIRED;
+    site._degraded_reason = (err && err.message) || 'connect failed';
   }
 
   /**

--- a/lib/router.js
+++ b/lib/router.js
@@ -54,6 +54,15 @@ class McpRouter {
     // Early queue for messages before transport is ready
     this.MAX_EARLY_QUEUE = 50;
     this.earlyQueue = [];
+
+    // Issue #76: degraded mode — entered when ALL configured sites fail to
+    // connect at boot. The bridge still answers `initialize` with a locally
+    // synthesized InitializeResult (so the MCP runtime stays connectable and
+    // the operator can call wp_bridge_health to see which sites are degraded);
+    // tools/list returns the bridge's three local tools only; non-bridge
+    // tools/call surfaces a per-call error naming the degraded sites.
+    this.degraded = false;
+    this.degradedSites = [];  // [{ siteId, reason }]
   }
 
   /**
@@ -61,6 +70,22 @@ class McpRouter {
    */
   setDefaultTransport(transport) {
     this.defaultTransport = transport;
+  }
+
+  /**
+   * Issue #76: enter degraded mode when no configured site connected at boot.
+   * The router will synthesize an InitializeResult on the next `initialize`
+   * request and refuse non-bridge tool calls with a descriptive error.
+   *
+   * @param {Array<{siteId:string, reason:string}>} degradedSites
+   */
+  enterDegradedMode(degradedSites) {
+    this.degraded = true;
+    this.degradedSites = Array.isArray(degradedSites) ? degradedSites.slice() : [];
+    this.log(
+      `Router entering degraded mode: ${this.degradedSites.length} site(s) failed to ` +
+      `connect at boot — ` + this.degradedSites.map((s) => `${s.siteId} (${s.reason})`).join('; ')
+    );
   }
 
   /**
@@ -90,6 +115,14 @@ class McpRouter {
       if (msg.params && msg.params.protocolVersion) {
         this.clientProtocolVersion = msg.params.protocolVersion;
       }
+      // Issue #76: in degraded mode (no site transport at boot), synthesize
+      // a locally-valid InitializeResult so the MCP runtime stays connectable
+      // and the client can still issue wp_bridge_health / etc. against the
+      // bridge's local tools.
+      if (this.degraded) {
+        this._sendSynthesizedInitializeResult(msg);
+        return;
+      }
       this._forwardToDefault(line);
       return;
     }
@@ -99,12 +132,22 @@ class McpRouter {
       this.cachedInitNotification = msg;
       this.initHandshakeComplete = true;
       this.pool.setHandshakeCache(this.cachedInitRequest, this.cachedInitNotification, this.clientProtocolVersion);
+      // In degraded mode there is no transport to forward to; the notification
+      // is purely informational once the synthesized InitializeResult has been
+      // sent.
+      if (this.degraded) return;
       this._forwardToDefault(line);
       return;
     }
 
     // tools/list — route to default, then inject site param
     if (msg.method === 'tools/list') {
+      // Issue #76: in degraded mode, return only the bridge's local tools so
+      // operators can call wp_bridge_health and see which sites are degraded.
+      if (this.degraded) {
+        this._sendSynthesizedToolsListResult(msg);
+        return;
+      }
       this._forwardToDefault(line);
       return;
     }
@@ -113,6 +156,13 @@ class McpRouter {
     if (msg.method === 'tools/call') {
       if (msg.params && isBridgeTool(msg.params.name)) {
         this._handleBridgeToolCall(msg);
+        return;
+      }
+      // Issue #76: in degraded mode there is no backing site transport; surface
+      // a per-call error naming the degraded sites so the client sees a clear
+      // diagnostic, not a hang.
+      if (this.degraded) {
+        this._sendDegradedToolsCallError(msg);
         return;
       }
       this._handleToolsCall(msg);
@@ -234,22 +284,112 @@ class McpRouter {
   _forwardToDefault(line) {
     if (this.defaultTransport) {
       this.defaultTransport.send(line);
-    } else {
-      if (this.earlyQueue.length >= this.MAX_EARLY_QUEUE) {
-        this.log('Early queue full — rejecting message');
-        try {
-          const msg = JSON.parse(line);
-          if (msg.id !== undefined) {
-            this.sendToClient(JSON.stringify({
-              jsonrpc: '2.0', id: msg.id,
-              error: { code: -32603, message: 'Server not ready — queue full' }
-            }));
-          }
-        } catch (e) { /* non-JSON, drop */ }
-        return;
-      }
-      this.earlyQueue.push(line);
+      return;
     }
+    // Issue #76: in degraded mode any message that reached this point (i.e.
+    // not handled by a degraded-aware branch above) gets a per-call error
+    // rather than being queued forever waiting for a transport that will
+    // never arrive.
+    if (this.degraded) {
+      try {
+        const msg = JSON.parse(line);
+        if (msg.id !== undefined) {
+          this.sendToClient(JSON.stringify({
+            jsonrpc: '2.0', id: msg.id,
+            error: {
+              code: -32603,
+              message: `Bridge running in degraded mode — no site transport available. ` +
+                this._degradedSummary(),
+            },
+          }));
+        }
+      } catch (e) { /* non-JSON, drop */ }
+      return;
+    }
+    if (this.earlyQueue.length >= this.MAX_EARLY_QUEUE) {
+      this.log('Early queue full — rejecting message');
+      try {
+        const msg = JSON.parse(line);
+        if (msg.id !== undefined) {
+          this.sendToClient(JSON.stringify({
+            jsonrpc: '2.0', id: msg.id,
+            error: { code: -32603, message: 'Server not ready — queue full' }
+          }));
+        }
+      } catch (e) { /* non-JSON, drop */ }
+      return;
+    }
+    this.earlyQueue.push(line);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal — degraded mode (Issue #76)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Synthesize a valid MCP InitializeResult so the client's MCP validator
+   * receives `protocolVersion`, `capabilities`, and `serverInfo` instead of
+   * EOF (the failure mode pinned in #76 — bridge died before any response).
+   *
+   * Echoes the client's `protocolVersion` when present (per MCP spec — the
+   * server returns the negotiated version, defaulting to its own when no
+   * client-side version was provided).
+   */
+  _sendSynthesizedInitializeResult(msg) {
+    const clientProtocol = msg.params && msg.params.protocolVersion;
+    const result = {
+      jsonrpc: '2.0',
+      id: msg.id,
+      result: {
+        protocolVersion: clientProtocol || '2025-06-18',
+        capabilities: { tools: {}, resources: {} },
+        serverInfo: {
+          name: 'abilities-mcp (degraded)',
+          version: this._bridgeVersion(),
+        },
+      },
+    };
+    this.sendToClient(JSON.stringify(result));
+  }
+
+  /**
+   * Synthesize a tools/list response with only the bridge's local tools.
+   * In degraded mode there is no WordPress adapter to answer the real list,
+   * so wp_bridge_health / wp_browse_tools / wp_load_tools are still callable
+   * for diagnostics.
+   */
+  _sendSynthesizedToolsListResult(msg) {
+    const result = { jsonrpc: '2.0', id: msg.id, result: { tools: [] } };
+    injectBridgeTools(result);
+    this.sendToClient(JSON.stringify(result));
+  }
+
+  _sendDegradedToolsCallError(msg) {
+    this.sendToClient(JSON.stringify({
+      jsonrpc: '2.0', id: msg.id,
+      error: {
+        code: -32603,
+        message: `Tool call cannot be served — bridge is running in degraded mode. ` +
+          this._degradedSummary() +
+          ` Run: abilities-mcp reauth <site> to recover, or use the bridge tools ` +
+          `(wp_bridge_health, wp_browse_tools, wp_load_tools) for diagnostics.`,
+      },
+    }));
+  }
+
+  _degradedSummary() {
+    if (!this.degradedSites || this.degradedSites.length === 0) {
+      return 'No degraded-site details available.';
+    }
+    const parts = this.degradedSites.map((s) => `${s.siteId}: ${s.reason}`);
+    return `Degraded sites — ${parts.join('; ')}.`;
+  }
+
+  _bridgeVersion() {
+    try {
+      const pkg = require('../package.json');
+      return (pkg && pkg.version) || 'unknown';
+    } catch { return 'unknown'; }
   }
 
   // ---------------------------------------------------------------------------

--- a/test/connection-pool.test.js
+++ b/test/connection-pool.test.js
@@ -544,3 +544,176 @@ describe('ConnectionPool — OAuth subsite routing (Issue #48)', () => {
       'no subsite suffix → no subsite URL header forwarded');
   });
 });
+
+describe('ConnectionPool — connectDefault per-site auth-init isolation (#76)', () => {
+  /**
+   * Failure mode the gate forbids (verbatim from issue #76):
+   *   "MCP server boots and responds with valid InitializeResult even when
+   *    some/all configured sites have expired refresh tokens; degraded sites
+   *    are reported via tools/list, per-call errors, or a dedicated tools/call
+   *    shape — not via init failure."
+   *
+   * Pre-#76: `connectDefault()` connected one site (the configured default);
+   * if that site's transport.connect() threw (RefreshError on expired refresh
+   * token, per `lib/auth/token-manager.js:147-152`), the throw propagated to
+   * the bootstrap catch in `abilities-mcp.js`, which `process.exit(1)`d the
+   * bridge. The MCP client saw EOF and surfaced the malformed-InitializeResult
+   * validator error.
+   *
+   * Post-#76: connectDefault tries the configured default first; on failure
+   * it iterates other configured sites in order, returning the first transport
+   * that successfully connects (and reassigning `config.defaultSite` in-memory).
+   * Returns null only when ALL sites fail — boot does not exit.
+   *
+   * Drives `_createTransport` via a stub that succeeds/fails per site key.
+   */
+  function makeConfig(sites, defaultSite) {
+    return { defaultSite, sites };
+  }
+
+  function fakeOAuthSite() {
+    return {
+      url: 'https://example.com',
+      mcp_resource: 'https://example.com/wp-json/mcp/mcp-adapter-default-server',
+      auth: {
+        method: 'oauth',
+        client_id: 'c',
+        access_token_ref: 'ref:abilities-mcp:a',
+        refresh_token_ref: 'ref:abilities-mcp:r',
+      },
+      auth_status: 'active',
+    };
+  }
+
+  function makePoolWithStubs(config, perSiteOutcomes) {
+    const pool = new ConnectionPool(config, () => {});
+    pool._createTransport = async (key /* compositeKey */) => {
+      const outcome = perSiteOutcomes[key];
+      if (!outcome) throw new Error(`unconfigured outcome for ${key}`);
+      if (outcome.throwAtCreate) throw outcome.throwAtCreate;
+      const transport = {
+        endpoint: `https://${key}.example.com/wp-json/mcp/mcp-adapter-default-server`,
+        onMessage: null,
+        connect: async () => {
+          if (outcome.throwAtConnect) throw outcome.throwAtConnect;
+        },
+        send: () => {},
+        shutdown: async () => {},
+        isReady: () => true,
+      };
+      return transport;
+    };
+    return pool;
+  }
+
+  it('all sites healthy — no behavioral change for non-degraded operators (regression)', async () => {
+    const config = makeConfig({
+      siteA: fakeOAuthSite(),
+      siteB: fakeOAuthSite(),
+    }, 'siteA');
+    const pool = makePoolWithStubs(config, {
+      siteA: {},
+      siteB: {},
+    });
+    const transport = await pool.connectDefault(() => {});
+    assert.ok(transport, 'transport returned for healthy default site');
+    assert.equal(config.defaultSite, 'siteA',
+      'configured default unchanged when it connects successfully');
+    assert.equal(config.sites.siteA.auth_status, 'active');
+  });
+
+  it('default site fails (RefreshError) → falls back to next configured site, marks default degraded', async () => {
+    // The token-manager throws this exact error shape at lib/auth/token-manager.js:148.
+    const refreshErr = new Error('Refresh token expired for site "siteA". Run: abilities-mcp reauth siteA');
+    refreshErr.code = 'reauth_required';
+    const config = makeConfig({
+      siteA: fakeOAuthSite(),
+      siteB: fakeOAuthSite(),
+    }, 'siteA');
+    const pool = makePoolWithStubs(config, {
+      siteA: { throwAtConnect: refreshErr },
+      siteB: {},
+    });
+
+    const transport = await pool.connectDefault(() => {});
+
+    assert.ok(transport, 'fallback transport returned even when configured default fails');
+    assert.equal(config.defaultSite, 'siteB',
+      'in-memory defaultSite reassigned to fallback');
+    assert.equal(config.sites.siteA.auth_status, 'expired',
+      'configured default marked degraded so wp_bridge_health surfaces it');
+    assert.match(config.sites.siteA._degraded_reason, /Refresh token expired/);
+    assert.equal(config.sites.siteB.auth_status, 'active',
+      'fallback site keeps its existing active status');
+  });
+
+  it('every site fails → returns null (bridge enters degraded mode in bootstrap)', async () => {
+    const refreshErr = new Error('Refresh token expired');
+    const config = makeConfig({
+      siteA: fakeOAuthSite(),
+      siteB: fakeOAuthSite(),
+      siteC: fakeOAuthSite(),
+    }, 'siteA');
+    const pool = makePoolWithStubs(config, {
+      siteA: { throwAtConnect: refreshErr },
+      siteB: { throwAtConnect: refreshErr },
+      siteC: { throwAtConnect: refreshErr },
+    });
+
+    const result = await pool.connectDefault(() => {});
+
+    assert.equal(result, null,
+      'all-sites-failed returns null so bootstrap enters degraded mode instead of exit(1)');
+    assert.equal(config.sites.siteA.auth_status, 'expired');
+    assert.equal(config.sites.siteB.auth_status, 'expired');
+    assert.equal(config.sites.siteC.auth_status, 'expired');
+  });
+
+  it('first failure isolates — second site connects without re-attempting first', async () => {
+    // Pin: the loop must not re-enter a failed site. Capture call order.
+    const calls = [];
+    const config = makeConfig({
+      siteA: fakeOAuthSite(),
+      siteB: fakeOAuthSite(),
+    }, 'siteA');
+    const pool = new ConnectionPool(config, () => {});
+    pool._createTransport = async (key) => {
+      calls.push(key);
+      if (key === 'siteA') throw new Error('siteA failed');
+      return {
+        endpoint: 'https://b.example.com/x',
+        onMessage: null,
+        connect: async () => {},
+        send: () => {},
+        shutdown: async () => {},
+        isReady: () => true,
+      };
+    };
+
+    await pool.connectDefault(() => {});
+
+    assert.deepEqual(calls, ['siteA', 'siteB'],
+      'try order is configured-default-then-others; first failure does not retry');
+  });
+
+  it('error during _createTransport (not just connect) is also isolated', async () => {
+    // The auth-init boundary covers BOTH _createTransport (discovery,
+    // OAuth state setup) AND transport.connect() (token pre-fetch). Both
+    // must isolate per-site.
+    const config = makeConfig({
+      siteA: fakeOAuthSite(),
+      siteB: fakeOAuthSite(),
+    }, 'siteA');
+    const pool = makePoolWithStubs(config, {
+      siteA: { throwAtCreate: new Error('discovery failed for siteA') },
+      siteB: {},
+    });
+
+    const transport = await pool.connectDefault(() => {});
+
+    assert.ok(transport, 'siteB transport returned despite siteA discovery failure');
+    assert.equal(config.defaultSite, 'siteB');
+    assert.equal(config.sites.siteA.auth_status, 'expired');
+    assert.match(config.sites.siteA._degraded_reason, /discovery failed/);
+  });
+});

--- a/test/router-degraded-mode.test.js
+++ b/test/router-degraded-mode.test.js
@@ -1,0 +1,187 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { McpRouter } = require('../lib/router');
+
+/**
+ * McpRouter degraded-mode behavior — Issue #76.
+ *
+ * The gate (verbatim from #76 issue body):
+ *   "MCP server boots and responds with valid InitializeResult even when
+ *    some/all configured sites have expired refresh tokens; degraded sites
+ *    are reported via tools/list, per-call errors, or a dedicated tools/call
+ *    shape — not via init failure."
+ *
+ * When `pool.connectDefault()` returns null (all configured sites failed at
+ * boot — see test/connection-pool.test.js #76 describe block), the bootstrap
+ * calls `router.enterDegradedMode(degradedSites)` instead of exit(1). The
+ * router then:
+ *   - synthesizes a valid InitializeResult on `initialize` (echoing the
+ *     client's protocolVersion; serverInfo with the bridge package version)
+ *   - returns the bridge's three local tools on tools/list
+ *   - surfaces a per-call error on non-bridge tools/call naming degraded sites
+ *   - bridge tools/call (wp_bridge_health, wp_browse_tools, wp_load_tools)
+ *     still work locally — they don't need a backing transport
+ *
+ * Tests drive the router with a captured-sendToClient callback so the exact
+ * wire-shape responses are inspectable.
+ */
+
+function makeRouter(opts = {}) {
+  const sent = [];
+  const router = new McpRouter({
+    config: { defaultSite: 'siteA', sites: { siteA: {}, siteB: {} } },
+    siteKeys: ['siteA', 'siteB'],
+    isMultiSite: true,
+    pool: {
+      setHandshakeCache() {},
+      healthCheck: async () => ({ status: 'unreachable', latencyMs: 1, error: 'degraded' }),
+    },
+    catalog: {
+      isEnabled: () => false,
+      cacheTools() {},
+      getFilteredTools: () => [],
+    },
+    sendToClient: (s) => sent.push(s),
+    log: () => {},
+  });
+  if (opts.degraded !== false) {
+    router.enterDegradedMode(opts.degradedSites || [
+      { siteId: 'siteA', reason: 'Refresh token expired' },
+      { siteId: 'siteB', reason: 'Refresh token expired' },
+    ]);
+  }
+  return { router, sent };
+}
+
+function parseLast(sent) {
+  return JSON.parse(sent[sent.length - 1]);
+}
+
+describe('McpRouter — degraded mode (#76)', () => {
+  it('synthesizes valid InitializeResult on `initialize` (all three required fields)', () => {
+    const { router, sent } = makeRouter();
+    router.handleClientMessage({
+      jsonrpc: '2.0', id: 1, method: 'initialize',
+      params: { protocolVersion: '2025-06-18', capabilities: {} },
+    }, '<line>');
+
+    assert.equal(sent.length, 1);
+    const resp = parseLast(sent);
+    assert.equal(resp.id, 1);
+    assert.ok(resp.result, 'response carries result, not error');
+    assert.equal(typeof resp.result.protocolVersion, 'string',
+      'protocolVersion present — closes the malformed-InitializeResult symptom');
+    assert.equal(resp.result.protocolVersion, '2025-06-18',
+      'echoes client protocolVersion per MCP negotiation');
+    assert.equal(typeof resp.result.capabilities, 'object',
+      'capabilities present');
+    assert.equal(typeof resp.result.serverInfo, 'object',
+      'serverInfo present');
+    assert.equal(typeof resp.result.serverInfo.name, 'string');
+    assert.equal(typeof resp.result.serverInfo.version, 'string');
+  });
+
+  it('synthesized InitializeResult defaults protocolVersion when client omits it', () => {
+    const { router, sent } = makeRouter();
+    router.handleClientMessage({
+      jsonrpc: '2.0', id: 1, method: 'initialize',
+      params: { capabilities: {} },
+    }, '<line>');
+
+    const resp = parseLast(sent);
+    assert.equal(typeof resp.result.protocolVersion, 'string');
+    assert.ok(resp.result.protocolVersion.length > 0);
+  });
+
+  it('tools/list returns the three bridge tools only', () => {
+    const { router, sent } = makeRouter();
+    router.handleClientMessage({
+      jsonrpc: '2.0', id: 2, method: 'tools/list',
+    }, '<line>');
+
+    const resp = parseLast(sent);
+    assert.ok(resp.result, 'tools/list returns result, not error');
+    assert.ok(Array.isArray(resp.result.tools));
+    const names = resp.result.tools.map((t) => t.name).sort();
+    assert.deepEqual(names, ['wp_bridge_health', 'wp_browse_tools', 'wp_load_tools'],
+      'degraded-mode tools/list = bridge tools only (no WordPress-side tools)');
+  });
+
+  it('non-bridge tools/call surfaces per-call error naming degraded sites', () => {
+    const { router, sent } = makeRouter();
+    router.handleClientMessage({
+      jsonrpc: '2.0', id: 3, method: 'tools/call',
+      params: { name: 'content-list', arguments: {} },
+    }, '<line>');
+
+    const resp = parseLast(sent);
+    assert.ok(resp.error, 'non-bridge tool call returns error in degraded mode');
+    assert.equal(resp.id, 3);
+    assert.match(resp.error.message, /degraded/i,
+      'error message names degraded mode for operator clarity');
+    assert.match(resp.error.message, /siteA/);
+    assert.match(resp.error.message, /siteB/);
+    assert.match(resp.error.message, /reauth/i,
+      'error message names the recovery path');
+  });
+
+  it('bridge tools/call (wp_bridge_health) still works in degraded mode — diagnostics path stays open', async () => {
+    // wp_bridge_health is the operator's diagnostic tool; it MUST be callable
+    // even when every WordPress site is degraded so operators can see which
+    // sites are degraded and pick a reauth target.
+    const { router, sent } = makeRouter();
+    router.handleClientMessage({
+      jsonrpc: '2.0', id: 4, method: 'tools/call',
+      params: { name: 'wp_bridge_health', arguments: {} },
+    }, '<line>');
+
+    // wp_bridge_health calls pool.healthCheck per site — async; await tick.
+    await new Promise((r) => setImmediate(r));
+
+    const resp = parseLast(sent);
+    assert.ok(resp.result, 'bridge tool call returns result, not error');
+    assert.ok(resp.result.content, 'wp_bridge_health emits content');
+  });
+
+  it('non-degraded mode (regression) — initialize forwards to defaultTransport, no synthesis', () => {
+    const sent = [];
+    const transportSends = [];
+    const router = new McpRouter({
+      config: { defaultSite: 'siteA', sites: { siteA: {} } },
+      siteKeys: ['siteA'],
+      isMultiSite: false,
+      pool: { setHandshakeCache() {} },
+      catalog: { isEnabled: () => false, cacheTools() {}, getFilteredTools: () => [] },
+      sendToClient: (s) => sent.push(s),
+      log: () => {},
+    });
+    router.setDefaultTransport({ send: (line) => transportSends.push(line) });
+
+    router.handleClientMessage({
+      jsonrpc: '2.0', id: 1, method: 'initialize',
+      params: { protocolVersion: '2025-06-18' },
+    }, '<line>');
+
+    assert.equal(sent.length, 0,
+      'non-degraded path does NOT synthesize a response — forwards to transport');
+    assert.equal(transportSends.length, 1,
+      'forwarded line reaches the default transport unchanged');
+  });
+
+  it('enterDegradedMode is reentrant — second call refreshes the degraded-sites list', () => {
+    const { router, sent } = makeRouter();
+    router.enterDegradedMode([{ siteId: 'newsite', reason: 'recheck' }]);
+
+    router.handleClientMessage({
+      jsonrpc: '2.0', id: 5, method: 'tools/call',
+      params: { name: 'content-list' },
+    }, '<line>');
+
+    const resp = parseLast(sent);
+    assert.match(resp.error.message, /newsite/);
+    assert.doesNotMatch(resp.error.message, /siteA/);
+  });
+});


### PR DESCRIPTION
## Investigation (gate item a) — hypothesis confirmed in source

The issue body's `pool.connectDefault()` exit hypothesis was traced verbatim through the relevant files before any code was changed:

| Step | Source location | What happens |
|---|---|---|
| 1 | [abilities-mcp.js#L215-L225](abilities-mcp.js#L215-L225) | `await pool.connectDefault(...)` inside `try` block; catch path: `process.exit(1)` |
| 2 | [lib/connection-pool.js#L142-L149](lib/connection-pool.js#L142-L149) | `connectDefault` calls `_createTransport(key, null)` then `await transport.connect()` |
| 3 | OAuth path: [lib/connection-pool.js#L353-L429](lib/connection-pool.js#L353-L429) | `_createOAuthHttpTransport` runs discovery + builds `OAuthHttpTransport` |
| 4 | [lib/auth/token-manager.js#L147-L152](lib/auth/token-manager.js#L147-L152) | When `siteAuth.authStatus === EXPIRED`, `refresh()` throws `RefreshError` (`reauth_required`) |
| 5 | The throw propagates through `transport.connect()` → `connectDefault` → bootstrap catch → `process.exit(1)` |

The `process.exit(1)` happens **before** any client request reaches the bridge. The MCP client sees EOF on stdin and the MCP runtime validator surfaces the "all three InitializeResult fields undefined" error pinned in issue #76's verbatim repro.

The hypothesis was correct. The fix is at the same boundary the issue body identified — but the smallest correct change is **per-site try/catch isolation at that boundary**, not a swap of `process.exit(1)` for a synthesized InitializeResult (which Reviewer round-3 corrected as inadequate per `Risk register row 6`: a surface fix would not satisfy the per-site-isolation gate).

## What changed

### 1. `lib/connection-pool.js#connectDefault` — per-site fallback at the auth-init boundary

`connectDefault()` now tries the configured default site first; on per-site failure (RefreshError, discovery failure, anything else thrown from `_createTransport` or `transport.connect`), it marks the site degraded in-memory and iterates remaining configured sites in `Object.keys(config.sites)` order. The first site that connects becomes the runtime default (`config.defaultSite` reassigned in-memory only — `wp-sites.json` on disk is untouched). Returns `null` only when ALL sites fail.

### 2. `lib/router.js#enterDegradedMode` — synthesized InitializeResult when no transport connected

When `connectDefault` returns `null` (every configured site failed), the bootstrap calls `router.enterDegradedMode(degradedSites)` instead of `process.exit(1)`. The router then:

- **`initialize`** — synthesizes a valid `InitializeResult` (echoes client `protocolVersion`; `capabilities: { tools, resources }`; `serverInfo` with the bridge package version). All three fields the MCP validator requires are present.
- **`tools/list`** — returns the three bridge tools only (`wp_bridge_health`, `wp_browse_tools`, `wp_load_tools`) so operators can diagnose and recover.
- **non-bridge `tools/call`** — surfaces a per-call error naming the degraded sites and pointing to `abilities-mcp reauth <site>`.
- **bridge `tools/call`** — still works locally; `wp_bridge_health` exposes per-site status.

### 3. `abilities-mcp.js` bootstrap — pairs null return with degraded mode

The remaining `try/catch` only fires on non-per-site errors (a thrown synchronous error during bootstrap, or a bug in `connectDefault` itself).

## How it satisfies the acceptance gate

| Gate | Evidence |
|---|---|
| (a) Confirm `pool.connectDefault()` exit hypothesis IN SOURCE before implementing | See "Investigation" section above — 5-step source trace, anchored in file/line refs. |
| Verbatim issue gate: *"MCP server boots and responds with valid InitializeResult even when some/all configured sites have expired refresh tokens; degraded sites are reported via tools/list, per-call errors, or a dedicated tools/call shape — not via init failure."* | All three reporting channels covered: tools/list returns bridge tools (degraded sites surfaced via wp_bridge_health output), per-call errors fire for non-bridge tools/call, bridge tools (wp_bridge_health) is the dedicated tools/call shape. Init never fails — synthesized when no transport, otherwise forwarded to a connected fallback. |
| (b) Per-site try/catch isolation at the auth-init boundary | [lib/connection-pool.js](lib/connection-pool.js) `connectDefault` loops `tryOrder` with try/catch per site. Both `_createTransport` errors AND `transport.connect()` errors isolate (test: "error during _createTransport (not just connect) is also isolated"). |
| (c) Regression test: bridge boots cleanly + serves valid InitializeResult when ≥1 site has `auth_status=expired`; degraded site surfaced via tools/list / per-call error, not init failure | Pool tests cover the per-site fallback semantics; router tests cover the synthesized-InitializeResult + bridge-tools-only + per-call-error responses. The "default site fails (RefreshError) → falls back to next configured site, marks default degraded" test reproduces the exact gate scenario. |
| (d) Regression: bridge with all-healthy sites still boots correctly (no behavioral change for non-degraded operators) | Pool test: "all sites healthy — no behavioral change for non-degraded operators (regression)" + router test: "non-degraded mode (regression) — initialize forwards to defaultTransport, no synthesis". Both pin the pre-fix non-degraded path. |
| (e) `npm test` green | `tests 386  pass 386  fail 0  duration_ms 2130` — full suite, not subsetted. |
| (f) PR body references sprint Sprint Plan Gate block + Deviations line | See sections below. |

## Tests run

```
$ npm test
ℹ tests 386
ℹ suites 93
ℹ pass 386
ℹ fail 0
ℹ duration_ms 2130
```

### Negative-control verification (per `feedback_negative_control_per_test_pin`)

Two pin verifications via `git checkout` revert + targeted re-run + MD5-verified restore.

**Pin 1 — pool fallback** (`lib/connection-pool.js`):

```
▶ ConnectionPool — connectDefault per-site auth-init isolation (#76)
  ✔ all sites healthy — no behavioral change for non-degraded operators  ← regression test, passes either way
  ✖ default site fails (RefreshError) → falls back to next configured site, marks default degraded
  ✖ every site fails → returns null (bridge enters degraded mode in bootstrap)
  ✖ first failure isolates — second site connects without re-attempting first
  ✖ error during _createTransport (not just connect) is also isolated
ℹ tests 19  ℹ pass 15  ℹ fail 4
```

**Pin 2 — router degraded mode** (`lib/router.js`):

```
▶ McpRouter — degraded mode (#76)
  ✖ synthesizes valid InitializeResult on `initialize` (all three required fields)
  ✖ synthesized InitializeResult defaults protocolVersion when client omits it
  ✖ tools/list returns the three bridge tools only
  ✖ non-bridge tools/call surfaces per-call error naming degraded sites
  ✖ bridge tools/call (wp_bridge_health) still works in degraded mode — diagnostics path stays open
  ✔ non-degraded mode (regression) — initialize forwards to defaultTransport, no synthesis  ← regression, passes either way
  ✖ enterDegradedMode is reentrant — second call refreshes the degraded-sites list
ℹ tests 7  ℹ pass 1  ℹ fail 6
```

MD5 verified clean restore on both files; full `npm test` re-confirmed 386/386 post-restore.

## Sprint Plan Gate

Per Schema Validity Polish Sprint v2.1 (Obsidian: `Plans/Alpha Release Gate/Schema Validity Polish Sprint 2026-05-10.md`), reflecting this PR's actual touch:

```
Official WordPress Compatibility Review:
- Registry / source-of-truth impact: None. Per-site auth-init error
  boundary fix at bridge boot, not at ability registration. No ability
  name / schema / callback / permission semantics changes.
- Adapter / product-layer impact: Bridge layer only. Per-site try/catch
  isolation at the auth-init boundary so one site's expired refresh token
  does not kill the bridge process; degraded-mode router synthesizes a
  locally-valid InitializeResult and exposes bridge-only tools/list when
  no site transport is available. No protocol semantics change, no
  auth-flow change, no adapter touch.
```

## Issue / Project / phase linkage

- Closes #76.
- Sprint plan: `Plans/Alpha Release Gate/Schema Validity Polish Sprint 2026-05-10.md` v2.1 — Phase B Wave 2 row B.3
- Companion Wave 2 PR: #80 (multisite probe gate + migrate, #77) — opened separately in this same Bridge dev chat.
- On-disk `wp-sites.json` is NOT rewritten on degraded-site marking — recovery via `abilities-mcp reauth <site>` is operator-driven and the next bridge boot re-attempts the connection.

## Deviations

None.