### PR TITLE
fix(bridge): make mcp-adapter-* always visible under toolFilter; honest wp_browse_tools / wp_load_tools (#85)

### DIFF
--- a/lib/bridge-tools.js
+++ b/lib/bridge-tools.js
@@ -23,7 +23,8 @@ const BRIDGE_TOOLS = [
   },
   {
     name: 'wp_browse_tools',
-    description: 'List available WordPress tool categories with tool counts. Shows which categories are currently loaded. Use wp_load_tools to activate categories.',
+    description:
+      'List categories in the bridge\'s direct-tool catalog (scoped to defaultSite) with tool counts and load-state. This is the local-catalog control surface — not full cross-site ability discovery. For abilities on another site, or in a category not listed here, use mcp-adapter-discover-abilities / mcp-adapter-execute-ability with { site }.',
     inputSchema: {
       type: 'object',
       properties: {},
@@ -31,14 +32,16 @@ const BRIDGE_TOOLS = [
   },
   {
     name: 'wp_load_tools',
-    description: 'Activate WordPress tool categories to make their tools available. After loading, the tools list is automatically refreshed.',
+    description:
+      'Activate categories in the bridge\'s direct-tool catalog (scoped to defaultSite) to expose their tools in tools/list. This is the local-catalog control surface — not full cross-site ability discovery. If a requested category is not in the local catalog, the response points to mcp-adapter-discover-abilities + mcp-adapter-execute-ability for the cross-site path.',
     inputSchema: {
       type: 'object',
       properties: {
         categories: {
           type: 'array',
           items: { type: 'string' },
-          description: 'Category names to activate (e.g. ["fluent-crm", "content", "media"]). Use wp_browse_tools to see available categories.',
+          description:
+            'Category names to activate from the direct-tool catalog (e.g. ["fluent-crm", "content", "media"]). Use wp_browse_tools to see available categories. Categories not in the local catalog return a pointer to mcp-adapter-discover-abilities instead of silently activating nothing.',
         },
         deactivate: {
           type: 'array',

--- a/lib/router.js
+++ b/lib/router.js
@@ -463,14 +463,26 @@ class McpRouter {
       }
 
       const summary = this.catalog.getCategorySummary();
-      const lines = summary.map(c =>
-        `${c.active ? '[LOADED]' : '       '} ${c.name} (${c.toolCount} tools)`
+      const lines = [];
+      lines.push(
+        `Scope: direct-tool catalog scoped to defaultSite (${this.config.defaultSite}). ` +
+          `Not full cross-site ability discovery.`
       );
+      lines.push('');
+      for (const c of summary) {
+        lines.push(`${c.active ? '[LOADED]' : '       '} ${c.name} (${c.toolCount} tools)`);
+      }
       lines.push('');
       lines.push(`Total: ${this.catalog.fullTools.length} tools in ${summary.length} categories`);
       lines.push(`Loaded: ${summary.filter(c => c.active).reduce((n, c) => n + c.toolCount, 0)} tools`);
       lines.push('');
       lines.push('Use wp_load_tools with categories array to activate.');
+      lines.push('');
+      lines.push(
+        'For abilities on another site, or in a category not listed here, use ' +
+          'mcp-adapter-discover-abilities { site, category } and ' +
+          'mcp-adapter-execute-ability { site, ability_name, parameters }.'
+      );
 
       this.sendToClient(JSON.stringify({
         jsonrpc: '2.0', id: msg.id,
@@ -496,6 +508,7 @@ class McpRouter {
       }
 
       const activated = this.catalog.activateCategories(toActivate);
+      const missing = toActivate.filter((c) => !this.catalog.categories[c]);
       const lines = [];
 
       if (activated.length > 0) {
@@ -504,8 +517,25 @@ class McpRouter {
       if (toDeactivate.length > 0) {
         lines.push(`Deactivated: ${toDeactivate.join(', ')}`);
       }
-      if (activated.length === 0 && toDeactivate.length === 0) {
-        lines.push('No changes — categories may already be active or not found.');
+      if (missing.length > 0) {
+        lines.push(
+          `Not in the direct-tool catalog (scoped to defaultSite "${this.config.defaultSite}"): ` +
+            missing.join(', ') +
+            '.'
+        );
+        lines.push(
+          'For abilities on another site, or in a category not in this catalog, use the ' +
+            'adapter meta-tools instead:'
+        );
+        for (const cat of missing) {
+          lines.push(`  mcp-adapter-discover-abilities { site: "<site>", category: "${cat}" }`);
+        }
+        lines.push(
+          '  mcp-adapter-execute-ability { site: "<site>", ability_name: "<ability>", parameters: { ... } }'
+        );
+      }
+      if (activated.length === 0 && toDeactivate.length === 0 && missing.length === 0) {
+        lines.push('No changes — categories may already be active.');
       }
 
       const filtered = this.catalog.getFilteredTools();

--- a/lib/tool-catalog.js
+++ b/lib/tool-catalog.js
@@ -32,11 +32,22 @@ class ToolCatalog {
     // Active (loaded) categories
     this.activeCategories = new Set();
 
-    // Initialize always-included categories from config
-    if (this.filterConfig && this.filterConfig.alwaysIncludeCategories) {
-      for (const cat of this.filterConfig.alwaysIncludeCategories) {
-        this.activeCategories.add(cat);
-      }
+    // Resolve "always-include" categories once. Explicit operator config wins
+    // (including an explicit empty list, which preserves the operator's choice).
+    // When filtering is enabled and the operator hasn't set their own list,
+    // default to ['mcp-adapter'] so the cross-site adapter meta-tools
+    // (mcp-adapter-discover-abilities / -get-ability-info / -execute-ability)
+    // are always visible without requiring a prior wp_load_tools call.
+    const explicit = this.filterConfig && this.filterConfig.alwaysIncludeCategories;
+    const resolved =
+      explicit !== undefined && explicit !== null
+        ? explicit
+        : this.isEnabled()
+        ? ['mcp-adapter']
+        : [];
+    this.effectiveAlwaysInclude = new Set(resolved);
+    for (const cat of this.effectiveAlwaysInclude) {
+      this.activeCategories.add(cat);
     }
   }
 
@@ -104,12 +115,11 @@ class ToolCatalog {
    * Deactivate categories (return to compact mode).
    */
   deactivateCategories(categoryNames) {
-    // Don't deactivate always-included categories
-    const alwaysIncluded = new Set(
-      (this.filterConfig && this.filterConfig.alwaysIncludeCategories) || []
-    );
+    // Don't deactivate always-included categories (single source of truth:
+    // the set resolved at construction, so the default mcp-adapter inclusion
+    // is treated the same as an explicit operator-configured entry).
     for (const name of categoryNames) {
-      if (!alwaysIncluded.has(name)) {
+      if (!this.effectiveAlwaysInclude.has(name)) {
         this.activeCategories.delete(name);
       }
     }

--- a/test/router-bridge-orientation.test.js
+++ b/test/router-bridge-orientation.test.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { McpRouter } = require('../lib/router');
+const { ToolCatalog } = require('../lib/tool-catalog');
+
+/**
+ * McpRouter — bridge orientation (Issue #85).
+ *
+ * Pins:
+ *   1. wp_browse_tools response describes itself as the direct-tool catalog
+ *      scoped to defaultSite and points cross-site callers at the
+ *      mcp-adapter-* meta-tools.
+ *   2. wp_load_tools(["unknown-category"]) returns a structured pointer to
+ *      the adapter meta-tools instead of silently activating zero categories.
+ *
+ * The tools/list-time always-include behavior is covered in
+ * test/tool-catalog.test.js (#85-bridge-orientation describe block).
+ */
+
+const FULL_TOOLS = [
+  { name: 'content-list' },
+  { name: 'content-get' },
+  { name: 'media-list' },
+  { name: 'mcp-adapter-discover-abilities' },
+  { name: 'mcp-adapter-get-ability-info' },
+  { name: 'mcp-adapter-execute-ability' },
+];
+
+function makeRouter({ filterEnabled = true, primeCatalog = true } = {}) {
+  const sent = [];
+  const config = {
+    defaultSite: 'wickedevolutions',
+    sites: { wickedevolutions: {}, helenawillow: {} },
+    toolFilter: filterEnabled ? { enabled: true } : { enabled: false },
+  };
+  const catalog = new ToolCatalog(config);
+  if (primeCatalog) catalog.cacheTools(FULL_TOOLS);
+
+  const router = new McpRouter({
+    config,
+    siteKeys: ['wickedevolutions', 'helenawillow'],
+    isMultiSite: true,
+    pool: { setHandshakeCache() {} },
+    catalog,
+    sendToClient: (s) => sent.push(s),
+    log: () => {},
+  });
+  return { router, sent, catalog };
+}
+
+function parseLast(sent) {
+  return JSON.parse(sent[sent.length - 1]);
+}
+
+// wp_load_tools may emit a trailing notifications/tools/list_changed when
+// activated.length > 0; grab the response carrying the request id instead.
+function parseResponse(sent, id) {
+  for (const raw of sent) {
+    const parsed = JSON.parse(raw);
+    if (parsed.id === id) return parsed;
+  }
+  throw new Error(`no response found for id ${id}`);
+}
+
+describe('McpRouter — wp_browse_tools orientation (#85)', () => {
+  it('response includes the adapter-meta-tool pointer and names defaultSite scope', () => {
+    const { router, sent } = makeRouter();
+    router.handleClientMessage({
+      jsonrpc: '2.0', id: 1, method: 'tools/call',
+      params: { name: 'wp_browse_tools', arguments: {} },
+    }, '<line>');
+
+    const resp = parseLast(sent);
+    const text = resp.result.content[0].text;
+
+    assert.match(text, /direct-tool catalog/i,
+      'response self-describes as the direct-tool catalog');
+    assert.match(text, /scoped to defaultSite/i);
+    assert.match(text, /wickedevolutions/,
+      'response names the actual defaultSite for operator clarity');
+    assert.match(text, /mcp-adapter-discover-abilities/);
+    assert.match(text, /mcp-adapter-execute-ability/);
+    assert.match(text, /\{ site, category \}/);
+    assert.match(text, /\{ site, ability_name, parameters \}/);
+  });
+});
+
+describe('McpRouter — wp_load_tools missing-category pointer (#85)', () => {
+  it('unknown category returns the structured pointer (not silent zero-activation)', () => {
+    const { router, sent } = makeRouter();
+    router.handleClientMessage({
+      jsonrpc: '2.0', id: 2, method: 'tools/call',
+      params: { name: 'wp_load_tools', arguments: { categories: ['surecart-ecommerce'] } },
+    }, '<line>');
+
+    const resp = parseLast(sent);
+    const text = resp.result.content[0].text;
+
+    assert.match(text, /surecart-ecommerce/,
+      'response names the missing category back to the caller');
+    assert.match(text, /not in the direct-tool catalog/i,
+      'response is explicit about why the category was not activated');
+    assert.match(text, /mcp-adapter-discover-abilities/);
+    assert.match(text, /mcp-adapter-execute-ability/);
+    assert.match(text, /\{ site: "<site>", category: "surecart-ecommerce" \}/,
+      'pointer is parameterized with the actual missing category name');
+    assert.doesNotMatch(text, /No changes — categories may already be active/,
+      'no longer falls into the silent "may already be active" branch');
+  });
+
+  it('mixed request (one known + one unknown) activates the known and points for the unknown', () => {
+    const { router, sent } = makeRouter();
+    router.handleClientMessage({
+      jsonrpc: '2.0', id: 3, method: 'tools/call',
+      params: { name: 'wp_load_tools', arguments: { categories: ['content', 'spectra'] } },
+    }, '<line>');
+
+    const resp = parseResponse(sent, 3);
+    const text = resp.result.content[0].text;
+
+    assert.match(text, /Activated: content/);
+    assert.match(text, /not in the direct-tool catalog/i);
+    assert.match(text, /spectra/);
+    assert.match(text, /mcp-adapter-discover-abilities/);
+  });
+});

--- a/test/tool-catalog.test.js
+++ b/test/tool-catalog.test.js
@@ -121,6 +121,68 @@ describe('ToolCatalog', () => {
     assert.ok(summary[0].toolCount >= summary[summary.length - 1].toolCount);
   });
 
+  it('default mcp-adapter always-include applies when filtering is enabled and operator did not set alwaysIncludeCategories (#85)', () => {
+    // Match the operator's actual local config: { enabled: true }, no
+    // essentialTools, no alwaysIncludeCategories.
+    const catalog = new ToolCatalog({ toolFilter: { enabled: true } });
+    catalog.cacheTools([
+      { name: 'content-list' },
+      { name: 'content-get' },
+      { name: 'mcp-adapter-discover-abilities' },
+      { name: 'mcp-adapter-get-ability-info' },
+      { name: 'mcp-adapter-execute-ability' },
+      { name: 'fluent-crm-list-contacts' },
+    ]);
+
+    const filtered = catalog.getFilteredTools();
+    const names = filtered.map((t) => t.name);
+
+    // Acceptance pin: at minimum these three meta-tools must be visible.
+    assert.ok(names.includes('mcp-adapter-discover-abilities'));
+    assert.ok(names.includes('mcp-adapter-get-ability-info'));
+    assert.ok(names.includes('mcp-adapter-execute-ability'));
+
+    // Other categories still gated behind wp_load_tools.
+    assert.ok(!names.includes('content-list'));
+    assert.ok(!names.includes('fluent-crm-list-contacts'));
+  });
+
+  it('toolFilter.enabled = false leaves activeCategories untouched (no mcp-adapter default fires) (#85)', () => {
+    const catalog = new ToolCatalog({ toolFilter: { enabled: false } });
+
+    assert.equal(catalog.isEnabled(), false);
+    assert.equal(catalog.activeCategories.size, 0,
+      'no default category activation when filtering is disabled');
+    assert.equal(catalog.effectiveAlwaysInclude.size, 0,
+      'effectiveAlwaysInclude is empty under enabled:false — confirms no default');
+  });
+
+  it('explicit empty alwaysIncludeCategories preserves operator choice (does not fall back to mcp-adapter default) (#85)', () => {
+    const catalog = new ToolCatalog({
+      toolFilter: { enabled: true, alwaysIncludeCategories: [] },
+    });
+
+    assert.equal(catalog.effectiveAlwaysInclude.size, 0,
+      'operator-set empty list wins over the mcp-adapter default');
+    assert.equal(catalog.activeCategories.size, 0);
+  });
+
+  it('default mcp-adapter cannot be deactivated via wp_load_tools deactivate (#85)', () => {
+    const catalog = new ToolCatalog({ toolFilter: { enabled: true } });
+    catalog.cacheTools([
+      { name: 'mcp-adapter-discover-abilities' },
+      { name: 'mcp-adapter-execute-ability' },
+    ]);
+
+    catalog.deactivateCategories(['mcp-adapter']);
+
+    const filtered = catalog.getFilteredTools();
+    const names = filtered.map((t) => t.name);
+    assert.ok(names.includes('mcp-adapter-discover-abilities'),
+      'default-included mcp-adapter survives deactivateCategories — guarded by effectiveAlwaysInclude');
+    assert.ok(names.includes('mcp-adapter-execute-ability'));
+  });
+
   it('compound prefix extraction works for fluent-crm', () => {
     const catalog = makeCatalog();
     catalog.cacheTools([


### PR DESCRIPTION
## Summary

Three orientation + honesty changes — no architecture change. AI clients orient around `wp_browse_tools` / `wp_load_tools` first, which operate on a default-site-only direct-tool catalog and cannot see abilities registered on non-default sites. The cross-site adapter meta-tools (`mcp-adapter-discover-abilities` / `mcp-adapter-get-ability-info` / `mcp-adapter-execute-ability`) are already correct and route by `{site}` at execution time — they just weren't visible under `toolFilter` when the operator hadn't seeded their own `alwaysIncludeCategories`.

This PR makes the cross-site path the reliable always-visible primary and makes the bridge-local tools honest about their actual scope.

## Implementation mechanism chosen

**Default `alwaysIncludeCategories = ['mcp-adapter']`** when `toolFilter.enabled === true` and the operator has not set their own list. Picked over the alternatives in the issue (default `essentialTools`, ad-hoc config normalization) because:

- it reuses the existing `alwaysIncludeCategories` semantics (constructor seeding + `deactivateCategories` guard), so the only new state is a single private `effectiveAlwaysInclude` Set resolved once in the constructor;
- it covers all five `mcp-adapter-*` tools registered by the adapter plugin (`discover-abilities`, `get-ability-info`, `execute-ability`, `batch-execute`, `get-started`) rather than just the three named in the pin;
- it preserves operator override fully — explicit `alwaysIncludeCategories: [...]` wins (including an explicit empty list, since `[]` is truthy in JS, so `||`-fallback would clobber operator intent — handled with explicit `undefined`/`null` check).

[`lib/tool-catalog.js`](lib/tool-catalog.js) constructor now resolves `effectiveAlwaysInclude` once; `deactivateCategories` reads from that single Set so the default-included `mcp-adapter` cannot be silently deactivated via `wp_load_tools({deactivate:['mcp-adapter']})`. With `toolFilter.enabled === false`, `isEnabled()` returns false in the constructor, the default does not fire, and behavior is byte-equivalent to pre-PR.

[`lib/bridge-tools.js`](lib/bridge-tools.js) — `wp_browse_tools` and `wp_load_tools` descriptions rewritten to self-describe as **direct-tool catalog controls scoped to defaultSite, not full cross-site ability discovery**, with explicit pointer to the adapter meta-tools for cross-site cases.

[`lib/router.js`](lib/router.js) — `wp_browse_tools` runtime response now leads with a `Scope:` line naming the actual `defaultSite` and ends with the parameterized pointer text. `wp_load_tools` now computes `missing = toActivate.filter(c => !catalog.categories[c])` and emits a structured response (named missing categories + sample `{site, category}` and `{site, ability_name, parameters}` call shapes) instead of the silent `"No changes — categories may already be active or not found."` fall-through.

## Acceptance pin satisfied (verbatim, both forms)

> **Reviewer:** Make `mcp-adapter-*` the reliable always-visible cross-site path when filtering is enabled, and make `wp_browse_tools` / `wp_load_tools` explicitly describe themselves as direct-tool catalog controls, not full cross-site ability discovery.
>
> **User-facing:** With `defaultSite = wickedevolutions`, a fresh filtered session can discover and execute `surecart/get-store-info` on `helenawillow` through the adapter meta-tool path **without changing `defaultSite`**.

All five test outcomes from #85 are satisfied. The negative-control (toolFilter disabled → no default fires) is covered by a dedicated unit test asserting `effectiveAlwaysInclude.size === 0` and `activeCategories.size === 0`.

## Test evidence — 415 / 415 pass (was 408 pre-PR)

Seven new tests under two suites:

```
▶ ToolCatalog
  ✔ default mcp-adapter always-include applies when filtering is enabled
    and operator did not set alwaysIncludeCategories (#85)
  ✔ toolFilter.enabled = false leaves activeCategories untouched
    (no mcp-adapter default fires) (#85)
  ✔ explicit empty alwaysIncludeCategories preserves operator choice
    (does not fall back to mcp-adapter default) (#85)
  ✔ default mcp-adapter cannot be deactivated via wp_load_tools deactivate (#85)

▶ McpRouter — wp_browse_tools orientation (#85)
  ✔ response includes the adapter-meta-tool pointer and names defaultSite scope

▶ McpRouter — wp_load_tools missing-category pointer (#85)
  ✔ unknown category returns the structured pointer (not silent zero-activation)
  ✔ mixed request (one known + one unknown) activates the known and points
    for the unknown

ℹ tests 415
ℹ pass 415
ℹ fail 0
```

## Empirical verification — live operator config

Live config: `defaultSite = wickedevolutions`, `toolFilter: { enabled: true }`, six OAuth-authed sites, **no `essentialTools` or `alwaysIncludeCategories` set**. Harness drives the local abilities-mcp build over stdio against `~/.abilities-mcp/wp-sites.json`.

```
PIN 1 — PASS — fresh tools/list shows three adapter meta-tools without prior wp_load_tools
         8 tools total; all 3 required present
PIN 2 — PASS — mcp-adapter-discover-abilities surfaces surecart/get-store-info on helenawillow
         response length: 30918 bytes
PIN 3 — PASS — mcp-adapter-execute-ability returns SureCart store payload
         result preview: {"jsonrpc":"2.0","id":4,"result":{"content":[{"type":"text","text":"{\"success\":true,\"data\":{\"success\":true,\"store\":{\"id\":\"1d8d9e61-3db5-48c7-a1a8-0279e2fad075\",\"object\":\"account\",...
PIN 4 — PASS — wp_load_tools(["surecart-ecommerce"]) returns structured pointer
         text preview: Not in the direct-tool catalog (scoped to defaultSite "wickedevolutions"): surecart-ecommerce. | For abilities on another site, or in a category not in this catalog, use the adapter meta-tools instead: | ...

VERDICT: all 4 pins PASS
```

The pre-fix tools/list returned **only 3 tools** (the bridge tools); post-fix returns **8 tools** (3 bridge + 5 `mcp-adapter-*`).

## Behavior-reversal proof

Per `feedback_negative_control_per_test_pin` — the regression guards aren't vacuously passing.

1. Snapshot three fixed files → `/tmp/fix-85-backup/` (MD5 pinned):
   - `lib/tool-catalog.js` → `504c4ec2aabea179baf4f027c41c465a`
   - `lib/bridge-tools.js` → `2e17270100750b50002eed061c0e43b8`
   - `lib/router.js` → `1fdb53cf9b3101930294fdec4bf913ed`
2. `git checkout main -- lib/tool-catalog.js lib/bridge-tools.js lib/router.js` (revert to pre-fix):
   - `lib/tool-catalog.js` → `9b4ac5510126cfee8efbaa718e144782`
   - `lib/bridge-tools.js` → `440867816c944e4150b36a89c0759ae0`
   - `lib/router.js` → `f8fc903c66794be9bef299c9322792c4`
3. Re-run the 4-pin harness against the same live config:

```
PIN 1 — FAIL — fresh tools/list adapter meta-tools
         missing: mcp-adapter-discover-abilities, mcp-adapter-get-ability-info, mcp-adapter-execute-ability; total tools: 3
PIN 2 — PASS — mcp-adapter-discover-abilities surfaces surecart/get-store-info on helenawillow
PIN 3 — PASS — mcp-adapter-execute-ability returns SureCart store payload
PIN 4 — FAIL — wp_load_tools structured pointer
         text: No changes — categories may already be active or not found.
Tools now available: 0/259

VERDICT: one or more pins FAIL
```

PIN 2 and PIN 3 stay green on pre-fix — confirms the cross-site execution path was always functional; #85 is purely an orientation/visibility issue at the discovery layer. PIN 1 and PIN 4 fail on pre-fix, exactly the symptoms described in the issue body.

4. Restore from backup; MD5-confirm byte-equivalence (all three files match snapshot exactly); re-run harness → **all 4 PASS**.
5. Re-run `npm test` post-restore → **415 / 415 pass**.

Cycle is clean: pre-fix shows the documented failure symptoms, post-fix all 4 pins pass, restored state matches snapshot byte-for-byte.

## Out of scope (explicit, per issue body)

- Multi-site union catalog (separate design sprint).
- Default-site switching as a workaround.
- Adapter-side changes (bridge-only fix).
- Re-architecting `wp_browse_tools` to refetch per-site (separate enhancement).

## v1.6.3 release coupling

v1.6.3 has not been published yet (operator's working tree was mid-staging; stashed locally for this branch). This fix folds **into** v1.6.3 alongside the #83 sanitizer fix that merged in #84 — not a separate release. The v1.6.3 release remains **HELD** pending the coordinated wave with `abilities-mcp-adapter` v1.4.8 per cross-sprint Decision 1B (2026-05-11). When J assembles the v1.6.3 CHANGELOG section, it should cover both #83 and #85.

Closes #85