### PR TITLE
fix(router): intercept failed-initialize response, synthesize InitializeResult (#76 follow-up)

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -203,6 +203,37 @@ class McpRouter {
       return;
     }
 
+    // Issue #76 follow-up — request-time boundary.
+    //
+    // OAuthHttpTransport.connect() does NOT pre-validate tokens (lib/transports/
+    // oauth-http-transport.js:139-143 — sets ready=true, returns). When the
+    // configured default site has an expired refresh token, _createTransport
+    // and connect() both succeed; the bridge does NOT enter the connect-time
+    // degraded path covered by #81. Instead, drainEarlyQueue() forwards the
+    // cached `initialize` request through the transport, _processMessage
+    // calls _postWithRetry → getAccessToken → refresh → throws RefreshError
+    // synchronously when authStatus===EXPIRED (lib/auth/token-manager.js:147).
+    // _processMessage catches the throw at lib/transports/oauth-http-transport.js:
+    // 379-388 and emits onMessage with `{jsonrpc, id, error}` — the cached
+    // initialize id paired with `OAuth HTTP bridge error: …`. Without this
+    // intercept, the error→CallToolResult conversion below blanket-converts
+    // it to `{result:{content:[],isError:true}}` and the MCP runtime rejects
+    // the response shape. Pin the gate-violating shape here: when the failed
+    // response carries the cached initialize id, synthesize a valid
+    // InitializeResult locally and enter degraded mode for the failed site.
+    if (parsedMsg.error && parsedMsg.id !== undefined &&
+        this.cachedInitRequest && parsedMsg.id === this.cachedInitRequest.id) {
+      const failedSite = this.config && this.config.defaultSite;
+      const reason = (parsedMsg.error && parsedMsg.error.message) || 'unknown';
+      this.log(
+        `Initialize forward failed for "${failedSite || '(unknown)'}": ${reason} — ` +
+        `synthesizing degraded-mode InitializeResult to satisfy MCP runtime`
+      );
+      this._sendSynthesizedInitializeResult(this.cachedInitRequest);
+      this.enterDegradedMode([{ siteId: failedSite || '(unknown)', reason }]);
+      return;
+    }
+
     // Sanitize tools/list responses
     if (isToolsListResponse(parsedMsg)) {
       sanitizeToolsList(parsedMsg, this.log);

--- a/test/manual/repro-76-followup.js
+++ b/test/manual/repro-76-followup.js
@@ -1,0 +1,264 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Live reproduction harness for the #76 follow-up gate failure
+ * (request-time boundary).
+ *
+ *   Bridge IS catching connectDefault per-site failure, but the response
+ *   synthesized for the cached initialize comes out as CallToolResult shape
+ *   (content[] + isError:true) instead of InitializeResult shape
+ *   (protocolVersion + capabilities + serverInfo).
+ *
+ * What this script does:
+ *   1. Spins up a tiny localhost HTTP server that responds to OAuth discovery
+ *      probes (.well-known/oauth-authorization-server +
+ *      .well-known/oauth-protected-resource) with valid metadata. The bridge
+ *      needs discovery to succeed so the request-time path is reached;
+ *      discovery failure would surface the connect-time path covered by #81.
+ *   2. Writes a synthetic wp-sites.json fixture with a single OAuth site
+ *      whose `auth_status` is `'expired'` and whose `access_token_expires_at`
+ *      is in the past. With this state, `lib/auth/token-manager.js#refresh`
+ *      throws RefreshError synchronously at line 147 — no HTTP call to the
+ *      token endpoint, no keychain reads required for the failure path.
+ *   3. Cold-spawns the bridge as a child process pointed at the fixture.
+ *   4. Sends a JSON-RPC `initialize` request over the bridge's stdin.
+ *   5. Captures the bridge's stdout response.
+ *   6. Reports the captured request + response bytes verbatim, then asserts
+ *      the response shape (InitializeResult, NOT CallToolResult).
+ *
+ * Run:
+ *   node test/manual/repro-76-followup.js
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const https = require('https');
+const { execSync, spawn } = require('child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const BRIDGE_BIN = path.join(REPO_ROOT, 'abilities-mcp.js');
+
+function jsonOk(res, payload) {
+  const body = JSON.stringify(payload);
+  res.writeHead(200, {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(body),
+  });
+  res.end(body);
+}
+
+function generateSelfSignedCert(tmp) {
+  // Discovery refuses plain HTTP unless `allowInsecure` is plumbed all the way
+  // through ConnectionPool — and the bridge bootstrap doesn't pass that flag
+  // today (out of scope for this PR). Workaround: use HTTPS with a self-signed
+  // cert and spawn the bridge with NODE_TLS_REJECT_UNAUTHORIZED=0 so discovery
+  // accepts it.
+  const keyPath = path.join(tmp, 'key.pem');
+  const certPath = path.join(tmp, 'cert.pem');
+  execSync(
+    `openssl req -x509 -newkey rsa:2048 -nodes -keyout "${keyPath}" -out "${certPath}" ` +
+    `-days 1 -subj "/CN=127.0.0.1" ` +
+    `-addext "subjectAltName=IP:127.0.0.1,DNS:localhost" 2>/dev/null`,
+    { stdio: 'pipe' }
+  );
+  return {
+    key: fs.readFileSync(keyPath),
+    cert: fs.readFileSync(certPath),
+  };
+}
+
+function startMockSite(tmp) {
+  return new Promise((resolve) => {
+    const tlsOpts = generateSelfSignedCert(tmp);
+    const server = https.createServer(tlsOpts, (req, res) => {
+      const u = new URL(req.url, `https://${req.headers.host}`);
+      const origin = `https://${req.headers.host}`;
+      if (u.pathname === '/.well-known/oauth-authorization-server') {
+        return jsonOk(res, {
+          issuer: origin,
+          authorization_endpoint: `${origin}/oauth/authorize`,
+          token_endpoint: `${origin}/oauth/token`,
+          registration_endpoint: `${origin}/oauth/register`,
+          response_types_supported: ['code'],
+          grant_types_supported: ['authorization_code', 'refresh_token'],
+          code_challenge_methods_supported: ['S256'],
+        });
+      }
+      if (u.pathname === '/.well-known/oauth-protected-resource') {
+        return jsonOk(res, {
+          resource: `${origin}/wp-json/mcp/mcp-adapter-default-server`,
+          authorization_servers: [origin],
+        });
+      }
+      // Anything else — 404 (the bridge should never reach here in this
+      // reproduction; refresh() throws synchronously before any HTTP call).
+      res.writeHead(404);
+      res.end();
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({ server, origin: `https://127.0.0.1:${port}` });
+    });
+  });
+}
+
+async function main() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'abilities-mcp-repro-76-'));
+  const configPath = path.join(tmp, 'wp-sites.json');
+
+  const { server, origin } = await startMockSite(tmp);
+  const yesterday = new Date(Date.now() - 24 * 3600 * 1000).toISOString();
+  const futureDate = new Date(Date.now() + 90 * 24 * 3600 * 1000).toISOString();
+
+  const config = {
+    defaultSite: 'wicked-community',
+    sites: {
+      'wicked-community': {
+        url: origin,
+        label: 'wicked-community (synthetic)',
+        mcp_resource: `${origin}/wp-json/mcp/mcp-adapter-default-server`,
+        auth: {
+          method: 'oauth',
+          client_id: 'synthetic-client',
+          access_token_ref: 'ref:abilities-mcp:wicked-community/access',
+          refresh_token_ref: 'ref:abilities-mcp:wicked-community/refresh',
+          access_token_expires_at: yesterday,    // forces _isWithinRefreshWindow=true
+          refresh_token_expires_at: futureDate,  // not actually checked
+        },
+        // The auth_status that triggers refresh() to throw RefreshError
+        // synchronously at lib/auth/token-manager.js:147 — no HTTP, no
+        // keychain reads on the failing path.
+        auth_status: 'expired',
+      },
+    },
+  };
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2), { mode: 0o600 });
+
+  console.log(`-- mock discovery server: ${origin}`);
+  console.log(`-- synthetic config:      ${configPath}`);
+  console.log('');
+
+  const bridge = spawn('node', [
+    BRIDGE_BIN,
+    `--config=${configPath}`,
+  ], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      // Self-signed cert on the mock — accept it for this synthetic harness.
+      // The bridge in production verifies certs normally; this only relaxes
+      // verification for the spawned harness child.
+      NODE_TLS_REJECT_UNAUTHORIZED: '0',
+      ABILITIES_MCP_DEBUG: '0',
+    },
+  });
+
+  let stdoutBuf = '';
+  let stderrBuf = '';
+  bridge.stdout.on('data', (chunk) => { stdoutBuf += chunk.toString(); });
+  bridge.stderr.on('data', (chunk) => { stderrBuf += chunk.toString(); });
+
+  // Send `initialize` after the bridge has had a moment to set up its stdin
+  // handler + complete the bootstrap (which on this path includes the OAuth
+  // discovery probe to the mock server).
+  const initializeRequest = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      clientInfo: { name: 'repro-76-followup', version: '1.0' },
+    },
+  };
+
+  // Wait for the bridge to print its config-source line on stderr — that's
+  // the explicit signal that loadConfig has completed.
+  await new Promise((resolve) => {
+    const onData = () => {
+      if (/Config source/i.test(stderrBuf) || /loaded:/i.test(stderrBuf) ||
+          stderrBuf.split('\n').length > 2) {
+        bridge.stderr.off('data', onData);
+        resolve();
+      }
+    };
+    bridge.stderr.on('data', onData);
+    setTimeout(resolve, 3000);  // hard cap so the script can't hang
+  });
+
+  // Send initialize and wait for the response (single-line JSON on stdout).
+  const requestBytes = JSON.stringify(initializeRequest) + '\n';
+  bridge.stdin.write(requestBytes);
+
+  const responseLine = await new Promise((resolve) => {
+    const tick = () => {
+      const idx = stdoutBuf.indexOf('\n');
+      if (idx >= 0) return resolve(stdoutBuf.slice(0, idx));
+      setTimeout(tick, 50);
+    };
+    tick();
+    setTimeout(() => resolve(stdoutBuf || '<timeout — no response>'), 8000);
+  });
+
+  bridge.stdin.end();
+  bridge.kill('SIGTERM');
+  await new Promise((r) => bridge.once('exit', r));
+  server.close();
+  fs.rmSync(tmp, { recursive: true, force: true });
+
+  console.log('=== STDIN (request) ===');
+  console.log(requestBytes.trim());
+  console.log('');
+  console.log('=== STDOUT (response) ===');
+  console.log(responseLine);
+  console.log('');
+  console.log('=== STDERR (bridge log — operator-visible degraded-mode advisory) ===');
+  console.log(stderrBuf.trim());
+  console.log('');
+
+  let parsed;
+  try { parsed = JSON.parse(responseLine); }
+  catch (err) {
+    console.error(`FAIL: response is not valid JSON: ${err.message}`);
+    process.exit(2);
+  }
+
+  const errors = [];
+  if (!parsed.result) errors.push('response.result missing');
+  if (parsed.result) {
+    if (typeof parsed.result.protocolVersion !== 'string') {
+      errors.push(`result.protocolVersion: expected string, got ${typeof parsed.result.protocolVersion}`);
+    }
+    if (typeof parsed.result.capabilities !== 'object' || parsed.result.capabilities === null) {
+      errors.push(`result.capabilities: expected object, got ${typeof parsed.result.capabilities}`);
+    }
+    if (typeof parsed.result.serverInfo !== 'object' || parsed.result.serverInfo === null) {
+      errors.push(`result.serverInfo: expected object, got ${typeof parsed.result.serverInfo}`);
+    }
+    if (parsed.result.content !== undefined) {
+      errors.push('result.content present — that is CallToolResult shape (the gate-violating shape from the operator reproduction)');
+    }
+    if (parsed.result.isError !== undefined) {
+      errors.push('result.isError present — that is CallToolResult shape (the gate-violating shape from the operator reproduction)');
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error('=== GATE VIOLATED ===');
+    for (const e of errors) console.error(`  - ${e}`);
+    process.exit(1);
+  }
+
+  console.log('=== GATE SATISFIED ===');
+  console.log('  - response.result.protocolVersion: present (string)');
+  console.log('  - response.result.capabilities:    present (object)');
+  console.log('  - response.result.serverInfo:      present (object)');
+  console.log('  - response.result.content / isError: absent (correct — InitializeResult shape, not CallToolResult)');
+}
+
+main().catch((err) => {
+  console.error('repro harness failed:', err);
+  process.exit(2);
+});

