### PR TITLE
fix(test): cross-platform test runner (Windows-safe test discovery)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/Wicked-Evolutions/abilities-mcp.git"
   },
   "scripts": {
-    "test": "node --test test/*.test.js test/auth/*.test.js test/cli/*.test.js test/transports/*.test.js",
+    "test": "node scripts/run-tests.js",
     "validate:mcpb": "npx --yes @anthropic-ai/mcpb validate manifest.json",
     "pack:mcpb": "node scripts/pack-mcpb.js",
     "verify:pack-isolation": "node scripts/verify-pack-isolation.js"

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Cross-platform test entry point.
+ *
+ * Replaces the previous shell-glob npm script:
+ *   node --test test/*.test.js test/auth/*.test.js test/cli/*.test.js test/transports/*.test.js
+ * That form only works where a POSIX shell expands the globs before `node`
+ * runs. On Windows the npm script runs under cmd/PowerShell, which pass the
+ * globs through literally, so `node` finds no files and exits 1.
+ *
+ * This enumerates the exact same curated set in pure Node — one level per
+ * listed directory, non-recursive on purpose so the test surface does not
+ * silently grow with future nested files — then runs `node --test` with
+ * explicit paths.
+ *
+ * Copyright (C) 2026 Influencentricity | Wicked Evolutions
+ * @license GPL-2.0-or-later
+ */
+
+const { readdirSync } = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+// Same set the old globs matched. Keep non-recursive.
+const DIRS = ['test', 'test/auth', 'test/cli', 'test/transports'];
+
+const files = [];
+for (const dir of DIRS) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === 'ENOENT') continue;
+    throw err;
+  }
+  const inDir = entries
+    .filter((e) => e.isFile() && e.name.endsWith('.test.js'))
+    .map((e) => path.join(dir, e.name))
+    .sort();
+  files.push(...inDir);
+}
+
+if (files.length === 0) {
+  console.error('run-tests: no .test.js files found in', DIRS.join(', '));
+  process.exit(1);
+}
+
+const res = spawnSync(process.execPath, ['--test', ...files], { stdio: 'inherit' });
+process.exit(res.status === null ? 1 : res.status);


### PR DESCRIPTION
## What

Replace the shell-glob `test` script with a dependency-free cross-platform runner (`scripts/run-tests.js`).

## Why

`npm test` was `node --test test/*.test.js test/auth/*.test.js …`. Those globs are expanded by a POSIX shell on Linux/macOS before `node` runs; on Windows the script runs under `cmd`/PowerShell, which pass them through literally, so `node` finds nothing and exits 1. The suite has **never run on Windows** (surfaced by the `windows-latest` matrix in #110).

## How

`scripts/run-tests.js` enumerates the **exact same curated set** — `test`, `test/auth`, `test/cli`, `test/transports`, non-recursive (**46 files** today) — in pure Node and invokes `node --test` with explicit paths.

- **Non-recursive on purpose:** preserves the exact set; won't silently absorb future nested test files.
- **`node --test` auto-discovery intentionally avoided:** on this repo it over-matches `lib/cli/commands/test.js` (a source file), the `dist-mcpb` build artifact, and test helpers. Native glob args in `node --test` are Node ≥21 only; we support ≥18.

## Verification

- Runner resolves exactly **46** files (same as the old globs).
- `npm test` locally: **478 tests, 0 fail.**

Closes #111. Unblocks the `windows-latest` matrix in #110 (rebase #110 after this merges).
