### PR TITLE
fix(attach): v1.6.6 — terminate route-absent loop + answer initialize when all sites fail (#102, #103)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ dist-mcpb/
 
 # Claude Code agent worktrees / local metadata (never committed)
 .claude/
+
+# IJFW local agent tooling / metadata (never committed; matches at any depth)
+.ijfw/
+ijfw/

--- a/.npmignore
+++ b/.npmignore
@@ -12,3 +12,11 @@ wp-sites.json
 .idea/
 *.swp
 *.swo
+
+# Local agent tooling / metadata — never published (matches at any depth)
+.ijfw/
+**/.ijfw/
+.claude/
+ijfw/
+AGENTS.md
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to Abilities MCP are documented here.
 
 ## [Unreleased]
 
+## [1.6.6] - 2026-06-14
+
+Attach reliability. Two bugs that prevented an AI client from attaching to the bridge, plus the route-source hardening that surfaced alongside them.
+
+### Fixed
+
+- **Client attach no longer loops forever when a configured MCP route is absent (Issue [#103](https://github.com/Wicked-Evolutions/abilities-mcp/issues/103)).** When a site's persisted `mcp_resource` route returns HTTP `404 rest_no_route` (the route does not exist on the server — e.g. the server's adapter still advertises the older default name), both HTTP transports treated every 404 as "session expired" and re-ran `performHandshake()`, which re-POSTed `initialize`, got the same 404, and recursed without bound — the client never received an `InitializeResult`. Fixed in three parts: (1) a `404` carrying WordPress's `rest_no_route` code is surfaced as a terminal `mcp_route_absent` error (shared helper `lib/transports/rest-error.js`) so the router's per-site fallback (#87) / degraded convergence (#76) engages instead of recovering; `HttpTransport` additionally re-throws it ahead of its network-retry branch so it is not retried. (2) A new `_inHandshake` guard on both transports bounds session recovery to exactly one re-handshake for *any* persistent 404 — `performHandshake()`'s own `initialize`/`initialized` POSTs can no longer re-enter the recovery branch. (3) Discovery metadata caching no longer pins a null protected-resource for the process lifetime.
+- **Client attach no longer hangs when all sites fail at boot (Issue [#102](https://github.com/Wicked-Evolutions/abilities-mcp/issues/102), part a).** When every configured site failed to connect at boot, the bridge entered degraded mode but `drainEarlyQueue()` forwarded the early-queued `initialize` to a null default transport — silently dropping it, so the client hung to its 60s `initialize` deadline and detached. `drainEarlyQueue()` now re-dispatches queued messages through `handleClientMessage()` in degraded boot, so a queued `initialize` reaches the existing degraded synthesis path (a locally-synthesized `InitializeResult`) and the client attaches in degraded mode. The connected path is unchanged. (Part b — a genuinely *hanging* site that delays degraded mode past the deadline via the serial connect walk — is tracked separately in [#108](https://github.com/Wicked-Evolutions/abilities-mcp/issues/108).)
+
+### Changed
+
+- **OAuth transport prefers the live-discovered protected-resource over a stale persisted `mcp_resource` (Issue [#103](https://github.com/Wicked-Evolutions/abilities-mcp/issues/103), Component B).** When `.well-known/oauth-protected-resource` advertises a `resource` that differs from the persisted `mcp_resource` (e.g. the bridge config carries the v1.6.5 default route name but the site's adapter still advertises the older name), the bridge connects via the live-discovered resource (RFC 9728 authoritative) and logs an actionable `reauth` hint. Operator-configured multisite subsite endpoints (`resolvedEndpoint`) still take precedence.
+
+### Known follow-ups
+
+- [#108](https://github.com/Wicked-Evolutions/abilities-mcp/issues/108) — bounded boot / lazy connect so a hanging site can't delay degraded mode (#102 part b).
+- [#106](https://github.com/Wicked-Evolutions/abilities-mcp/issues/106) / [#107](https://github.com/Wicked-Evolutions/abilities-mcp/issues/107) — complete #103 Component B's route-source edge cases (dedup keying; multisite subsite path).
+
 ## [1.6.5] - 2026-05-21
 
 ### Changed

--- a/lib/connection-pool.js
+++ b/lib/connection-pool.js
@@ -513,7 +513,12 @@ class ConnectionPool {
     const discoverFn = this._discover || discover;
 
     let asMetadata = (this._asMetadataCache.get(siteConfig.url) || {}).asMetadata;
-    if (!asMetadata) {
+    let prMetadata = (this._asMetadataCache.get(siteConfig.url) || {}).prMetadata;
+    // Issue #103 (P3): re-run discovery when AS metadata is missing OR when a
+    // prior attempt cached a null protected-resource. A transient
+    // .well-known/oauth-protected-resource failure must not poison Component B's
+    // live-resource preference for the whole process lifetime.
+    if (!asMetadata || !prMetadata) {
       const result = await discoverFn(siteConfig.url, {
         pinned: !!siteConfig.oauth_capability_pinned,
         pinnedFirstSeenAt: siteConfig.oauth_capability_pinned
@@ -521,6 +526,7 @@ class ConnectionPool {
         allowInsecure: this._allowInsecure,
       });
       asMetadata = result.asMetadata;
+      prMetadata = result.prMetadata;
       this._asMetadataCache.set(siteConfig.url, {
         asMetadata: result.asMetadata,
         prMetadata: result.prMetadata,
@@ -535,8 +541,26 @@ class ConnectionPool {
 
     const siteAuth = _siteAuthFromConfig(compositeKey, siteConfig, asMetadata);
 
+    // Issue #103 (Component B): prefer the live-discovered protected-resource
+    // URL over the stale persisted mcp_resource when they differ. The RFC 9728
+    // .well-known/oauth-protected-resource document is authoritative; the
+    // persisted value may be stale if the server's adapter route was renamed.
+    // resolvedEndpoint (multisite subsite case) still wins unconditionally —
+    // it is derived from the operator-configured multisite map, not discovery.
+    const discoveredResource = prMetadata && prMetadata.resource;
+    let endpoint = resolvedEndpoint || siteConfig.mcp_resource;
+    if (!resolvedEndpoint && discoveredResource && discoveredResource !== siteConfig.mcp_resource) {
+      this.log(
+        `Site "${compositeKey}": persisted mcp_resource (${siteConfig.mcp_resource}) ` +
+        `differs from live .well-known protected-resource (${discoveredResource}) — ` +
+        `using live-discovered resource (RFC 9728 authoritative). Re-run ` +
+        `\`abilities-mcp reauth ${compositeKey}\` to refresh the persisted value.`
+      );
+      endpoint = discoveredResource;
+    }
+
     return new OAuthHttpTransport({
-      endpoint: resolvedEndpoint || siteConfig.mcp_resource,
+      endpoint,
       subsiteUrl: subsiteUrl || null,
       tokenManager: this._tokenManager,
       siteAuth,

--- a/lib/router.js
+++ b/lib/router.js
@@ -110,11 +110,27 @@ class McpRouter {
    */
   drainEarlyQueue() {
     if (this.earlyQueue.length === 0) return;
-    this.log(`Draining ${this.earlyQueue.length} early queued message(s)`);
+    this.log(
+      `Draining ${this.earlyQueue.length} early queued message(s)` +
+      (this.defaultTransport ? '' : ' via local handlers (degraded)')
+    );
     const queued = this.earlyQueue.slice();
     this.earlyQueue = [];
     for (const line of queued) {
-      if (this.defaultTransport) this.defaultTransport.send(line);
+      if (this.defaultTransport) {
+        this.defaultTransport.send(line);
+        continue;
+      }
+      // Issue #102(a): degraded boot — no default transport. Re-dispatch through
+      // handleClientMessage so a queued initialize reaches the degraded synthesis
+      // path (synthesized InitializeResult / bridge-only tools/list) instead of
+      // being silently dropped, which hangs the client to its 60s deadline.
+      // enterDegradedMode() has already set this.degraded before drainEarlyQueue()
+      // runs at boot, so handleClientMessage routes to the degraded branches.
+      let parsed;
+      try { parsed = JSON.parse(line); }
+      catch { this.log('Dropping non-JSON early-queued line in degraded drain'); continue; }
+      this.handleClientMessage(parsed, line);
     }
   }
 

--- a/lib/transports/http-transport.js
+++ b/lib/transports/http-transport.js
@@ -3,6 +3,7 @@
 const https = require('https');
 const http = require('http');
 const { URL } = require('url');
+const { isRestNoRoute } = require('./rest-error');
 const MAX_QUEUE = 100;
 
 /**
@@ -41,6 +42,9 @@ class HttpTransport {
     // State
     this.sessionId = null;
     this.sessionToken = null; // Mcp-Session-Token (HMAC, echoed back on every request)
+    // Issue #103: true while performHandshake's own init/initialized POSTs are
+    // in flight, so they cannot re-enter the session-recovery branch and loop.
+    this._inHandshake = false;
     this.clientProtocolVersion = null; // Captured from initialize request for version rewriting
     this.ready = false;
     this.onMessage = null;  // Callback: (parsedMsg, rawLine) => void
@@ -120,23 +124,33 @@ class HttpTransport {
       this.clientProtocolVersion = initRequest.params.protocolVersion;
     }
 
-    // Send initialize request
-    const initLine = JSON.stringify(initRequest);
-    const initResult = await this._postWithRetry(initLine);
-    if (initResult && initResult.body && initResult.body.trim()) {
-      // Parse and forward the init response (but don't send to client — pool handles this)
-      this.log(`HTTP handshake init response: ${initResult.statusCode}`);
-    }
+    // Issue #103: mark the handshake window so the init / initialized POSTs
+    // below cannot themselves re-enter the session-recovery branch in
+    // _postWithRetry. Without this, a persistent 404 during a re-handshake
+    // re-enters recovery with a fresh attempt=0 and loops unbounded. This
+    // bounds recovery to exactly one re-handshake for any persistent 404.
+    this._inHandshake = true;
+    try {
+      // Send initialize request
+      const initLine = JSON.stringify(initRequest);
+      const initResult = await this._postWithRetry(initLine);
+      if (initResult && initResult.body && initResult.body.trim()) {
+        // Parse and forward the init response (but don't send to client — pool handles this)
+        this.log(`HTTP handshake init response: ${initResult.statusCode}`);
+      }
 
-    // Capture session ID from init
-    if (initResult && initResult.sessionId) {
-      this.sessionId = initResult.sessionId;
-    }
+      // Capture session ID from init
+      if (initResult && initResult.sessionId) {
+        this.sessionId = initResult.sessionId;
+      }
 
-    // Send initialized notification
-    if (initNotification) {
-      const notifLine = JSON.stringify(initNotification);
-      await this._postWithRetry(notifLine);
+      // Send initialized notification
+      if (initNotification) {
+        const notifLine = JSON.stringify(initNotification);
+        await this._postWithRetry(notifLine);
+      }
+    } finally {
+      this._inHandshake = false;
     }
   }
 
@@ -393,6 +407,21 @@ class HttpTransport {
     try {
       const result = await this._post(body);
 
+      // Issue #103: a 404 `rest_no_route` means the configured MCP route does not
+      // exist on the server — structurally non-recoverable. Re-handshaking re-POSTs
+      // initialize, gets the same 404, and loops forever. Surface it as a terminal
+      // error so the router's #87 per-site fallback / #76 degraded convergence engages
+      // (the same terminal path a connection error already takes).
+      if (result.statusCode === 404 && isRestNoRoute(result.body)) {
+        const err = new Error(
+          `MCP route not found at ${this.endpoint} (HTTP 404 rest_no_route) — ` +
+          `the configured route does not exist on the server`
+        );
+        err.code = 'mcp_route_absent';
+        err.statusCode = 404;
+        throw err;
+      }
+
       // Session expired — re-handshake and retry.
       // 404/410: explicit session-not-found signals.
       // 401/403: some WordPress configs return these for stale session tokens,
@@ -400,7 +429,7 @@ class HttpTransport {
       //          it's a genuine auth failure (wrong credentials, capability denied).
       const isExplicitExpiry = result.statusCode === 404 || result.statusCode === 410;
       const isStaleSession = (result.statusCode === 401 || result.statusCode === 403) && this.sessionId !== null;
-      if ((isExplicitExpiry || isStaleSession) && attempt === 0) {
+      if ((isExplicitExpiry || isStaleSession) && attempt === 0 && !this._inHandshake) {
         this.log(`Session expired (HTTP ${result.statusCode}) — attempting recovery`);
         this.sessionId = null;
         this.sessionToken = null;
@@ -420,6 +449,11 @@ class HttpTransport {
 
       return result;
     } catch (err) {
+      // Issue #103: mcp_route_absent is a terminal, structurally non-recoverable
+      // error (the configured route does not exist). It must NOT be retried as a
+      // network error — retrying just delays the terminal failure the router's
+      // #87 fallback / #76 degraded path needs to see.
+      if (err && err.code === 'mcp_route_absent') throw err;
       // Network error — retry with backoff
       if (attempt < this.maxRetries) {
         const delay = this.baseRetryDelay * Math.pow(2, attempt);

--- a/lib/transports/oauth-http-transport.js
+++ b/lib/transports/oauth-http-transport.js
@@ -3,6 +3,7 @@
 const https = require('https');
 const http = require('http');
 const { URL } = require('url');
+const { isRestNoRoute } = require('./rest-error');
 
 const MAX_QUEUE = 100;
 
@@ -118,6 +119,9 @@ class OAuthHttpTransport {
     // State
     this.sessionId = null;
     this.sessionToken = null;
+    // Issue #103: true while performHandshake's own init/initialized POSTs are
+    // in flight, so they cannot re-enter the session-recovery branch and loop.
+    this._inHandshake = false;
     this.clientProtocolVersion = null;
     this.ready = false;
     this.onMessage = null;
@@ -185,18 +189,28 @@ class OAuthHttpTransport {
       this.clientProtocolVersion = initRequest.params.protocolVersion;
     }
 
-    const initLine = JSON.stringify(initRequest);
-    const initResult = await this._postWithRetry(initLine);
-    if (initResult && initResult.body && initResult.body.trim()) {
-      this.log(`OAuth HTTP handshake init response: ${initResult.statusCode}`);
-    }
-    if (initResult && initResult.sessionId) {
-      this.sessionId = initResult.sessionId;
-    }
+    // Issue #103: mark the handshake window so the init / initialized POSTs
+    // below cannot themselves re-enter the session-recovery branch in
+    // _postWithRetry. Without this, a persistent 404 during a re-handshake
+    // re-enters recovery with a fresh attempt=0 and loops unbounded. This
+    // bounds recovery to exactly one re-handshake for any persistent 404.
+    this._inHandshake = true;
+    try {
+      const initLine = JSON.stringify(initRequest);
+      const initResult = await this._postWithRetry(initLine);
+      if (initResult && initResult.body && initResult.body.trim()) {
+        this.log(`OAuth HTTP handshake init response: ${initResult.statusCode}`);
+      }
+      if (initResult && initResult.sessionId) {
+        this.sessionId = initResult.sessionId;
+      }
 
-    if (initNotification) {
-      const notifLine = JSON.stringify(initNotification);
-      await this._postWithRetry(notifLine);
+      if (initNotification) {
+        const notifLine = JSON.stringify(initNotification);
+        await this._postWithRetry(notifLine);
+      }
+    } finally {
+      this._inHandshake = false;
     }
   }
 
@@ -507,13 +521,28 @@ class OAuthHttpTransport {
       throw expiredErr;
     }
 
+    // Issue #103: a 404 `rest_no_route` means the configured MCP route does not
+    // exist on the server — structurally non-recoverable. Re-handshaking re-POSTs
+    // initialize, gets the same 404, and loops forever. Surface it as a terminal
+    // error so the router's #87 per-site fallback / #76 degraded convergence engages
+    // (the same terminal path a connection error already takes).
+    if (result.statusCode === 404 && isRestNoRoute(result.body)) {
+      const err = new Error(
+        `MCP route not found at ${this.endpoint} (HTTP 404 rest_no_route) — ` +
+        `the configured route does not exist on the server`
+      );
+      err.code = 'mcp_route_absent';
+      err.statusCode = 404;
+      throw err;
+    }
+
     // Session recovery — same triggers as HttpTransport, except 401/403 with
     // an active session is now AT MOST a stale-session signal. Bearer staleness
     // is already handled above, so a 401 reaching this branch means the token
     // is fresh but the MCP session expired. We still allow one re-handshake.
     const isExplicitExpiry = result.statusCode === 404 || result.statusCode === 410;
     const isStaleSession = result.statusCode === 403 && this.sessionId !== null;
-    if ((isExplicitExpiry || isStaleSession) && attempt === 0) {
+    if ((isExplicitExpiry || isStaleSession) && attempt === 0 && !this._inHandshake) {
       this.log(`OAuth HTTP session expired (HTTP ${result.statusCode}) — attempting recovery`);
       this.sessionId = null;
       this.sessionToken = null;

--- a/lib/transports/rest-error.js
+++ b/lib/transports/rest-error.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/**
+ * Shared REST error helpers for HTTP transports.
+ *
+ * Kept as a single small module so both HttpTransport and OAuthHttpTransport
+ * use identical detection logic — no duplication, no drift between the two.
+ *
+ * Copyright (C) 2026 Influencentricity | Wicked Evolutions
+ * @license GPL-2.0-or-later
+ */
+
+/**
+ * Returns true if an HTTP response body is a WordPress `rest_no_route` error.
+ * This indicates the configured REST route does not exist on the server —
+ * a structurally non-recoverable condition (Issue #103).
+ *
+ * Safe on any input: non-string, empty string, and non-JSON all return false.
+ *
+ * @param {*} body - Raw HTTP response body string
+ * @returns {boolean}
+ */
+function isRestNoRoute(body) {
+  if (typeof body !== 'string' || body.length === 0) return false;
+  try { return JSON.parse(body).code === 'rest_no_route'; } catch { return false; }
+}
+
+module.exports = { isRestNoRoute };

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.3",
   "name": "abilities-mcp",
   "display_name": "WordPress (Abilities MCP)",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "Connect AI clients to WordPress through the Abilities API. One-click bridge to your site's content, users, plugins, and Fluent ecosystem.",
   "long_description": "Abilities MCP is the open-source bridge that turns any WordPress site into a first-class MCP server. Install this bundle, type your site URL + WordPress username + application password, and your AI client gets typed access to content, users, media, plugins, themes, settings, FluentCRM/Forms/Community, and any other ability registered through the WordPress Abilities API.\n\nRequires the `abilities-mcp-adapter` and `abilities-for-ai` plugins on the WordPress site. The adapter exposes the MCP endpoint; this bundle is the client-side bridge running on your machine.",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wickedevolutions/abilities-mcp",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "Open-source MCP bridge connecting AI clients to WordPress through the Abilities API — multi-site routing, zero dependencies",
   "main": "abilities-mcp.js",
   "bin": {

--- a/test/connection-pool.test.js
+++ b/test/connection-pool.test.js
@@ -717,3 +717,154 @@ describe('ConnectionPool — connectDefault per-site auth-init isolation (#76)',
     assert.match(config.sites.siteA._degraded_reason, /discovery failed/);
   });
 });
+
+/**
+ * Issue #103 (Component B) — prefer live-discovered protected-resource over
+ * stale persisted mcp_resource.
+ *
+ * Uses the `discover` injection seam (this._discover) to stub discovery
+ * with a controlled prMetadata.resource value, then asserts the created
+ * OAuthHttpTransport gets the correct endpoint.
+ */
+describe('ConnectionPool — Issue #103 Component B: live-discovered resource preference', () => {
+  function makeOAuthConfig(mcpResource) {
+    return {
+      defaultSite: 'siteA',
+      sites: {
+        siteA: {
+          url: 'https://example.com',
+          mcp_resource: mcpResource,
+          auth: {
+            method: 'oauth',
+            client_id: 'client-x',
+            access_token_ref: makeRef(SECRET_SERVICE, 'siteA/access'),
+            refresh_token_ref: makeRef(SECRET_SERVICE, 'siteA/refresh'),
+            access_token_expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+            refresh_token_expires_at: new Date(Date.now() + 90 * 24 * 3600 * 1000).toISOString(),
+          },
+          auth_status: 'active',
+        },
+      },
+    };
+  }
+
+  async function makePool(config, discoveredResource) {
+    const store = new MemorySecretStore();
+    await store.set(SECRET_SERVICE, 'siteA/access', 'AT');
+    await store.set(SECRET_SERVICE, 'siteA/refresh', 'RT');
+    const tm = new TokenManager({ secretStore: store, allowInsecure: true });
+
+    const discover = async (siteUrl) => ({
+      asMetadata: {
+        issuer: siteUrl,
+        token_endpoint: `${siteUrl}/oauth/token`,
+        authorization_endpoint: `${siteUrl}/oauth/authorize`,
+      },
+      asMetadataUrl: `${siteUrl}/.well-known/oauth-authorization-server`,
+      prMetadata: discoveredResource ? { resource: discoveredResource } : null,
+      prMetadataUrl: `${siteUrl}/.well-known/oauth-protected-resource`,
+      probeResults: [],
+    });
+
+    const pool = new ConnectionPool(config, () => {}, {
+      secretStore: store,
+      tokenManager: tm,
+      discover,
+      allowInsecure: true,
+    });
+    return pool;
+  }
+
+  it('when live discovery resource differs from persisted mcp_resource, uses live resource', async () => {
+    const persistedResource = 'https://example.com/wp-json/mcp/old-adapter-name';
+    const liveResource = 'https://example.com/wp-json/mcp/abilities-mcp-adapter-default-server';
+    const config = makeOAuthConfig(persistedResource);
+
+    const pool = await makePool(config, liveResource);
+    const transport = await pool._createTransport('siteA', null);
+
+    assert.ok(transport instanceof OAuthHttpTransport);
+    assert.equal(transport.endpoint, liveResource,
+      'live-discovered resource (RFC 9728 authoritative) should be used when persisted value is stale');
+    assert.notEqual(transport.endpoint, persistedResource,
+      'stale persisted mcp_resource must not be used when live discovery provides a different value');
+  });
+
+  it('when live discovery resource equals persisted mcp_resource, uses mcp_resource (no-op)', async () => {
+    const resource = 'https://example.com/wp-json/mcp/abilities-mcp-adapter-default-server';
+    const config = makeOAuthConfig(resource);
+
+    const pool = await makePool(config, resource);
+    const transport = await pool._createTransport('siteA', null);
+
+    assert.ok(transport instanceof OAuthHttpTransport);
+    assert.equal(transport.endpoint, resource,
+      'when persisted and live values match, endpoint is unchanged');
+  });
+
+  it('when resolvedEndpoint is set (multisite subsite), it wins over live discovery', async () => {
+    // resolvedEndpoint is the operator-configured subsite endpoint and always
+    // takes precedence — live discovery does not override it.
+    const persistedResource = 'https://example.com/wp-json/mcp/old-adapter';
+    const liveResource = 'https://example.com/wp-json/mcp/new-adapter';
+    // resolveSiteKey (lib/config.js) builds a subsite endpoint as:
+    //   subsite origin + the PARENT mcp_resource pathname.
+    // It is intentionally derived from the persisted parent route, NOT from live
+    // discovery — so the expected value carries the parent's `/old-adapter` path
+    // on the subsite host. Component B must not override this operator-derived
+    // endpoint.
+    const subsiteEndpoint = 'https://community.example.com/wp-json/mcp/old-adapter';
+
+    // Use a config with multisite so resolveSiteKey produces a resolvedEndpoint.
+    const store = new MemorySecretStore();
+    await store.set(SECRET_SERVICE, 'siteA/access', 'AT');
+    await store.set(SECRET_SERVICE, 'siteA/refresh', 'RT');
+    const tm = new TokenManager({ secretStore: store, allowInsecure: true });
+
+    const config = {
+      defaultSite: 'siteA',
+      sites: {
+        siteA: {
+          url: 'https://example.com',
+          mcp_resource: persistedResource,
+          auth: {
+            method: 'oauth',
+            client_id: 'client-x',
+            access_token_ref: makeRef(SECRET_SERVICE, 'siteA/access'),
+            refresh_token_ref: makeRef(SECRET_SERVICE, 'siteA/refresh'),
+            access_token_expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+            refresh_token_expires_at: new Date(Date.now() + 90 * 24 * 3600 * 1000).toISOString(),
+          },
+          auth_status: 'active',
+          multisite: {
+            community: 'https://community.example.com',
+          },
+        },
+      },
+    };
+
+    const discover = async (siteUrl) => ({
+      asMetadata: {
+        issuer: siteUrl,
+        token_endpoint: `${siteUrl}/oauth/token`,
+        authorization_endpoint: `${siteUrl}/oauth/authorize`,
+      },
+      asMetadataUrl: `${siteUrl}/.well-known/oauth-authorization-server`,
+      prMetadata: { resource: liveResource },
+      prMetadataUrl: `${siteUrl}/.well-known/oauth-protected-resource`,
+      probeResults: [],
+    });
+
+    const pool = new ConnectionPool(config, () => {}, {
+      secretStore: store, tokenManager: tm, discover, allowInsecure: true,
+    });
+
+    // siteA.community produces a resolvedEndpoint via resolveSiteKey.
+    const transport = await pool._createTransport('siteA.community', null);
+    assert.ok(transport instanceof OAuthHttpTransport);
+    assert.equal(transport.endpoint, subsiteEndpoint,
+      'resolvedEndpoint (multisite subsite) must win over live-discovered resource');
+    assert.notEqual(transport.endpoint, liveResource,
+      'live-discovered resource must NOT override an operator-derived subsite endpoint');
+  });
+});

--- a/test/router-degraded-mode.test.js
+++ b/test/router-degraded-mode.test.js
@@ -413,3 +413,116 @@ describe('McpRouter — degraded mode (#76)', () => {
     assert.doesNotMatch(resp.error.message, /siteA/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #102(a) — deterministic early-queue drop in degraded boot
+// ---------------------------------------------------------------------------
+
+describe('McpRouter — drainEarlyQueue in degraded boot (#102a)', () => {
+  // Shared factory: degraded router with no defaultTransport, capturing sent lines.
+  function makeDeградedRouter() {
+    const sent = [];
+    const router = new McpRouter({
+      config: { defaultSite: 'x', sites: { x: {} } },
+      siteKeys: ['x'],
+      isMultiSite: false,
+      pool: { setHandshakeCache() {} },
+      catalog: { isEnabled: () => false, cacheTools() {}, getFilteredTools: () => [] },
+      sendToClient: (s) => sent.push(s),
+      log: () => {},
+    });
+    router.enterDegradedMode([{ siteId: 'x', reason: 'connect failed' }]);
+    // defaultTransport intentionally left null (degraded path)
+    return { router, sent };
+  }
+
+  it('queued initialize in degraded drain emits valid InitializeResult (not dropped)', () => {
+    const { router, sent } = makeDeградedRouter();
+    const initLine = JSON.stringify({
+      jsonrpc: '2.0', id: 99, method: 'initialize',
+      params: { protocolVersion: '2025-06-18', capabilities: {} },
+    });
+    router.earlyQueue.push(initLine);
+    router.drainEarlyQueue();
+
+    assert.equal(sent.length, 1, 'initialize must not be dropped — exactly one response emitted');
+    const resp = JSON.parse(sent[0]);
+    assert.equal(resp.id, 99, 'response id echoes the request id');
+    assert.ok(resp.result, 'response carries result, not error');
+    assert.equal(typeof resp.result.protocolVersion, 'string', 'protocolVersion present');
+    assert.equal(resp.result.protocolVersion, '2025-06-18', 'echoes client protocolVersion');
+    assert.equal(typeof resp.result.capabilities, 'object', 'capabilities present');
+    assert.equal(typeof resp.result.serverInfo, 'object', 'serverInfo present');
+    assert.equal(typeof resp.result.serverInfo.name, 'string', 'serverInfo.name present');
+    assert.ok(!resp.error, 'no error field — client connect completes, not hangs');
+  });
+
+  it('queued initialized notification in degraded drain is swallowed without throwing or emitting error', () => {
+    const { router, sent } = makeDeградedRouter();
+    // First push initialize so cachedInitRequest is set (initialized handler calls pool.setHandshakeCache)
+    router.earlyQueue.push(JSON.stringify({
+      jsonrpc: '2.0', id: 1, method: 'initialize',
+      params: { protocolVersion: '2025-06-18', capabilities: {} },
+    }));
+    router.earlyQueue.push(JSON.stringify({
+      jsonrpc: '2.0', method: 'initialized',
+    }));
+    // Should not throw
+    assert.doesNotThrow(() => router.drainEarlyQueue());
+    // initialize → 1 response; initialized → no response (swallowed)
+    const errorResponses = sent.filter((s) => {
+      try { return JSON.parse(s).error !== undefined; } catch { return false; }
+    });
+    assert.equal(errorResponses.length, 0, 'no error emitted for initialized notification in degraded drain');
+  });
+
+  it('queued tools/list in degraded drain emits bridge-only tools list', () => {
+    const { router, sent } = makeDeградedRouter();
+    router.earlyQueue.push(JSON.stringify({
+      jsonrpc: '2.0', id: 7, method: 'tools/list',
+    }));
+    router.drainEarlyQueue();
+
+    assert.equal(sent.length, 1);
+    const resp = JSON.parse(sent[0]);
+    assert.ok(resp.result, 'tools/list returns result, not error');
+    assert.ok(Array.isArray(resp.result.tools), 'result.tools is an array');
+    const names = resp.result.tools.map((t) => t.name).sort();
+    assert.deepEqual(names, ['wp_bridge_health', 'wp_browse_tools', 'wp_load_tools'],
+      'degraded drain tools/list = bridge tools only');
+  });
+
+  it('connected path unchanged — drainEarlyQueue with defaultTransport forwards via send, not handleClientMessage', () => {
+    const sent = [];
+    const transportSends = [];
+    const router = new McpRouter({
+      config: { defaultSite: 'x', sites: { x: {} } },
+      siteKeys: ['x'],
+      isMultiSite: false,
+      pool: { setHandshakeCache() {} },
+      catalog: { isEnabled: () => false, cacheTools() {}, getFilteredTools: () => [] },
+      sendToClient: (s) => sent.push(s),
+      log: () => {},
+    });
+    // Connected: defaultTransport present, not degraded
+    router.setDefaultTransport({ send: (l) => transportSends.push(l) });
+
+    const line1 = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18' } });
+    const line2 = JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' });
+    router.earlyQueue.push(line1);
+    router.earlyQueue.push(line2);
+    router.drainEarlyQueue();
+
+    assert.deepEqual(transportSends, [line1, line2],
+      'connected path: both lines forwarded byte-identical via defaultTransport.send');
+    assert.equal(sent.length, 0,
+      'connected path: sendToClient NOT called — handleClientMessage bypassed');
+  });
+
+  it('non-JSON early-queued line in degraded drain is skipped without throwing', () => {
+    const { router, sent } = makeDeградedRouter();
+    router.earlyQueue.push('not-valid-json{{{');
+    assert.doesNotThrow(() => router.drainEarlyQueue());
+    assert.equal(sent.length, 0, 'non-JSON line skipped silently');
+  });
+});

--- a/test/transports/helpers/mock-mcp-resource.js
+++ b/test/transports/helpers/mock-mcp-resource.js
@@ -26,6 +26,7 @@ class MockMcpResource {
     this.config = {
       statusOverride: null,
       statusForCount: 0,
+      bodyOverride: null,      // string: body to use when statusOverride fires
       successBodyFor: null,    // (req, body) => string
       ...opts.config,
     };
@@ -74,7 +75,7 @@ class MockMcpResource {
         this.config.statusForCount--;
         res.statusCode = this.config.statusOverride;
         res.setHeader('Content-Type', 'application/json');
-        res.end('');
+        res.end(this.config.bodyOverride || '');
         return;
       }
 

--- a/test/transports/http-transport.test.js
+++ b/test/transports/http-transport.test.js
@@ -1,0 +1,146 @@
+'use strict';
+
+/**
+ * HttpTransport — Issue #103 regression tests.
+ *
+ * Covers:
+ *   1. 404 + rest_no_route body → _postWithRetry throws (code mcp_route_absent),
+ *      performHandshake is called AT MOST ONCE (proving no unbounded re-handshake loop).
+ *   2. 404 without rest_no_route → exactly one re-handshake (existing recovery preserved).
+ *
+ * Uses a raw http server (no dependency on MockMcpResource) to give precise
+ * control over status code and body independently of auth logic.
+ *
+ * Copyright (C) 2026 Influencentricity | Wicked Evolutions
+ * @license GPL-2.0-or-later
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+
+const { HttpTransport } = require('../../lib/transports/http-transport');
+
+/**
+ * Starts a minimal HTTP server that always responds with a fixed status + body.
+ * Returns { server, origin, stop }.
+ */
+function startFixedServer(statusCode, body) {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      const chunks = [];
+      req.on('data', (c) => chunks.push(c));
+      req.on('end', () => {
+        res.statusCode = statusCode;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(body);
+      });
+    });
+    server.on('error', reject);
+    server.listen({ host: '127.0.0.1', port: 0 }, () => {
+      const port = server.address().port;
+      resolve({
+        server,
+        origin: `http://127.0.0.1:${port}`,
+        stop: () => new Promise((r) => server.close(r)),
+      });
+    });
+  });
+}
+
+describe('HttpTransport — Issue #103: 404 rest_no_route terminates without loop', () => {
+  it('404 with rest_no_route body throws mcp_route_absent; performHandshake not called', async () => {
+    // The server always returns 404 + rest_no_route regardless of request.
+    // If the transport loops, it would call performHandshake which calls
+    // _postWithRetry again, which would again 404 → infinite recursion / stack overflow.
+    // The fix throws immediately on first 404+rest_no_route so performHandshake
+    // is never invoked from _postWithRetry.
+    const srv = await startFixedServer(404, JSON.stringify({ code: 'rest_no_route', message: 'No route was found matching the URL and request method.', data: { status: 404 } }));
+    try {
+      const t = new HttpTransport({
+        endpoint: `${srv.origin}/wp-json/mcp/v1`,
+        username: 'u',
+        password: 'p',
+        logger: () => {},
+      });
+
+      // Spy: count performHandshake calls.
+      let handshakeCalls = 0;
+      const origHandshake = t.performHandshake.bind(t);
+      t.performHandshake = async (...args) => {
+        handshakeCalls++;
+        return origHandshake(...args);
+      };
+
+      // P1 (Issue #103): the terminal throw must NOT be swallowed by the broad
+      // network-error catch and retried up to maxRetries. Count raw POSTs — it
+      // must be exactly one.
+      let postCalls = 0;
+      const origPost = t._post.bind(t);
+      t._post = async (...args) => { postCalls++; return origPost(...args); };
+
+      // _postWithRetry must throw with code mcp_route_absent.
+      await assert.rejects(
+        t._postWithRetry(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })),
+        (err) => {
+          assert.equal(err.code, 'mcp_route_absent', `expected mcp_route_absent, got ${err.code}`);
+          assert.equal(err.statusCode, 404);
+          assert.match(err.message, /rest_no_route/);
+          return true;
+        }
+      );
+
+      // performHandshake must NOT have been called — that is the loop guard.
+      assert.equal(handshakeCalls, 0,
+        'performHandshake must not be called when rest_no_route is detected (would loop)');
+
+      // P1: terminal — exactly one POST, not retried as a network error.
+      assert.equal(postCalls, 1,
+        'rest_no_route must be terminal — exactly one POST, not retried (P1)');
+    } finally {
+      await srv.stop();
+    }
+  });
+
+  it('persistent non-rest_no_route 404 converges: exactly one REAL re-handshake, no loop', { timeout: 5000 }, async () => {
+    // Server returns a non-rest_no_route 404 on EVERY request, including the
+    // re-handshake's own initialize POST. With the REAL performHandshake (not a
+    // stub), this is the case that previously looped unbounded: recovery →
+    // performHandshake → init POST 404 → recovery → … The Issue #103 _inHandshake
+    // guard bounds it to exactly one re-handshake; the outer retry (attempt=1)
+    // then skips recovery and returns the 404. The 5s timeout fails fast if the
+    // guard regresses (the loop would otherwise hang).
+    const srv = await startFixedServer(404, '{}');
+    try {
+      const t = new HttpTransport({
+        endpoint: `${srv.origin}/wp-json/mcp/v1`,
+        username: 'u',
+        password: 'p',
+        logger: () => {},
+      });
+
+      // Seed the cached init request so the recovery path can execute.
+      t.cachedInitRequest = { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} };
+
+      // Spy that calls through to the REAL performHandshake (which itself POSTs
+      // initialize — the recursion path the old no-op stub hid).
+      let handshakeCalls = 0;
+      const origHandshake = t.performHandshake.bind(t);
+      t.performHandshake = async (...args) => { handshakeCalls++; return origHandshake(...args); };
+
+      const result = await t._postWithRetry(
+        JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} })
+      );
+
+      // Converges, returning the terminal 404 — no throw, no hang.
+      assert.equal(result.statusCode, 404);
+
+      // Exactly one real re-handshake — the guard stopped the init POST's 404
+      // from spawning further handshakes.
+      assert.equal(handshakeCalls, 1,
+        'exactly one real re-handshake for a persistent non-rest_no_route 404 (no loop)');
+    } finally {
+      await srv.stop();
+    }
+  });
+});

--- a/test/transports/oauth-http-transport.test.js
+++ b/test/transports/oauth-http-transport.test.js
@@ -10,6 +10,7 @@ const { makeRef } = require('../../lib/auth/secret-store');
 const { AUTH_STATUS } = require('../../lib/auth/events');
 const { MockAuthServer } = require('../auth/helpers/mock-auth-server');
 const { MockMcpResource } = require('./helpers/mock-mcp-resource');
+const http = require('node:http');
 
 /**
  * OAuthHttpTransport — runtime bearer + refresh on 401 (Issue #17).
@@ -376,6 +377,126 @@ describe('OAuthHttpTransport — multisite subsite header (Issue #48)', () => {
       await t.shutdown();
     } finally {
       await server.stop(); await resource.stop();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #103 — route-absent 404 must NOT trigger infinite re-handshake loop
+// ---------------------------------------------------------------------------
+
+/**
+ * Starts a minimal HTTP server that always responds with a fixed status + body.
+ * Used here to avoid any interaction with MockMcpResource's auth logic.
+ */
+function startFixedHttpServer(statusCode, body) {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      const chunks = [];
+      req.on('data', (c) => chunks.push(c));
+      req.on('end', () => {
+        res.statusCode = statusCode;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(body);
+      });
+    });
+    server.on('error', reject);
+    server.listen({ host: '127.0.0.1', port: 0 }, () => {
+      const port = server.address().port;
+      resolve({
+        server,
+        origin: `http://127.0.0.1:${port}`,
+        stop: () => new Promise((r) => server.close(r)),
+      });
+    });
+  });
+}
+
+/** Minimal token manager stub that always returns a fixed access token. */
+function makeFakeTokenManager(token = 'AT-FAKE') {
+  return {
+    getAccessToken: async () => ({ accessToken: token, refreshed: false }),
+  };
+}
+
+describe('OAuthHttpTransport — Issue #103: 404 rest_no_route terminates without loop', () => {
+  it('404 with rest_no_route body throws mcp_route_absent; performHandshake called at most once', async () => {
+    // Every request to the server returns 404 + rest_no_route.
+    // Before the fix: _postWithRetry recovers → performHandshake → _postWithRetry
+    // → 404 again → performHandshake → … unbounded recursion.
+    // After the fix: the guard throws immediately, performHandshake is never
+    // invoked from within _postWithRetry.
+    const srv = await startFixedHttpServer(
+      404,
+      JSON.stringify({ code: 'rest_no_route', message: 'No route was found matching the URL and request method.', data: { status: 404 } })
+    );
+    try {
+      const t = new OAuthHttpTransport({
+        endpoint: `${srv.origin}/wp-json/mcp/v1`,
+        tokenManager: makeFakeTokenManager(),
+        siteAuth: { siteId: 'test', authStatus: 'active' },
+        logger: () => {},
+      });
+
+      // Spy: count performHandshake calls.
+      let handshakeCalls = 0;
+      const origHandshake = t.performHandshake.bind(t);
+      t.performHandshake = async (...args) => {
+        handshakeCalls++;
+        return origHandshake(...args);
+      };
+
+      await assert.rejects(
+        t._postWithRetry(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })),
+        (err) => {
+          assert.equal(err.code, 'mcp_route_absent', `expected mcp_route_absent, got ${err.code}`);
+          assert.equal(err.statusCode, 404);
+          assert.match(err.message, /rest_no_route/);
+          return true;
+        }
+      );
+
+      // performHandshake must NOT have been called from within _postWithRetry.
+      assert.equal(handshakeCalls, 0,
+        'performHandshake must not be called when rest_no_route is detected (that was the loop)');
+    } finally {
+      await srv.stop();
+    }
+  });
+
+  it('persistent non-rest_no_route 404 converges: exactly one REAL re-handshake, no loop', { timeout: 5000 }, async () => {
+    // Server returns a non-rest_no_route 404 on EVERY request, including the
+    // re-handshake's own initialize POST — the case that previously looped
+    // unbounded with the real performHandshake. The Issue #103 _inHandshake guard
+    // bounds it to exactly one re-handshake; the outer retry (attempt=1) then
+    // skips recovery and returns the 404. The 5s timeout fails fast on regress.
+    const srv = await startFixedHttpServer(404, '{}');
+    try {
+      const t = new OAuthHttpTransport({
+        endpoint: `${srv.origin}/wp-json/mcp/v1`,
+        tokenManager: makeFakeTokenManager(),
+        siteAuth: { siteId: 'test', authStatus: 'active' },
+        logger: () => {},
+      });
+
+      // Seed cached init so the recovery path can execute.
+      t.cachedInitRequest = { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} };
+
+      // Spy that calls through to the REAL performHandshake (which itself POSTs
+      // initialize — the recursion path the old no-op stub hid).
+      let handshakeCalls = 0;
+      const origHandshake = t.performHandshake.bind(t);
+      t.performHandshake = async (...args) => { handshakeCalls++; return origHandshake(...args); };
+
+      const result = await t._postWithRetry(
+        JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} })
+      );
+
+      assert.equal(result.statusCode, 404);
+      assert.equal(handshakeCalls, 1,
+        'exactly one real re-handshake for a persistent non-rest_no_route 404 (no loop)');
+    } finally {
+      await srv.stop();
     }
   });
 });

--- a/test/transports/rest-error.test.js
+++ b/test/transports/rest-error.test.js
@@ -1,0 +1,72 @@
+'use strict';
+
+/**
+ * Unit tests for lib/transports/rest-error.js
+ *
+ * Covers isRestNoRoute: valid rest_no_route JSON, other JSON codes, non-JSON,
+ * empty string, and non-string inputs — all edge cases safe on any input.
+ *
+ * Issue #103 — route-absent terminal detection helper.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { isRestNoRoute } = require('../../lib/transports/rest-error');
+
+describe('isRestNoRoute — WordPress rest_no_route detection', () => {
+  it('returns true for a valid rest_no_route JSON body', () => {
+    assert.equal(
+      isRestNoRoute(JSON.stringify({ code: 'rest_no_route', message: 'No route was found matching the URL and request method.', data: { status: 404 } })),
+      true
+    );
+  });
+
+  it('returns true for a minimal rest_no_route body (just code)', () => {
+    assert.equal(isRestNoRoute('{"code":"rest_no_route"}'), true);
+  });
+
+  it('returns false for a different WordPress error code', () => {
+    assert.equal(isRestNoRoute('{"code":"rest_forbidden","message":"Sorry, you are not allowed to do that."}'), false);
+  });
+
+  it('returns false for a valid JSON body with no code field', () => {
+    assert.equal(isRestNoRoute('{"error":"invalid_token"}'), false);
+  });
+
+  it('returns false for an empty object', () => {
+    assert.equal(isRestNoRoute('{}'), false);
+  });
+
+  it('returns false for a JSON array', () => {
+    assert.equal(isRestNoRoute('[]'), false);
+  });
+
+  it('returns false for non-JSON string', () => {
+    assert.equal(isRestNoRoute('Not Found'), false);
+  });
+
+  it('returns false for empty string', () => {
+    assert.equal(isRestNoRoute(''), false);
+  });
+
+  it('returns false for null', () => {
+    assert.equal(isRestNoRoute(null), false);
+  });
+
+  it('returns false for undefined', () => {
+    assert.equal(isRestNoRoute(undefined), false);
+  });
+
+  it('returns false for a number', () => {
+    assert.equal(isRestNoRoute(404), false);
+  });
+
+  it('returns false for an object (not a string)', () => {
+    assert.equal(isRestNoRoute({ code: 'rest_no_route' }), false);
+  });
+
+  it('returns false for truncated / malformed JSON', () => {
+    assert.equal(isRestNoRoute('{"code":"rest_no_route"'), false);
+  });
+});


### PR DESCRIPTION
## v1.6.6 — Attach reliability

Two bugs that prevented an AI client from attaching to the bridge, plus the route-source hardening that surfaced alongside them.

### Fixed
- **#103** — route-absent `404 rest_no_route` is now terminal (`mcp_route_absent`) instead of looping; `_inHandshake` guard bounds re-handshake to one for any persistent 404; OAuth transport prefers the live-discovered protected-resource over a stale persisted `mcp_resource` (Component B); discovery cache no longer pins a null protected-resource.
- **#102 (part a)** — `drainEarlyQueue()` re-dispatches queued messages through the degraded synthesis path, so a queued `initialize` is answered (degraded) instead of dropped when all sites fail at boot. (Part b — bounded boot for genuinely-hanging sites — tracked in #108.)

### Verification
- 478/478 tests pass.
- End-to-end: degraded boot answers `initialize` instantly; live boot connects via the live route with zero recovery loops.
- **Live-tested in Claude Desktop against the real 8-site multisite**: OAuth discovery succeeded, sites reachable (root 257 abilities; `wicked-community` 1,014). Component B confirmed switching to the live route in the debug log.
- Reviewed by GPT 5.5 (no blocking findings) + Opus 4.8.

### Notes
- Excludes the `abilities-mcp.js` mode-only change and local agent scaffolding (`.gitignore`/`.npmignore` hardened in `6dca928`; pristine-clone pack verified at 54 files, 0 `.ijfw`).

Fixes #103
Fixes #102