--- a/test/router-degraded-mode.test.js
+++ b/test/router-degraded-mode.test.js
@@ -171,6 +171,123 @@ describe('McpRouter — degraded mode (#76)', () => {
       'forwarded line reaches the default transport unchanged');
   });
 
+  it('request-time boundary (#76 follow-up) — initialize forward error → synthesized InitializeResult, NOT CallToolResult', () => {
+    // Operator reproduction (paste from PR-side captured evidence):
+    //   {"jsonrpc":"2.0","id":1,"result":{
+    //     "content":[{"type":"text","text":"[-32000] OAuth HTTP bridge error: ..."}],
+    //     "isError":true
+    //   }}
+    //
+    // This shape is CallToolResult, not InitializeResult — MCP SDK rejects it.
+    // The router must intercept error responses whose id matches the cached
+    // initialize and synthesize a valid InitializeResult locally before the
+    // generic JSON-RPC-error→CallToolResult conversion at the bottom of
+    // handleTransportMessage runs.
+    const sent = [];
+    const router = new McpRouter({
+      config: { defaultSite: 'wicked-community', sites: { 'wicked-community': {} } },
+      siteKeys: ['wicked-community'],
+      isMultiSite: false,
+      pool: { setHandshakeCache() {} },
+      catalog: { isEnabled: () => false, cacheTools() {}, getFilteredTools: () => [] },
+      sendToClient: (s) => sent.push(s),
+      log: () => {},
+    });
+    router.setDefaultTransport({ send: () => {} });
+
+    // 1. Client sends initialize — gets cached + forwarded.
+    router.handleClientMessage({
+      jsonrpc: '2.0', id: 1, method: 'initialize',
+      params: { protocolVersion: '2025-06-18', capabilities: {} },
+    }, '<line>');
+
+    // 2. Transport emits the operator-reproduced error response shape:
+    //    error response with id matching the cached initialize id.
+    router.handleTransportMessage({
+      jsonrpc: '2.0', id: 1,
+      error: {
+        code: -32000,
+        message: 'OAuth HTTP bridge error: OAuth refresh failed: ' +
+          'Refresh token expired for site "wicked-community". ' +
+          'Run: abilities-mcp reauth wicked-community',
+      },
+    }, null);
+
+    // 3. Client must see InitializeResult shape — NOT the CallToolResult shape
+    //    that motivated this PR.
+    assert.ok(sent.length >= 1, 'router must emit a response to the client');
+    const last = JSON.parse(sent[sent.length - 1]);
+    assert.equal(last.id, 1);
+    assert.ok(last.result, 'response carries result, not error');
+    assert.equal(typeof last.result.protocolVersion, 'string',
+      'protocolVersion present — InitializeResult shape, not CallToolResult');
+    assert.equal(last.result.protocolVersion, '2025-06-18',
+      'echoes client protocolVersion per MCP negotiation');
+    assert.equal(typeof last.result.capabilities, 'object',
+      'capabilities object present');
+    assert.equal(typeof last.result.serverInfo, 'object',
+      'serverInfo object present');
+
+    // The CallToolResult-shape fields MUST NOT be present on the synthesized
+    // initialize response — they are how the MCP runtime detected the bug.
+    assert.equal(last.result.content, undefined,
+      'no content[] — that is CallToolResult shape, the gate-violating shape');
+    assert.equal(last.result.isError, undefined,
+      'no isError — that is CallToolResult shape, the gate-violating shape');
+
+    // 4. Bridge must enter degraded mode so subsequent tool calls behave
+    //    correctly and wp_bridge_health surfaces the failure.
+    assert.equal(router.degraded, true,
+      'router must enter degraded mode on initialize failure');
+    assert.equal(router.degradedSites.length, 1);
+    assert.equal(router.degradedSites[0].siteId, 'wicked-community');
+    assert.match(router.degradedSites[0].reason, /Refresh token expired/);
+  });
+
+  it('request-time boundary (#76 follow-up) — non-initialize error responses still convert to CallToolResult (regression)', () => {
+    // The intercept must ONLY fire for the cached initialize id. Other
+    // request errors (e.g. tools/call) must keep the existing CallToolResult
+    // conversion behavior — that's how MCP clients learn about per-call
+    // errors today.
+    const sent = [];
+    const router = new McpRouter({
+      config: { defaultSite: 'siteA', sites: { siteA: {} } },
+      siteKeys: ['siteA'],
+      isMultiSite: false,
+      pool: { setHandshakeCache() {} },
+      catalog: { isEnabled: () => false, cacheTools() {}, getFilteredTools: () => [] },
+      sendToClient: (s) => sent.push(s),
+      log: () => {},
+    });
+    router.setDefaultTransport({ send: () => {} });
+
+    // Cache an initialize at id=1
+    router.handleClientMessage({
+      jsonrpc: '2.0', id: 1, method: 'initialize',
+      params: { protocolVersion: '2025-06-18' },
+    }, '<line>');
+
+    sent.length = 0;  // reset
+
+    // Transport emits an error for id=42 (some tools/call) — NOT the cached
+    // initialize id. Existing conversion semantics must still apply.
+    router.handleTransportMessage({
+      jsonrpc: '2.0', id: 42,
+      error: { code: -32603, message: 'tool failed' },
+    }, null);
+
+    assert.equal(sent.length, 1);
+    const last = JSON.parse(sent[0]);
+    assert.equal(last.id, 42);
+    assert.ok(last.result, 'tools-call error converts to CallToolResult shape');
+    assert.equal(last.result.isError, true);
+    assert.ok(Array.isArray(last.result.content));
+    assert.match(last.result.content[0].text, /tool failed/);
+
+    // Router must NOT have entered degraded mode for an unrelated tool error.
+    assert.equal(router.degraded, false);
+  });
+
   it('enterDegradedMode is reentrant — second call refreshes the degraded-sites list', () => {
     const { router, sent } = makeRouter();
     router.enterDegradedMode([{ siteId: 'newsite', reason: 'recheck' }]);


### PR DESCRIPTION
## What changed

Round-5 Source-check approved [#81](https://github.com/Wicked-Evolutions/abilities-mcp/pull/81) against the **connect-time** auth-init boundary, but operator-side smoke against v1.6.2 surfaced a second boundary that the connect-time fix doesn't cover: the **request-time** boundary, where `transport.connect()` succeeds, the bridge enters HEALTHY mode, and the refresh fires on first request when `drainEarlyQueue()` forwards the cached `initialize`.

The router's existing JSON-RPC-error → CallToolResult conversion ([`lib/router.js:209-224`](lib/router.js#L209-L224)) blanket-converts the failed-initialize error response to `{result:{content:[…],isError:true}}` — CallToolResult shape, not InitializeResult shape. The MCP SDK rejects the response with the same `expected … received undefined` pattern that motivated #76.

This PR intercepts error responses whose id matches the cached initialize before the conversion runs, synthesizes a valid InitializeResult locally, and enters degraded mode for subsequent requests.

## Investigation — both boundaries traced in source

| Boundary | Where it fires | Covered by |
|---|---|---|
| **Connect-time** | `_createTransport()` throws (e.g. discovery probe fails) — `connectDefault()` catches at the per-site try/catch and falls through to other sites; if all fail, `enterDegradedMode()` synthesizes InitializeResult ahead of any client request. | PR #81 |
| **Request-time** | `_createTransport()` succeeds, `transport.connect()` succeeds (lib/transports/oauth-http-transport.js:139-143 — sets `ready=true`, no token validation). Bridge HEALTHY. Cached `initialize` forwarded through transport. `_postWithRetry` → `getAccessToken` → `refresh()` → throws RefreshError synchronously at lib/auth/token-manager.js:147 when `authStatus===EXPIRED`. `_processMessage` (oauth-http-transport.js:379-388) catches and emits `onMessage({error,id})` with the cached initialize id. Router blanket-converts to CallToolResult. | **THIS PR** |

The operator reproduction's captured shape — `[-32000] OAuth HTTP bridge error: OAuth refresh failed: Refresh token expired for site \"wicked-community\". Run: abilities-mcp reauth wicked-community` — matches the wrapping format at oauth-http-transport.js:435 (`OAuth refresh failed: …`) wrapped again at oauth-http-transport.js:384 (`OAuth HTTP bridge error: …`) wrapped a third time by the router's CallToolResult conversion (`[${errCode}] …`). The trace is exact.

## How it satisfies the verbatim gate

> "MCP server boots and responds with valid InitializeResult even when some/all configured sites have expired refresh tokens; degraded sites are reported via tools/list, per-call errors, or a dedicated tools/call shape — not via init failure."

| Gate piece | Evidence |
|---|---|
| Bridge boots, no `process.exit(1)` | Live repro stderr: bridge stayed alive long enough to respond to initialize (no exit). `connectDefault` returned a transport (HEALTHY mode); the request-time intercept put it into degraded mode after the cached initialize failed. |
| Responds with valid InitializeResult | Live repro stdout (post-fix): `{"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{},"resources":{}},"serverInfo":{"name":"abilities-mcp (degraded)","version":"1.6.1"}}}` — all three required fields present. |
| Degraded sites reported via tools/list / per-call errors | Reused #81's `enterDegradedMode` plumbing — tools/list returns bridge tools only, non-bridge tools/call returns per-call error naming the failed site, wp_bridge_health surfaces it. |
| Not via init failure | Live control run (revert this PR's fix) reproduces the gate-violating shape; live post-fix run satisfies the gate. Captured below. |

## Live verification (per `feedback_live_verification_at_pr_time`)

[`test/manual/repro-76-followup.js`](test/manual/repro-76-followup.js) — spawns a localhost HTTPS mock that responds to OAuth discovery probes (`.well-known/oauth-authorization-server` + `.well-known/oauth-protected-resource`) with valid metadata, writes a synthetic wp-sites.json fixture with `auth_status: 'expired'` so `refresh()` throws synchronously at lib/auth/token-manager.js:147 without any HTTP call to the token endpoint, cold-spawns the bridge as a child process, sends `initialize` via stdin, captures stdout/stderr, asserts shape.

### Captured stdin (request — verbatim bytes)

```json
{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"repro-76-followup","version":"1.0"}}}
```

### Captured stdout (response — verbatim bytes)

**With this PR's fix (gate satisfied):**

```json
{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{},"resources":{}},"serverInfo":{"name":"abilities-mcp (degraded)","version":"1.6.1"}}}
```

**Control run — revert `lib/router.js` to origin/main, re-run repro (gate violated, byte-equivalent to operator reproduction):**

```json
{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"[-32000] OAuth HTTP bridge error: OAuth refresh failed: Refresh token expired for site \"wicked-community\". Run: abilities-mcp reauth wicked-community"}],"isError":true}}
```

The control output matches the operator's captured reproduction byte-for-byte. The fix produces the gate-satisfying shape; the control reverts to the gate-violating shape. Restore MD5-verified clean (`f8fc903c66794be9bef299c9322792c4` on both pre-revert and post-restore).

### Captured stderr (operator-visible advisory — post-fix)

```
Config source: [explicit-config] /tmp/abilities-mcp-repro-76-…/wp-sites.json (1 site: wicked-community oauth)
(node:NNNNN) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure …
```

(NODE_TLS_REJECT_UNAUTHORIZED is set only on the spawned harness child to accept the self-signed mock cert; the bridge in production verifies certs normally. The bridge's pool was constructed without `_allowInsecure`, so plain HTTP would have triggered the connect-time discovery refusal — out of scope for this PR.)

## Tests run

```
$ npm test
ℹ tests 402
ℹ suites 95
ℹ pass 402
ℹ fail 0
ℹ duration_ms 2198

$ node test/manual/repro-76-followup.js
… (captured above)
=== GATE SATISFIED ===
  - response.result.protocolVersion: present (string)
  - response.result.capabilities:    present (object)
  - response.result.serverInfo:      present (object)
  - response.result.content / isError: absent (correct — InitializeResult shape, not CallToolResult)
```

### Unit-level negative control

Reverted `lib/router.js` to `origin/main` and re-ran `test/router-degraded-mode.test.js`:

```
▶ McpRouter — degraded mode (#76)
  ✖ request-time boundary (#76 follow-up) — initialize forward error → synthesized InitializeResult, NOT CallToolResult
  ✔ request-time boundary (#76 follow-up) — non-initialize error responses still convert to CallToolResult (regression)
ℹ tests 9  ℹ pass 8  ℹ fail 1
```

The new request-time pin discriminates the fix; the regression test (non-initialize error → CallToolResult) passes either way (correct — pins existing behavior). MD5-verified clean restore.

## Sprint Plan Gate

Per Schema Validity Polish Sprint v2.1 (Obsidian: `Plans/Alpha Release Gate/Schema Validity Polish Sprint 2026-05-10.md`), reflecting this PR's actual touch:

```
Official WordPress Compatibility Review:
- Registry / source-of-truth impact: None. Bridge layer router-side
  intercept of failed-initialize transport responses; no ability
  registration / schema / callback / permission semantics changes.
- Adapter / product-layer impact: Bridge layer only. Router intercepts
  error responses whose id matches the cached initialize, synthesizes a
  locally-valid InitializeResult, and enters the existing degraded mode
  from #81. No protocol semantics change beyond what #81 already
  established for the connect-time path.
```

## Issue / Project / phase linkage

- Closes #76. (extends the connect-time fix from PR #81 to the request-time boundary surfaced post-merge by operator smoke).
- Sprint plan: `Plans/Alpha Release Gate/Schema Validity Polish Sprint 2026-05-10.md` v2.1 — Phase B Wave 2 row B.3 follow-up.
- Adjacent context (no closing keyword): Wave 1 PR #79, Wave 2 PR #80 unrelated to this surface.

## Deviations

None. Same `enterDegradedMode` plumbing reused from PR #81; the only new surface is the early-intercept branch in `handleTransportMessage` and the synthesized InitializeResult on that path.