### PR TITLE
fix(config): tildify Windows paths (stop leaking full home path in config-source line)

### DIFF
--- a/lib/config-source-line.js
+++ b/lib/config-source-line.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const os = require('os');
+const path = require('path');
 
 /**
  * Format the operator-visible startup diagnostic line that names which config
@@ -35,7 +36,10 @@ const os = require('os');
 function tildify(p) {
   if (!p) return p;
   const home = os.homedir();
-  if (home && (p === home || p.startsWith(home + '/'))) {
+  // Accept the platform separator (win32 `\`) as well as `/` — os.homedir()
+  // returns a back-slashed path on Windows, so a `/`-only check never matched
+  // and leaked the full C:\Users\<name> path.
+  if (home && (p === home || p.startsWith(home + path.sep) || p.startsWith(home + '/'))) {
     return '~' + p.slice(home.length);
   }
   return p;

--- a/test/config-source.test.js
+++ b/test/config-source.test.js
@@ -222,6 +222,14 @@ describe('tildify', () => {
     assert.equal(tildify(home), '~');
   });
 
+  it('replaces leading $HOME using the platform separator (win32 backslash)', () => {
+    const home = os.homedir();
+    assert.equal(
+      tildify(home + path.sep + 'foo' + path.sep + 'bar'),
+      '~' + path.sep + 'foo' + path.sep + 'bar'
+    );
+  });
+
   it('leaves paths outside $HOME untouched', () => {
     assert.equal(tildify('/tmp/foo'), '/tmp/foo');
     assert.equal(tildify('/etc/passwd'), '/etc/passwd');


### PR DESCRIPTION
Product fix for #115. `tildify()` only matched `home + '/'`, so on Windows (back-slashed `os.homedir()`) it returned the path unchanged and the config-source line leaked the full `C:\Users\<name>\...` path — defeating its stated privacy purpose. Now accepts `path.sep` too.

- Added a separator-agnostic test (uses `path.sep`, so it asserts the win32 backslash path on Windows).
- macOS: full suite green.
- One of the two remaining windows-latest failures in #110.

Closes #115.