### PR TITLE
fix(config): injectable seed deps (env-var branch testable on keychain hosts)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -72,7 +72,9 @@ async function resolveConfigFilePath(args) {
   return null;
 }
 
-async function loadConfig(args) {
+async function loadConfig(args, deps = {}) {
+  // `deps` is a test/DI seam (e.g. an injected secret store) — production callers
+  // use loadConfig(args) and get the default keychain-backed seeding path.
   // Explicit config path
   if (args.config) {
     return loadConfigFile(args.config, 'explicit-config');
@@ -104,7 +106,7 @@ async function loadConfig(args) {
   // (keytar unavailable, file-already-exists, write error) the seed is a
   // graceful no-op and we fall back to env-var-only mode below.
   if (process.env.ABILITIES_MCP_URL) {
-    const seedResult = await _seedFromEnvIfMissing(homeConfig, process.env);
+    const seedResult = await _seedFromEnvIfMissing(homeConfig, process.env, deps);
     if (seedResult && seedResult.seeded) {
       return loadConfigFile(homeConfig, 'home-dir');
     }
@@ -555,9 +557,9 @@ async function resolveSitePassword(site, secretStore) {
  * branch of `loadConfig` actually fires — so SSH-only, explicit-config, and
  * legacy-CLI install paths never pay the keytar import cost.
  */
-async function _seedFromEnvIfMissing(configPath, env) {
+async function _seedFromEnvIfMissing(configPath, env, deps) {
   const { seedFromEnvIfMissing } = require('./cli/config-store');
-  return seedFromEnvIfMissing(configPath, env);
+  return seedFromEnvIfMissing(configPath, env, deps);
 }
 
 module.exports = {

--- a/test/config-source.test.js
+++ b/test/config-source.test.js
@@ -102,7 +102,11 @@ describe('loadConfig — _configSource discriminant per branch (Issue #32)', () 
     try {
       const scriptAdjacent = path.resolve(__dirname, '..', 'wp-sites.json');
       if (fs.existsSync(scriptAdjacent)) return;
-      const cfg = await loadConfig({});
+      // Inject an unavailable secret store so seed-from-env (#34) is skipped
+      // and the env-var branch is reached deterministically — otherwise a host
+      // with a keychain (e.g. Windows Credential Manager) seeds a home-dir
+      // config and loadConfig returns 'home-dir' instead of 'env-var'.
+      const cfg = await loadConfig({}, { secretStore: { isAvailable: async () => false } });
       assert.equal(cfg._configSource, 'env-var');
       assert.equal(cfg._configSourceLabel, 'wickedevolutions.com');
     } finally {


### PR DESCRIPTION
Implements option A from #117 — a test/DI seam, no operator-facing surface.

`loadConfig()` seeds env config into a home-dir file when a keychain is available (#34), returning `home-dir` instead of `env-var`. The env-var test passed on headless ubuntu (no keychain) but failed on Windows CI (Credential Manager). Thread an optional `deps` through `loadConfig` → `_seedFromEnvIfMissing` → `seedFromEnvIfMissing` (which already accepted `deps.secretStore`); production `loadConfig(args)` is unchanged, and the test injects `{ secretStore: { isAvailable: async () => false } }`.

macOS: full suite green. Closes #117.

**Stacked on #114** (shows that commit until #114 merges). Final Windows-green proof runs on #110.