### PR TITLE
ci(test): add windows-latest to the test matrix (non-blocking until #119)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,19 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    # windows-latest is non-blocking for now: it provides ongoing Windows signal
+    # while the loopback-bind flakiness (#119) is fixed. Remove this once #119
+    # lands so Windows becomes a required, blocking check.
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         node-version: ['18', '20', '22']
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Node ${{ matrix.node-version }}
+      - name: Setup Node ${{ matrix.node-version }} on ${{ matrix.os }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}


### PR DESCRIPTION
## What

Add a `windows-latest` lane to the test matrix (alongside `ubuntu-latest`) across Node 18/20/22, `fail-fast: false`.

**`windows-latest` is non-blocking for now** (`continue-on-error` scoped to win32) so it provides ongoing Windows signal without blocking the repo while the loopback port-bind flakiness (#119) is fixed. **Remove `continue-on-error` once #119 lands** so Windows becomes a required check.

## Why

CI ran `ubuntu-latest` only, so Windows-specific bugs couldn't be caught — motivated by the Windows OAuth bug in #100/#101. Adding the lane immediately surfaced real, pre-existing Windows debt, fixed in:

- #112 — cross-platform test runner (suite couldn't even discover tests on Windows)
- #114 — Windows-safe home isolation (HOME + USERPROFILE)
- #116 — tildify Windows paths (privacy/display)
- #118 — injectable seed seam (env-var branch testable on keychain hosts)

After those, **Windows Node 22 is fully green**; Node 18/20 fail only on the unrelated loopback-bind flakiness tracked in #119.

## Status

ubuntu 18/20/22: blocking, green. windows 18/20/22: non-blocking until #119. Refs #119.
