### PR TITLE
fix(test): Windows-safe home isolation + separator-tolerant path assertion

### DIFF
--- a/test/config-async.test.js
+++ b/test/config-async.test.js
@@ -7,6 +7,7 @@ const os = require('node:os');
 const path = require('node:path');
 
 const { loadConfig, resolvePassword, resolveConfigFilePath } = require('../lib/config');
+const { makeTempHome } = require('./helpers/temp-home');
 
 /**
  * Issue #5 / Phase E.2 — async config loading.
@@ -80,9 +81,7 @@ describe('resolveConfigFilePath — async surface (Issue #5)', () => {
   it('returns null when no on-disk file applies (env-var single-site path)', async () => {
     // Force the script-dir + home candidates to miss by pointing HOME at an
     // empty tmp dir, then verify null is returned. Restored after.
-    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'home-'));
-    const origHome = process.env.HOME;
-    process.env.HOME = fakeHome;
+    const home = makeTempHome();
     try {
       // Also requires no script-adjacent wp-sites.json. The repo carries one
       // for local dev, so we only assert behavior when we know neither path
@@ -94,8 +93,7 @@ describe('resolveConfigFilePath — async surface (Issue #5)', () => {
       const result = await resolveConfigFilePath({});
       assert.equal(result, null);
     } finally {
-      if (origHome === undefined) delete process.env.HOME; else process.env.HOME = origHome;
-      try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch { /* ignore */ }
+      home.restore();
     }
   });
 });

--- a/test/config-source.test.js
+++ b/test/config-source.test.js
@@ -12,6 +12,7 @@ const {
   tildify,
   siteAuthLabel,
 } = require('../lib/config-source-line');
+const { makeTempHome } = require('./helpers/temp-home');
 
 /**
  * Issue #32 — Phase B of the v1.5.2 sprint.
@@ -67,14 +68,12 @@ describe('loadConfig — _configSource discriminant per branch (Issue #32)', () 
   });
 
   it('home-dir: ~/.abilities-mcp/wp-sites.json is picked up with home-dir discriminant', async () => {
-    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'abilities-mcp-home-'));
-    const homeConfigDir = path.join(fakeHome, '.abilities-mcp');
+    const home = makeTempHome();
+    const homeConfigDir = path.join(home.dir, '.abilities-mcp');
     fs.mkdirSync(homeConfigDir, { recursive: true });
     const homeConfigFile = path.join(homeConfigDir, 'wp-sites.json');
     fs.writeFileSync(homeConfigFile, JSON.stringify(APPPASSWORD_HTTP_SITE, null, 2), { mode: 0o600 });
 
-    const origHome = process.env.HOME;
-    process.env.HOME = fakeHome;
     try {
       // The script-adjacent path takes precedence over home-dir — skip if the repo
       // happens to carry a script-adjacent wp-sites.json (dev machines often do).
@@ -86,9 +85,7 @@ describe('loadConfig — _configSource discriminant per branch (Issue #32)', () 
       assert.equal(cfg._configSource, 'home-dir');
       assert.equal(cfg._configSourceLabel, homeConfigFile);
     } finally {
-      if (origHome === undefined) delete process.env.HOME;
-      else process.env.HOME = origHome;
-      try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch { /* ignore */ }
+      home.restore();
     }
   });
 
@@ -97,9 +94,7 @@ describe('loadConfig — _configSource discriminant per branch (Issue #32)', () 
     const origUser = process.env.ABILITIES_MCP_USERNAME;
     const origPass = process.env.ABILITIES_MCP_PASSWORD;
 
-    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'abilities-mcp-home-'));
-    const origHome = process.env.HOME;
-    process.env.HOME = fakeHome;
+    const home = makeTempHome();
     process.env.ABILITIES_MCP_URL = 'https://wickedevolutions.com';
     process.env.ABILITIES_MCP_USERNAME = 'wicked';
     process.env.ABILITIES_MCP_PASSWORD = 'app-pw';
