### PR TITLE
chore(release): v1.6.4 — Workstream-B bridge fixes (#87 S1/S2 + #89 + #90)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.3",
   "name": "abilities-mcp",
   "display_name": "WordPress (Abilities MCP)",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Connect AI clients to WordPress through the Abilities API. One-click bridge to your site's content, users, plugins, and Fluent ecosystem.",
   "long_description": "Abilities MCP is the open-source bridge that turns any WordPress site into a first-class MCP server. Install this bundle, type your site URL + WordPress username + application password, and your AI client gets typed access to content, users, media, plugins, themes, settings, FluentCRM/Forms/Community, and any other ability registered through the WordPress Abilities API.\n\nRequires the `abilities-mcp-adapter` and `abilities-for-ai` plugins on the WordPress site. The adapter exposes the MCP endpoint; this bundle is the client-side bridge running on your machine.",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wickedevolutions/abilities-mcp",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Open-source MCP bridge connecting AI clients to WordPress through the Abilities API — multi-site routing, zero dependencies",
   "main": "abilities-mcp.js",
   "bin": {


### PR DESCRIPTION
Release cut: version bump 1.6.3→1.6.4 on already-reviewed/merged main code (#87 S1/S2 #88, #89 #91, #90 #92). No code change beyond the version bump. Pinned artifact attested SHA256 `eccb16548a58bcb56f800abd768d93af16129e26ed3a295d9b5f646ac6292c04`. 🤖 Generated with [Claude Code](https://claude.com/claude-code)