### PR TITLE
feat(v1.6.6): advertise discover-abilities filter params to AI clients (#97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Abilities MCP are documented here.
 
 ## [Unreleased]
 
+## [1.6.6] - 2026-05-21
+
+### Added
+
+- **`mcp-adapter-discover-abilities` now advertises the six adapter-side filter / pagination parameters to AI clients (Issue [#97](https://github.com/Wicked-Evolutions/abilities-mcp/issues/97); closes adapter [#128](https://github.com/Wicked-Evolutions/abilities-mcp-adapter/issues/128)).** The adapter has accepted `category`, `annotation`, `search`, `compact`, `limit`, and `offset` on its `mcp-adapter/discover-abilities` ability since v1.2.0, and the bridge router has been forwarding them unchanged. The remaining gap was the `tools/list` projection: when an upstream layer projects an empty `inputSchema`, the bridge's defensive sanitizer normalizes it to `{ type: 'object' }`, after which AI clients have no way to know the optional params exist. v1.6.6 adds a small, additive schema overlay in `lib/tool-injector.js` (`applyAdapterToolSchemaOverlays`) that asserts the six params on the projected `inputSchema` for the `mcp-adapter-discover-abilities` tool — keyed by tool name, merged additively, adapter-wins on collision so a future adapter rename does not get clobbered. The overlay is a thin pass-through: the bridge only states what an AI client may pass; the adapter remains authoritative on runtime semantics. Operators see no router or forwarding change. Mirror of `src/Abilities/DiscoverAbilitiesAbility.php` register() input_schema; regression-guarded by 8 new tests in `test/tool-injector.test.js`.
+
+### Notes
+
+- **Version reservation.** v1.6.5 is reserved for the open `feat/v1.6.5-endpoint-rename-migration` branch (PR [#96](https://github.com/Wicked-Evolutions/abilities-mcp/pull/96)). v1.6.6 ships independently from main; whichever PR merges first publishes its version, and the other rebases.
+- Per Issue #97 the live forwarding path for `compact`, `limit`, and `category` was J-verified on dev2.helenawillow.com 2026-05-21; the remaining three (`annotation`, `search`, `offset`) ride the same `extractSiteParam`-only stripping in the router (rest-spread destructure of `site`), so they reach the adapter unchanged through the same path.
+
 ## [1.6.4] - 2026-05-17
 
 ### Added

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { sanitizeToolsList, isToolsListResponse } = require('./sanitizer');
-const { injectSiteParam, extractSiteParam } = require('./tool-injector');
+const { injectSiteParam, extractSiteParam, applyAdapterToolSchemaOverlays } = require('./tool-injector');
 const { isBridgeTool, injectBridgeTools } = require('./bridge-tools');
 
 /**
@@ -256,6 +256,11 @@ class McpRouter {
         this.catalog.cacheTools(parsedMsg.result.tools);
         parsedMsg.result.tools = this.catalog.getFilteredTools();
       }
+
+      // Apply schema overlays for known adapter tools whose filter / pagination
+      // params do not always reach AI clients through the adapter's projection
+      // (issue #97 + adapter #128). Additive — adapter wins on any collision.
+      applyAdapterToolSchemaOverlays(parsedMsg);
 
       // Inject bridge tools
       injectBridgeTools(parsedMsg);

--- a/lib/tool-injector.js
+++ b/lib/tool-injector.js
@@ -1,6 +1,109 @@
 'use strict';
 
 /**
+ * Adapter-tool schema overlays (issue #97 + adapter #128).
+ *
+ * Some adapter-side tools accept filter / pagination parameters that the
+ * adapter has registered in source since v1.2.0, but the parameters do not
+ * always reach the AI client as part of the `tools/list` projection — when
+ * an upstream layer projects an empty `inputSchema`, the bridge's defensive
+ * sanitizer normalizes it to `{ type: 'object' }`, after which AI clients
+ * have no way to know the optional params exist.
+ *
+ * The overlay is a thin pass-through assertion: the bridge advertises the
+ * params it knows the adapter accepts, merged ADDITIVELY into whatever the
+ * adapter's projection already advertised. If the adapter advertises a
+ * property already, the adapter's version wins (so a future adapter rename
+ * does not collide). The adapter remains authoritative on runtime semantics —
+ * the bridge only states what the AI client may pass.
+ *
+ * Keyed by MCP tool name (slash → hyphen): `mcp-adapter/discover-abilities`
+ * becomes `mcp-adapter-discover-abilities` on the wire.
+ *
+ * Mirror of `src/Abilities/DiscoverAbilitiesAbility.php` register() input_schema
+ * (adapter is authoritative on parameter names and runtime bounds).
+ */
+const ADAPTER_TOOL_SCHEMA_OVERLAYS = {
+  'mcp-adapter-discover-abilities': {
+    properties: {
+      category: {
+        type: 'string',
+        description:
+          'Filter by ability category slug (e.g. "content", "taxonomies", "fluent-crm"). Optional pass-through to the adapter.',
+      },
+      annotation: {
+        type: 'string',
+        enum: ['readonly', 'destructive'],
+        description:
+          'Filter by meta annotation: "readonly" for safe read operations, "destructive" for delete operations. Optional pass-through to the adapter.',
+      },
+      search: {
+        type: 'string',
+        description:
+          'Case-insensitive substring match against ability name, label, and description. Optional pass-through to the adapter.',
+      },
+      compact: {
+        type: 'boolean',
+        description:
+          'When true, returns only name, category, and tier per ability — skips label, description, and schemas. Use to keep large catalogs inside the AI client\'s tool-result token budget. Optional pass-through to the adapter.',
+      },
+      limit: {
+        type: 'integer',
+        minimum: 0,
+        maximum: 200,
+        description:
+          'Maximum number of abilities to return. Adapter caps at 200. Use with offset for paging through large catalogs. Optional pass-through to the adapter.',
+      },
+      offset: {
+        type: 'integer',
+        minimum: 0,
+        description:
+          'Number of abilities to skip before returning results. Use with limit for paging. Optional pass-through to the adapter.',
+      },
+    },
+  },
+};
+
+/**
+ * Apply the known-adapter-tool schema overlays to a tools/list response.
+ * Additive: if the adapter's projection already advertises a property, the
+ * adapter's version wins. Mutates `msg` in place.
+ *
+ * @param {object} msg - The full JSON-RPC tools/list response
+ * @returns {object} The mutated response
+ */
+function applyAdapterToolSchemaOverlays(msg) {
+  if (!msg || !msg.result || !Array.isArray(msg.result.tools)) return msg;
+
+  for (const tool of msg.result.tools) {
+    if (!tool || typeof tool.name !== 'string') continue;
+    const overlay = ADAPTER_TOOL_SCHEMA_OVERLAYS[tool.name];
+    if (!overlay) continue;
+
+    if (!tool.inputSchema || typeof tool.inputSchema !== 'object' || Array.isArray(tool.inputSchema)) {
+      tool.inputSchema = { type: 'object' };
+    }
+    if (tool.inputSchema.type === undefined) {
+      tool.inputSchema.type = 'object';
+    }
+    if (!tool.inputSchema.properties || typeof tool.inputSchema.properties !== 'object' || Array.isArray(tool.inputSchema.properties)) {
+      tool.inputSchema.properties = {};
+    }
+
+    // Adapter wins on collisions — only add properties the adapter did not
+    // already advertise. The bridge stays a thin pass-through that asserts
+    // what it knows the adapter accepts without overriding adapter intent.
+    for (const [propName, propDef] of Object.entries(overlay.properties)) {
+      if (!(propName in tool.inputSchema.properties)) {
+        tool.inputSchema.properties[propName] = propDef;
+      }
+    }
+  }
+
+  return msg;
+}
+
+/**
  * Inject a `site` parameter into every tool in a tools/list response.
  * This is the core of multi-site routing — the LLM sees `site` as an optional
  * enum parameter on every tool and specifies which WordPress site to target.
@@ -48,4 +151,9 @@ function extractSiteParam(args, defaultSite) {
   return { site: site || defaultSite, cleanArgs };
 }
 
-module.exports = { injectSiteParam, extractSiteParam };
+module.exports = {
+  injectSiteParam,
+  extractSiteParam,
+  applyAdapterToolSchemaOverlays,
+  ADAPTER_TOOL_SCHEMA_OVERLAYS,
+};

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.3",
   "name": "abilities-mcp",
   "display_name": "WordPress (Abilities MCP)",
-  "version": "1.6.4",
+  "version": "1.6.6",
   "description": "Connect AI clients to WordPress through the Abilities API. One-click bridge to your site's content, users, plugins, and Fluent ecosystem.",
   "long_description": "Abilities MCP is the open-source bridge that turns any WordPress site into a first-class MCP server. Install this bundle, type your site URL + WordPress username + application password, and your AI client gets typed access to content, users, media, plugins, themes, settings, FluentCRM/Forms/Community, and any other ability registered through the WordPress Abilities API.\n\nRequires the `abilities-mcp-adapter` and `abilities-for-ai` plugins on the WordPress site. The adapter exposes the MCP endpoint; this bundle is the client-side bridge running on your machine.",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wickedevolutions/abilities-mcp",
-  "version": "1.6.4",
+  "version": "1.6.6",
   "description": "Open-source MCP bridge connecting AI clients to WordPress through the Abilities API — multi-site routing, zero dependencies",
   "main": "abilities-mcp.js",
   "bin": {

--- a/test/tool-injector.test.js
+++ b/test/tool-injector.test.js
@@ -2,7 +2,12 @@
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
-const { injectSiteParam, extractSiteParam } = require('../lib/tool-injector');
+const {
+  injectSiteParam,
+  extractSiteParam,
+  applyAdapterToolSchemaOverlays,
+  ADAPTER_TOOL_SCHEMA_OVERLAYS,
+} = require('../lib/tool-injector');
 
 function makeToolsListMsg(tools) {
   return { jsonrpc: '2.0', id: 1, result: { tools } };
@@ -68,5 +73,138 @@ describe('extractSiteParam', () => {
     const { site, cleanArgs } = extractSiteParam({}, 'default');
     assert.equal(site, 'default');
     assert.deepEqual(cleanArgs, {});
+  });
+});
+
+describe('applyAdapterToolSchemaOverlays — mcp-adapter-discover-abilities (#97)', () => {
+  it('advertises the six adapter filter params on mcp-adapter-discover-abilities when the projected schema is empty', () => {
+    const msg = makeToolsListMsg([
+      { name: 'mcp-adapter-discover-abilities', inputSchema: { type: 'object' } },
+    ]);
+
+    applyAdapterToolSchemaOverlays(msg);
+
+    const props = msg.result.tools[0].inputSchema.properties;
+    assert.ok(props, 'properties created');
+    for (const key of ['category', 'annotation', 'search', 'compact', 'limit', 'offset']) {
+      assert.ok(props[key], `missing property: ${key}`);
+    }
+    assert.equal(props.category.type, 'string');
+    assert.equal(props.annotation.type, 'string');
+    assert.deepEqual(props.annotation.enum, ['readonly', 'destructive']);
+    assert.equal(props.search.type, 'string');
+    assert.equal(props.compact.type, 'boolean');
+    assert.equal(props.limit.type, 'integer');
+    assert.equal(props.limit.minimum, 0);
+    assert.equal(props.limit.maximum, 200);
+    assert.equal(props.offset.type, 'integer');
+    assert.equal(props.offset.minimum, 0);
+  });
+
+  it('site can still be injected after the overlay (compose cleanly)', () => {
+    const msg = makeToolsListMsg([
+      { name: 'mcp-adapter-discover-abilities', inputSchema: { type: 'object' } },
+    ]);
+
+    applyAdapterToolSchemaOverlays(msg);
+    injectSiteParam(msg, ['dev2', 'helena'], 'dev2');
+
+    const props = msg.result.tools[0].inputSchema.properties;
+    for (const key of ['site', 'category', 'annotation', 'search', 'compact', 'limit', 'offset']) {
+      assert.ok(props[key], `missing property after composition: ${key}`);
+    }
+  });
+
+  it('does not require any property — the param-less call shape stays valid', () => {
+    const msg = makeToolsListMsg([
+      { name: 'mcp-adapter-discover-abilities', inputSchema: { type: 'object' } },
+    ]);
+    applyAdapterToolSchemaOverlays(msg);
+    const schema = msg.result.tools[0].inputSchema;
+    // Either there is no `required` array, or it is empty.
+    if (Array.isArray(schema.required)) {
+      assert.equal(schema.required.length, 0, 'no overlay property should be required');
+    }
+  });
+
+  it('adapter projection wins over overlay on collisions — bridge does not override adapter intent', () => {
+    const adapterCategory = {
+      type: 'string',
+      description: 'ADAPTER-AUTHORITATIVE DESCRIPTION',
+      // Hypothetical future adapter rename / tightening — bridge must not stomp it.
+      pattern: '^[a-z][a-z0-9-]*$',
+    };
+    const msg = makeToolsListMsg([
+      {
+        name: 'mcp-adapter-discover-abilities',
+        inputSchema: {
+          type: 'object',
+          properties: { category: adapterCategory },
+        },
+      },
+    ]);
+
+    applyAdapterToolSchemaOverlays(msg);
+
+    const projectedCategory = msg.result.tools[0].inputSchema.properties.category;
+    assert.equal(projectedCategory, adapterCategory, 'adapter-supplied property is preserved by reference');
+    assert.equal(projectedCategory.description, 'ADAPTER-AUTHORITATIVE DESCRIPTION');
+    assert.equal(projectedCategory.pattern, '^[a-z][a-z0-9-]*$');
+    // The remaining 5 overlay params are still added.
+    for (const key of ['annotation', 'search', 'compact', 'limit', 'offset']) {
+      assert.ok(msg.result.tools[0].inputSchema.properties[key], `missing complementary property: ${key}`);
+    }
+  });
+
+  it('only applies to known tool names — other tools are untouched', () => {
+    const msg = makeToolsListMsg([
+      { name: 'mcp-adapter-execute-ability', inputSchema: { type: 'object', properties: { ability_name: { type: 'string' } } } },
+      { name: 'content-list', inputSchema: { type: 'object', properties: { post_type: { type: 'string' } } } },
+    ]);
+
+    applyAdapterToolSchemaOverlays(msg);
+
+    assert.deepEqual(
+      Object.keys(msg.result.tools[0].inputSchema.properties),
+      ['ability_name'],
+      'mcp-adapter-execute-ability not in overlay map — schema unchanged',
+    );
+    assert.deepEqual(
+      Object.keys(msg.result.tools[1].inputSchema.properties),
+      ['post_type'],
+      'unrelated tool schema untouched',
+    );
+  });
+
+  it('is a no-op when msg has no tools array', () => {
+    const empty = { jsonrpc: '2.0', id: 1, result: {} };
+    const result = applyAdapterToolSchemaOverlays(empty);
+    assert.equal(result, empty);
+  });
+
+  it('repairs a malformed inputSchema (array or non-object) into a valid object before overlay', () => {
+    const msg = makeToolsListMsg([
+      { name: 'mcp-adapter-discover-abilities', inputSchema: [] },
+    ]);
+    applyAdapterToolSchemaOverlays(msg);
+    const schema = msg.result.tools[0].inputSchema;
+    assert.equal(schema.type, 'object');
+    assert.equal(typeof schema.properties, 'object');
+    assert.ok(!Array.isArray(schema.properties));
+    assert.ok(schema.properties.compact, 'overlay applied after repair');
+  });
+});
+
+describe('ADAPTER_TOOL_SCHEMA_OVERLAYS — sanity', () => {
+  it('discover-abilities overlay names match the adapter source exactly', () => {
+    // Mirror of src/Abilities/DiscoverAbilitiesAbility.php input_schema property
+    // names. If the adapter renames or drops one of these the bridge overlay
+    // must follow — the parity is the contract this test pins.
+    const overlay = ADAPTER_TOOL_SCHEMA_OVERLAYS['mcp-adapter-discover-abilities'];
+    assert.ok(overlay);
+    assert.deepEqual(
+      Object.keys(overlay.properties).sort(),
+      ['annotation', 'category', 'compact', 'limit', 'offset', 'search'],
+    );
   });
 });


### PR DESCRIPTION
## What changed

The `abilities-mcp-adapter` has accepted six filter / pagination parameters on its `mcp-adapter/discover-abilities` ability since v1.2.0 — `category`, `annotation`, `search`, `compact`, `limit`, `offset` — and the bridge's request router has been forwarding them to the adapter unchanged (the router's `extractSiteParam` only strips `site` via rest-spread destructuring; every other key passes through as-is). The remaining gap was the `tools/list` projection: AI clients use the bridge's advertised `inputSchema` (a JSON-Schema description of what arguments a tool accepts) to know what to send. When an upstream layer projects an empty `inputSchema` for this tool, the bridge's defensive sanitizer normalizes it to `{ type: 'object' }`, after which AI clients have no way to know the optional filter params exist — so they can't pass them, and the catalog is unreachable at any scale beyond the full ~1,649-ability dump.

This PR adds a small additive **schema overlay** in `lib/tool-injector.js` that asserts the six params on the projected `inputSchema` for `mcp-adapter-discover-abilities`. The overlay is:

- **Additive** — merged into whatever the adapter's projection already advertised; never replaces it.
- **Adapter-wins** — if the adapter advertises a property already, the adapter's version is preserved by reference. A future adapter rename or tightening (e.g. a new `pattern` regex on `category`) is not clobbered by the bridge.
- **Keyed by tool name** — only `mcp-adapter-discover-abilities` is overlaid today; the same pattern stays available for any future per-tool projection gap without expanding the surface area now.

Wired into the existing `tools/list` pipeline in `lib/router.js` between the catalog-filter step and `injectBridgeTools` + `injectSiteParam`. No router or forwarding change.

## Touch points

| File | Change |
|---|---|
| `lib/tool-injector.js` | Added `ADAPTER_TOOL_SCHEMA_OVERLAYS` map (one entry: `mcp-adapter-discover-abilities`) + `applyAdapterToolSchemaOverlays(msg)` helper. Mirror of `src/Abilities/DiscoverAbilitiesAbility.php` register() input_schema names. |
| `lib/router.js` | One call site between catalog-filter and bridge-tool injection in the `tools/list` response branch. |
| `test/tool-injector.test.js` | 8 new tests under `describe('applyAdapterToolSchemaOverlays …', …)` and an `ADAPTER_TOOL_SCHEMA_OVERLAYS — sanity` parity test pinning the property names against the adapter source. |
| `CHANGELOG.md` | New `## [1.6.6] - 2026-05-21` section with one Added entry + a Notes subsection covering the v1.6.5 version-reservation and the forwarding spot-check. |
| `package.json` + `manifest.json` | Version → `1.6.6`. |

## How it satisfies the acceptance gate

Mirroring the adapter's parameter names exactly:

| Param | Type | Bounds / values | Source-of-truth (adapter PHP, plain language) |
|---|---|---|---|
| `category` | string | — | Filter to a single ability category slug, e.g. `"fluent-crm"`. |
| `annotation` | string | enum: `readonly`, `destructive` | Filter to abilities flagged as safe-read (`readonly`) or delete-class (`destructive`). |
| `search` | string | — | Case-insensitive substring match on name, label, and description. |
| `compact` | boolean | — | Skip label/description/schemas; return `{name, category, tier}` only. |
| `limit` | integer | minimum 0, maximum 200 | Page size; adapter caps at 200. |
| `offset` | integer | minimum 0 | Page offset for pagination. |

All six are optional. `site` continues to be added by `injectSiteParam` in the same `tools/list` pass; the overlay and the site-injection compose cleanly (covered by test).

## Spot-check of the three params J had not live-verified

J's dev2 evidence already confirmed `compact`, `limit`, and `category` reach the adapter intact. I traced the bridge's request path for `annotation`, `search`, and `offset` to confirm they ride the same forwarding:

- `lib/router.js:665` is the single arg-stripping site for `tools/call`. It calls `extractSiteParam(toolArgs, defaultSite)`.
- `extractSiteParam` (in `lib/tool-injector.js`) destructures `{ site, ...cleanArgs }` — the rest-spread carries every key other than `site` into `cleanArgs` unchanged.
- The router then forwards `{ ...msg.params, arguments: cleanArgs }` to the adapter transport.

There is no per-arg allowlist anywhere in the forwarding path; `annotation`, `search`, `offset` are forwarded identically to `compact`, `limit`, `category`. No router change required.

## Tests run

- `npm test`: **`435 / 435 passing`** (427 baseline + 8 new overlay cases), 1.88s.
- `npm run validate:mcpb`: **`Manifest schema validation passes!`**
- `npm run pack:mcpb`: built `abilities-mcp-1.6.6.mcpb`, 453.2 kB, 59 files (0 ignored).

## `.mcpb` artifact for local install + test

Per the established release shape (v1.6.5 PR #96): no `npm publish`, no `v1.6.6` GitHub Release tag from this PR. J authorizes both after local install + dev2 acceptance against the attached bundle.

- **Path:** `/Users/wicked/my-agent/wordpress-plugins-temp/abilities-mcp/abilities-mcp.mcpb`
- **Versioned copy:** `/Users/wicked/my-agent/wordpress-plugins-temp/_releases/abilities-mcp-1.6.6.mcpb`
- **sha256:** `cdde8129ce1df852d2b0ce88cb5a35cb028690d5217e34d3be0d91b0d6110dcf`
- **Size:** 464,093 bytes / 453.2 kB packaged / 1.4 MB unpacked
- **Internal manifest version:** 1.6.6

## Acceptance gate (J verifies on dev2 with this bundle installed)

- `mcp-adapter-discover-abilities { site: "dev2", compact: true, limit: 200 }` returns ~200 compact abilities through the AI-client tool surface (no manual JSON-RPC).
- `mcp-adapter-discover-abilities { site: "dev2", category: "fluent-crm", compact: true, limit: 5 }` returns 5 compact FluentCRM abilities.
- `mcp-adapter-discover-abilities { site: "dev2" }` continues to work unchanged.

## Version reservation

v1.6.5 is reserved for the open `feat/v1.6.5-endpoint-rename-migration` branch (PR #96, endpoint rename + stale-endpoint pre-flight). v1.6.6 ships from `main` independently; whichever PR merges first publishes its version, the other rebases on top of it. The two PRs touch disjoint files (#96: `lib/config.js`, `lib/cli/config-store.js`, `lib/connection-pool.js`, `lib/transports/ssh-transport.js`, `lib/cli/commands/test.js`; this PR: `lib/router.js`, `lib/tool-injector.js`, `test/tool-injector.test.js`) — no source conflict expected; CHANGELOG sections will need ordering adjustment at the rebase.

## Sprint Plan Gate (Principles v1)

Official WordPress Compatibility Review:
- Registry / source-of-truth impact: None. No ability registration, schema, callback, or permission semantics changed in any WordPress codebase. The bridge mirrors what the adapter's `DiscoverAbilitiesAbility` register() already declares.
- Adapter / product-layer impact: Bridge `tools/list` projection now consistently exposes the six adapter-side filter params for `mcp-adapter-discover-abilities`. Adapter remains authoritative on runtime semantics; bridge is a thin pass-through schema assertion. No change to other adapter tools, no change to bridge-local synthetic tools.

## Issue / Project / phase linkage

- Fixes #97
- Closes adapter [#128](https://github.com/Wicked-Evolutions/abilities-mcp-adapter/issues/128) (the AI-client side of the discover-filter unreachability — adapter side already addressed in v1.4.9 with the `mcp.public` + `show_in_rest` meta-shape fixes from PR adapter#138 + #135).
- References adapter [#121](https://github.com/Wicked-Evolutions/abilities-mcp-adapter/issues/121) (discovery does not scale) — this is the first concrete scaling fix on the bridge side; #121 covers a broader surface and stays open.

## Deviations

Two notes, neither code-shipping beyond the issue's binding scope:

1. **The overlay sits inside `lib/tool-injector.js` rather than being a new file.** The user instruction said "Locate the bridge tool definition for `mcp-adapter-discover-abilities`" — there is no such per-tool definition in the bridge source today; `mcp-adapter-*` tools come from the adapter's `tools/list` response, with the bridge only adding `site` via `injectSiteParam` and the three local bridge tools via `injectBridgeTools`. The cleanest place for an additive per-tool schema assertion is alongside the existing per-tool schema mutation (`tool-injector.js`), exported as `applyAdapterToolSchemaOverlays`. Mentioned here so the framing matches the user's mental model.
2. **`limit` minimum is 0 in the overlay, matching the user's specified bound, while the adapter source uses minimum 1.** The user explicitly listed `limit : integer (minimum 0, maximum 200)` and `offset : integer (minimum 0)`. I used the user-specified values. If the adapter rejects `limit: 0` at runtime (which is its prerogative as the authoritative semantic layer), the failure surfaces from the adapter naturally; nothing in the bridge depends on the overlay matching the adapter's minimum exactly.