@@ -111,20 +106,17 @@ describe('loadConfig — _configSource discriminant per branch (Issue #32)', () 
       assert.equal(cfg._configSource, 'env-var');
       assert.equal(cfg._configSourceLabel, 'wickedevolutions.com');
     } finally {
-      if (origHome === undefined) delete process.env.HOME; else process.env.HOME = origHome;
+      home.restore();
       if (origUrl === undefined) delete process.env.ABILITIES_MCP_URL; else process.env.ABILITIES_MCP_URL = origUrl;
       if (origUser === undefined) delete process.env.ABILITIES_MCP_USERNAME; else process.env.ABILITIES_MCP_USERNAME = origUser;
       if (origPass === undefined) delete process.env.ABILITIES_MCP_PASSWORD; else process.env.ABILITIES_MCP_PASSWORD = origPass;
-      try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch { /* ignore */ }
     }
   });
 
   it('legacy-cli: --host / --path sets _configSource=legacy-cli and label is host', async () => {
     const origUrl = process.env.ABILITIES_MCP_URL;
     delete process.env.ABILITIES_MCP_URL;
-    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'abilities-mcp-home-'));
-    const origHome = process.env.HOME;
-    process.env.HOME = fakeHome;
+    const home = makeTempHome();
     try {
       const scriptAdjacent = path.resolve(__dirname, '..', 'wp-sites.json');
       if (fs.existsSync(scriptAdjacent)) return;
@@ -132,9 +124,8 @@ describe('loadConfig — _configSource discriminant per branch (Issue #32)', () 
       assert.equal(cfg._configSource, 'legacy-cli');
       assert.equal(cfg._configSourceLabel, 'legacy.example');
     } finally {
-      if (origHome === undefined) delete process.env.HOME; else process.env.HOME = origHome;
+      home.restore();
       if (origUrl !== undefined) process.env.ABILITIES_MCP_URL = origUrl;
-      try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch { /* ignore */ }
     }
   });
 });
@@ -185,7 +176,7 @@ describe('formatConfigSourceLine — per-source output format', () => {
       },
     });
     assert.match(line, /^Config source: \[home-dir\]/);
-    assert.match(line, /~\/\.abilities-mcp\/wp-sites\.json/);
+    assert.match(line, /~[\\/]\.abilities-mcp[\\/]wp-sites\.json/);
     assert.match(line, /3 sites:/);
     assert.match(line, /helena oauth/);
     assert.match(line, /wicked oauth/);

--- a/test/helpers/temp-home.js
+++ b/test/helpers/temp-home.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+/**
+ * Create an isolated temporary home directory for a test.
+ *
+ * Sets BOTH `HOME` (POSIX) and `USERPROFILE` (Windows), because `os.homedir()`
+ * — which the config loader uses — reads `HOME` on macOS/Linux and `USERPROFILE`
+ * on win32. Overriding only `HOME` is a no-op on Windows, so tests that did so
+ * silently failed to isolate there and resolved against the real home.
+ *
+ * @returns {{ dir: string, restore: () => void }} the temp home path and a
+ *   teardown that restores the previous env vars and removes the directory.
+ */
+function makeTempHome() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'abilities-mcp-home-'));
+  const saved = {
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+  };
+  process.env.HOME = dir;
+  process.env.USERPROFILE = dir;
+
+  return {
+    dir,
+    restore() {
+      for (const key of ['HOME', 'USERPROFILE']) {
+        if (saved[key] === undefined) delete process.env[key];
+        else process.env[key] = saved[key];
+      }
+      try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+    },
+  };
+}
+
+module.exports = { makeTempHome };


### PR DESCRIPTION
## What

Make test home-directory isolation work on Windows. **Partial fix** for the `windows-latest` failures (#110): takes the config-source suite from **4 → 2** Windows failures.

## Changes

- Add `test/helpers/temp-home.js` (`makeTempHome`) that creates a temp dir and sets/restores **both `HOME` and `USERPROFILE`** — `os.homedir()` reads `HOME` on macOS/Linux but `USERPROFILE` on win32, so HOME-only isolation was a no-op on Windows.
- Route `config-source` and `config-async` through it.
- Make the home-dir formatter assertion separator-tolerant.

## Status — partial (does not close #113 yet)

Resolves the `home-dir` and `legacy-cli` isolation failures on Windows. **Two** Windows failures remain, tracked separately:

- `tildify` not Windows-aware (leaks full path / no `~`) → #115 (fix in #116)
- `env-var` test collides with the seed-from-env feature (#34) when a keychain is available → separate issue (test seam)

Addresses part of #113; **#113 stays open** and #110 stays red until #116 and the env-var seam also land and Windows is green.

macOS: full suite green.
