### PR TITLE
fix(sanitizer): normalize array-shaped inputSchema.properties (#83)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Abilities MCP are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- **Sanitizer normalizes array-shaped `inputSchema.properties` (Issue [#83](https://github.com/Wicked-Evolutions/abilities-mcp/issues/83), Sprint C 2026-05-11).** Extends `validateToolSchema` in `lib/sanitizer.js` so that when a tool's `inputSchema.properties` is an array (PHP `'properties' => array()` JSON-encodes to `[]`), `null`, a string, or any other non-plain-object value, it is normalized to `{}` before client emission. The previous v1.6.2 fix (#78/#79) normalized broken top-level `inputSchema` but left malformed nested `properties` untouched — the value passed `typeof === 'object'` (arrays are objects in JS) and reached the `Object.entries()` loop unchanged. Anthropic's draft 2020-12 validator rejects the entire `tools/list` payload on the first invalid schema (`/properties must be object`), so a single vendor-registered `properties: []` shape breaks the whole catalog. Defends against the entire class of vendor-registered ability schema slips that share the `properties: []` shape; SureCart's `surecart/get-store-info` was the trigger case (live capture from helenawillow.com 2026-05-11, 1 of 789 tools failing) but the fix is name-agnostic. Boundary discipline binding: `inputSchema: { type: "object" }` shapes that omit the `properties` key entirely remain byte-unchanged (early-return on `schema.properties === undefined` before the malformed-shape normalize). Already-valid object-shaped `properties` pass through byte-identical (regression-guarded with reference-equality assertion in `test/sanitizer.test.js`).
+
+### Compatibility & operator notes
+
+- **No protocol semantics change** for valid schemas. Healthy operators see no behavioral difference. The fix activates only on the malformed-`properties` shape it closes.
+- **No operator action required** — passive defensive normalization on next bridge restart.
+- **Coordinated release wave** — held for joint release with abilities-mcp-adapter v1.4.8 per the cross-sprint coupling decision.
+
 ## [1.6.2] - 2026-05-10
 
 Schema validity polish + boot fragility MVP + multisite topology gate. Four Bridge fixes ship together as a bundled release closing the operator-side schema-400 + the silent-bridge-death-on-expired-refresh-token (both connect-time and request-time refresh boundaries) + the misplaced-multisite-block-cross-product issues.

--- a/lib/sanitizer.js
+++ b/lib/sanitizer.js
@@ -29,7 +29,19 @@ function validateToolSchema(toolName, schema, log) {
     log(`SCHEMA WARN [${toolName}]: invalid top-level type "${schema.type}"`);
   }
 
-  if (!schema.properties || typeof schema.properties !== 'object') return;
+  // Boundary: properties key absent — leave inputSchema byte-unchanged.
+  if (schema.properties === undefined) return;
+
+  // Normalize malformed `properties` shapes (PHP `array()` JSON-encodes to `[]`,
+  // strings, null, primitives) to `{}` before downstream validation. Anthropic's
+  // draft 2020-12 validator rejects the entire tools/list payload on the first
+  // invalid schema, so a single vendor-registered `properties: []` breaks the
+  // whole catalog. Mirror of the top-level inputSchema normalize one frame up.
+  if (schema.properties === null || typeof schema.properties !== 'object' || Array.isArray(schema.properties)) {
+    log(`SCHEMA NORMALIZE [${toolName}]: inputSchema.properties not a plain object — normalized to {}`);
+    schema.properties = {};
+    return;
+  }
 
   for (const [prop, def] of Object.entries(schema.properties)) {
     if (!def || typeof def !== 'object') {

--- a/test/sanitizer.test.js
+++ b/test/sanitizer.test.js
@@ -274,6 +274,92 @@ describe('sanitizeToolsList — inputSchema normalization (#78)', () => {
   });
 });
 
+describe('sanitizeToolsList — inputSchema.properties normalization (#83)', () => {
+  it('positive: properties: [] → properties: {} (matches acceptance pin)', () => {
+    const msg = makeToolsListMsg([makeTool({
+      inputSchema: { type: 'object', properties: [] },
+    })]);
+
+    sanitizeToolsList(msg);
+
+    assert.deepEqual(msg.result.tools[0].inputSchema, {
+      type: 'object',
+      properties: {},
+    });
+  });
+
+  it('negative-control: object-shaped properties with real fields → byte-identical', () => {
+    const valid = {
+      type: 'object',
+      properties: { foo: { type: 'string' }, bar: { type: 'integer' } },
+      required: ['foo'],
+    };
+    const before = JSON.stringify(valid);
+    const msg = makeToolsListMsg([makeTool({ inputSchema: valid })]);
+
+    sanitizeToolsList(msg);
+
+    const after = msg.result.tools[0].inputSchema;
+    assert.equal(after, valid, 'inputSchema reference must be unchanged');
+    assert.equal(after.properties, valid.properties, 'properties reference must be unchanged');
+    assert.equal(JSON.stringify(after), before, 'inputSchema must be byte-identical');
+  });
+
+  it('boundary: no `properties` key → unchanged byte-for-byte (key stays absent)', () => {
+    const noProps = { type: 'object' };
+    const before = JSON.stringify(noProps);
+    const msg = makeToolsListMsg([makeTool({ inputSchema: noProps })]);
+
+    sanitizeToolsList(msg);
+
+    const after = msg.result.tools[0].inputSchema;
+    assert.equal(after, noProps, 'inputSchema reference must be unchanged');
+    assert.equal('properties' in after, false, '`properties` key must remain absent');
+    assert.equal(JSON.stringify(after), before, 'inputSchema must be byte-identical');
+  });
+
+  it('smuggling-defense: properties: "string" → properties: {}', () => {
+    const msg = makeToolsListMsg([makeTool({
+      inputSchema: { type: 'object', properties: 'oops' },
+    })]);
+
+    sanitizeToolsList(msg);
+
+    assert.deepEqual(msg.result.tools[0].inputSchema, {
+      type: 'object',
+      properties: {},
+    });
+  });
+
+  it('smuggling-defense: properties: null → properties: {}', () => {
+    const msg = makeToolsListMsg([makeTool({
+      inputSchema: { type: 'object', properties: null },
+    })]);
+
+    sanitizeToolsList(msg);
+
+    assert.deepEqual(msg.result.tools[0].inputSchema, {
+      type: 'object',
+      properties: {},
+    });
+  });
+
+  it('emits SCHEMA NORMALIZE log line when properties is malformed', () => {
+    const logs = [];
+    const msg = makeToolsListMsg([makeTool({
+      name: 'surecart-get-store-info',
+      inputSchema: { type: 'object', properties: [] },
+    })]);
+
+    sanitizeToolsList(msg, (line) => logs.push(line));
+
+    assert.ok(
+      logs.some((l) => l.includes('SCHEMA NORMALIZE') && l.includes('surecart-get-store-info')),
+      'expected a SCHEMA NORMALIZE log line for the affected tool'
+    );
+  });
+});
+
 describe('sanitizeToolsList — multiple tools', () => {
   it('processes each tool independently', () => {
     const msg = makeToolsListMsg([


### PR DESCRIPTION
## Summary

Extends `validateToolSchema` in [`lib/sanitizer.js`](lib/sanitizer.js) so that when a tool's `inputSchema.properties` is an array (PHP `'properties' => array()` JSON-encodes to `[]`), `null`, a string, or any other non-plain-object value, it is normalized to `{}` before client emission. The previous v1.6.2 fix ([#78](https://github.com/Wicked-Evolutions/abilities-mcp/issues/78) / [#79](https://github.com/Wicked-Evolutions/abilities-mcp/pull/79)) normalized broken top-level `inputSchema` but left malformed nested `properties` untouched — the value passed `typeof === 'object'` (arrays are objects in JS) and reached the existing `Object.entries()` loop unchanged.

**Framing chosen — Option A (`schema.properties = {}`)** rather than Option B (`delete schema.properties`). Reason: in-place value swap preserves the structural intent the upstream tool registered (it had a `properties` key, however malformed) and is the narrower diff (no `delete` operator); the canonical empty-args shape `{ type: 'object', properties: {} }` already used throughout `test/sanitizer.test.js` is the natural target.

## Strategic framing

Defends against the entire class of vendor-registered ability schema slips that share the `properties: []` shape; SureCart's `surecart/get-store-info` was the trigger case but the fix is name-agnostic.

## Acceptance pin satisfied (verbatim from #83)

> `inputSchema: { type: "object", properties: [] }` becomes either `inputSchema: { type: "object", properties: {} }` OR `inputSchema: { type: "object" }` before client emission, with no change to already-valid object-shaped `properties`, AND with no change to `inputSchema` shapes that omit the `properties` key entirely.

- Positive: `properties: []` → `properties: {}` ✓ (Option A framing)
- Negative-control: object-shaped `properties` with real fields → byte-identical ✓
- Boundary: `inputSchema: { type: "object" }` (no `properties` key) → **byte-unchanged, key remains absent** ✓

The boundary case is enforced by an explicit early-return on `schema.properties === undefined` BEFORE the malformed-shape normalize, plus a regression test that asserts both reference equality of the inputSchema, `'properties' in after === false`, and `JSON.stringify` byte-equivalence.

## Test evidence — six unit cases (all pass, 408 / 408 suite total)

```
▶ sanitizeToolsList — inputSchema.properties normalization (#83)
  ✔ positive: properties: [] → properties: {} (matches acceptance pin)
  ✔ negative-control: object-shaped properties with real fields → byte-identical
  ✔ boundary: no `properties` key → unchanged byte-for-byte (key stays absent)
  ✔ smuggling-defense: properties: "string" → properties: {}
  ✔ smuggling-defense: properties: null → properties: {}
  ✔ emits SCHEMA NORMALIZE log line when properties is malformed
✔ sanitizeToolsList — inputSchema.properties normalization (#83)

ℹ tests 408
ℹ pass 408
ℹ fail 0
```

## Empirical AJV draft 2020-12 verification

Harness: validates every `tool.inputSchema` in `/tmp/tools-list-bridge.json` (789 tools captured from helenawillow.com 2026-05-11 via bridge stdio harness) against `ajv/dist/2020`, after running through `sanitizeToolsList`.

**Pre-fix (HEAD baseline lib/sanitizer.js, MD5 `93e5b44dc1c54b8d4d939270a69ab5e1`):**
```
mode:          sanitized
total tools:   789
invalid tools: 1
FAIL [237] surecart-get-store-info
  inputSchema: {"type":"object","properties":[]}
  error: /properties must be object
exit: 1
```

**Post-fix (this PR's lib/sanitizer.js, MD5 `7650ecb1adfc27ff7ec404d22f88ab32`):**
```
mode:          sanitized
total tools:   789
invalid tools: 0
VERDICT: all tools have valid draft-2020-12 inputSchemas
exit: 0
```

## Behavior-reversal proof

Per `feedback_negative_control_per_test_pin` — the regression guard isn't vacuously passing.

1. Snapshot fixed sanitizer → `/tmp/sanitizer.js.fixed-backup` (MD5 `7650ecb1adfc27ff7ec404d22f88ab32`)
2. `git checkout HEAD -- lib/sanitizer.js` (revert to pre-fix, MD5 `93e5b44dc1c54b8d4d939270a69ab5e1`)
3. Re-run AJV harness → **rejected, 1 invalid (`surecart-get-store-info`, `/properties must be object`), exit 1** ✓
4. Restore fix from backup → `cp /tmp/sanitizer.js.fixed-backup lib/sanitizer.js`
5. MD5-confirm restored byte-equivalence with backup → both `7650ecb1adfc27ff7ec404d22f88ab32` ✓
6. Re-run AJV harness → **accepted, 0 invalid, exit 0** ✓
7. Re-run `npm test` → 408 / 408 pass ✓

Cycle is clean: pre-fix rejects, post-fix accepts, restored state matches snapshot byte-for-byte.

## Boundary case explicitly unchanged

`inputSchema: { type: "object" }` (no `properties` key) is byte-unchanged. Verified by:
- Source-side: early-return on `schema.properties === undefined` is the first gate after the type-validity check, before any normalize branch
- Test-side: `'properties' in after` asserted false post-sanitize, plus reference-equality and `JSON.stringify` equality

## Out of scope

Per dispatch — `outputSchema` normalization (bridge already strips `outputSchema` before emit), source-side patches in vendor plugins (separate upstream report), sanitizer architecture refactoring (this is a targeted guard on the existing function), other-repo changes, and Node/plugin version bumps.

## Coordinated release wave

Bridge release is **HELD** until abilities-mcp-adapter v1.4.8 release is also ready, per cross-sprint Decision 1B. Do not tag, do not npm publish on merge. Authorization for tag + publish is J-level after the coordinated wave is assembled.

Closes #83